### PR TITLE
Fix Windows autostart command path hijack risk

### DIFF
--- a/src/autostart.rs
+++ b/src/autostart.rs
@@ -186,11 +186,16 @@ mod platform {
         current_exe().map(|p| format!("\"{}\"", p.display()))
     }
 
+    fn schtasks_exe() -> PathBuf {
+        let windir = std::env::var_os("WINDIR").unwrap_or_else(|| "C:\\Windows".into());
+        PathBuf::from(windir).join("System32").join("schtasks.exe")
+    }
+
     fn create_high_privilege_task() -> bool {
         let Some(tr) = quoted_exe() else {
             return false;
         };
-        Command::new("schtasks")
+        Command::new(schtasks_exe())
             .args([
                 "/Create", "/TN", TASK_NAME, "/TR", &tr, "/SC", "ONLOGON", "/RL", "HIGHEST", "/F",
             ])
@@ -200,7 +205,7 @@ mod platform {
     }
 
     fn delete_high_privilege_task() -> bool {
-        Command::new("schtasks")
+        Command::new(schtasks_exe())
             .args(["/Delete", "/TN", TASK_NAME, "/F"])
             .status()
             .map(|s| s.success())
@@ -208,7 +213,7 @@ mod platform {
     }
 
     fn high_privilege_task_exists() -> bool {
-        Command::new("schtasks")
+        Command::new(schtasks_exe())
             .args(["/Query", "/TN", TASK_NAME])
             .status()
             .map(|s| s.success())


### PR DESCRIPTION
### Motivation
- Prevent a local privilege escalation risk where elevated autostart logic executed an unqualified `schtasks` command that could be hijacked via the current directory or `%PATH%` when Vigil runs elevated on Windows.
- The change targets the Windows-only elevated-task code paths in `src/autostart.rs` to harden execution against path search attacks.
- No external skills were used to produce this change.

### Description
- Add a Windows-only helper `schtasks_exe()` that resolves to `%WINDIR%\System32\schtasks.exe` with a `C:\Windows` fallback by using `std::env::var_os("WINDIR")` and `PathBuf`.
- Replace `Command::new("schtasks")` calls in `create_high_privilege_task()`, `delete_high_privilege_task()`, and `high_privilege_task_exists()` with `Command::new(schtasks_exe())` to invoke the fully qualified executable.
- This is a minimal, behavior-preserving change confined to the Windows `platform` module and does not alter non-Windows code paths.

### Testing
- Ran `cargo fmt --all`, which completed successfully.
- Ran `cargo test --locked`, which failed in this environment due to an unrelated platform compilation error in the `winit` dependency (unsupported target), and the failure is not related to the autostart-path fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e22f65012c8328b8b9ff172308d4cd)