### PR TITLE
Add socket kill and optional UI-layer auto response

### DIFF
--- a/src/active_response.rs
+++ b/src/active_response.rs
@@ -99,7 +99,7 @@ struct SocketKillTarget {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DurationPreset {
     OneHour,
     OneDay,
@@ -605,7 +605,7 @@ mod platform {
             SocketAddr::V6(_) => return Err(SocketKillError::UnsupportedAddressFamily),
         };
 
-        let mut row = MIB_TCPROW {
+        let row = MIB_TCPROW {
             dwState: MIB_TCP_STATE_DELETE_TCB,
             dwLocalAddr: u32::from_be_bytes(local.ip().octets()),
             dwLocalPort: u32::from(local.port().to_be()),

--- a/src/active_response.rs
+++ b/src/active_response.rs
@@ -8,7 +8,9 @@
 //! The module persists a tiny state file so rules can be reconciled and
 //! expired later, and so the UI can reflect the current status after restarts.
 
+use crate::types::ConnInfo;
 use serde::{Deserialize, Serialize};
+use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::process::Command;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -51,6 +53,51 @@ struct BlockedProcess {
     expires_at_unix: Option<u64>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SocketKillError {
+    UnsupportedStatus(String),
+    InvalidLocalAddr(String),
+    InvalidRemoteAddr(String),
+    UnsupportedAddressFamily,
+    UnsupportedProtocol,
+    PlatformUnsupported,
+    PermissionDenied,
+    OsError(u32),
+}
+
+impl std::fmt::Display for SocketKillError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedStatus(status) => {
+                write!(f, "cannot kill a socket in {status} state")
+            }
+            Self::InvalidLocalAddr(addr) => write!(f, "invalid local address: {addr}"),
+            Self::InvalidRemoteAddr(addr) => write!(f, "invalid remote address: {addr}"),
+            Self::UnsupportedAddressFamily => {
+                write!(f, "socket kill currently supports IPv4 TCP only")
+            }
+            Self::UnsupportedProtocol => {
+                write!(f, "socket kill currently supports TCP connections only")
+            }
+            Self::PlatformUnsupported => {
+                write!(f, "socket kill is currently only implemented on Windows")
+            }
+            Self::PermissionDenied => {
+                write!(f, "administrator privileges are required to kill a TCP connection")
+            }
+            Self::OsError(code) => write!(f, "Windows returned error code {code}"),
+        }
+    }
+}
+
+impl std::error::Error for SocketKillError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SocketKillTarget {
+    local: SocketAddr,
+    remote: SocketAddr,
+}
+
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 pub enum DurationPreset {
@@ -80,6 +127,28 @@ pub fn status() -> Status {
 
 pub fn can_modify_firewall() -> bool {
     platform::is_supported() && platform::is_elevated()
+}
+
+pub fn can_kill_connection(conn: &ConnInfo) -> bool {
+    if !platform::is_supported() || !platform::is_elevated() {
+        return false;
+    }
+    socket_kill_target(conn).is_ok()
+}
+
+pub fn kill_connection(conn: &ConnInfo) -> Result<String, SocketKillError> {
+    if !platform::is_supported() {
+        return Err(SocketKillError::PlatformUnsupported);
+    }
+    if !platform::is_elevated() {
+        return Err(SocketKillError::PermissionDenied);
+    }
+    let target = socket_kill_target(conn)?;
+    platform::kill_tcp_connection(&target)?;
+    Ok(format!(
+        "Killed TCP connection {} -> {}.",
+        target.local, target.remote
+    ))
 }
 
 pub fn reconcile() {
@@ -344,6 +413,35 @@ fn ensure_modifiable() -> Result<(), String> {
     Ok(())
 }
 
+fn socket_kill_target(conn: &ConnInfo) -> Result<SocketKillTarget, SocketKillError> {
+    if !conn.status.eq_ignore_ascii_case("ESTABLISHED")
+        && !conn.status.eq_ignore_ascii_case("SYN_SENT")
+        && !conn.status.eq_ignore_ascii_case("SYN_RECEIVED")
+        && !conn.status.eq_ignore_ascii_case("FIN_WAIT_1")
+        && !conn.status.eq_ignore_ascii_case("FIN_WAIT_2")
+        && !conn.status.eq_ignore_ascii_case("CLOSE_WAIT")
+        && !conn.status.eq_ignore_ascii_case("CLOSING")
+        && !conn.status.eq_ignore_ascii_case("LAST_ACK")
+        && !conn.status.eq_ignore_ascii_case("TIME_WAIT")
+    {
+        return Err(SocketKillError::UnsupportedStatus(conn.status.clone()));
+    }
+
+    let local = conn
+        .local_addr
+        .parse::<SocketAddr>()
+        .map_err(|_| SocketKillError::InvalidLocalAddr(conn.local_addr.clone()))?;
+    let remote = conn
+        .remote_addr
+        .parse::<SocketAddr>()
+        .map_err(|_| SocketKillError::InvalidRemoteAddr(conn.remote_addr.clone()))?;
+
+    match (local.ip(), remote.ip()) {
+        (IpAddr::V4(_), IpAddr::V4(_)) => Ok(SocketKillTarget { local, remote }),
+        _ => Err(SocketKillError::UnsupportedAddressFamily),
+    }
+}
+
 fn normalise_target(target: &str) -> Result<String, String> {
     let target = target.trim();
     if target.is_empty() {
@@ -462,7 +560,10 @@ fn unix_now() -> u64 {
 #[cfg(windows)]
 mod platform {
     use super::*;
-    use windows::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows::Win32::Foundation::{CloseHandle, HANDLE, ERROR_ACCESS_DENIED, NO_ERROR};
+    use windows::Win32::NetworkManagement::IpHelper::{
+        SetTcpEntry, MIB_TCP_STATE_DELETE_TCB, MIB_TCPROW,
+    };
     use windows::Win32::Security::{
         GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY,
     };
@@ -491,6 +592,34 @@ mod platform {
             .is_ok();
             let _ = CloseHandle(token);
             ok && elevation.TokenIsElevated != 0
+        }
+    }
+
+    pub fn kill_tcp_connection(target: &SocketKillTarget) -> Result<(), SocketKillError> {
+        let local = match target.local {
+            SocketAddr::V4(local) => local,
+            SocketAddr::V6(_) => return Err(SocketKillError::UnsupportedAddressFamily),
+        };
+        let remote = match target.remote {
+            SocketAddr::V4(remote) => remote,
+            SocketAddr::V6(_) => return Err(SocketKillError::UnsupportedAddressFamily),
+        };
+
+        let mut row = MIB_TCPROW {
+            dwState: MIB_TCP_STATE_DELETE_TCB,
+            dwLocalAddr: u32::from_be_bytes(local.ip().octets()),
+            dwLocalPort: u32::from(local.port().to_be()),
+            dwRemoteAddr: u32::from_be_bytes(remote.ip().octets()),
+            dwRemotePort: u32::from(remote.port().to_be()),
+        };
+
+        let status = unsafe { SetTcpEntry(&row) };
+        if status == NO_ERROR {
+            Ok(())
+        } else if status == ERROR_ACCESS_DENIED.0 {
+            Err(SocketKillError::PermissionDenied)
+        } else {
+            Err(SocketKillError::OsError(status))
         }
     }
 
@@ -584,12 +713,18 @@ mod platform {
 
 #[cfg(not(windows))]
 mod platform {
+    use super::*;
+
     pub fn is_supported() -> bool {
         false
     }
 
     pub fn is_elevated() -> bool {
         false
+    }
+
+    pub fn kill_tcp_connection(_target: &SocketKillTarget) -> Result<(), SocketKillError> {
+        Err(SocketKillError::PlatformUnsupported)
     }
 
     pub fn add_block_rule(_rule_name: &str, _target: &str) -> Result<(), String> {
@@ -628,6 +763,35 @@ mod tests {
             inbound_rule_name: format!("in-{path}"),
             outbound_rule_name: format!("out-{path}"),
             expires_at_unix,
+        }
+    }
+
+    fn conn(local: &str, remote: &str, status: &str) -> ConnInfo {
+        ConnInfo {
+            timestamp: "12:00:00".into(),
+            proc_name: "evil.exe".into(),
+            pid: 4242,
+            proc_path: "C:/Temp/evil.exe".into(),
+            proc_user: "user".into(),
+            parent_name: "cmd.exe".into(),
+            parent_pid: 123,
+            service_name: String::new(),
+            publisher: String::new(),
+            local_addr: local.into(),
+            remote_addr: remote.into(),
+            status: status.into(),
+            score: 9,
+            reasons: vec!["test".into()],
+            ancestor_chain: vec![("cmd.exe".into(), 123)],
+            pre_login: false,
+            hostname: None,
+            country: None,
+            asn: None,
+            asn_org: None,
+            reputation_hit: None,
+            recently_dropped: false,
+            long_lived: false,
+            dga_like: false,
         }
     }
 
@@ -685,5 +849,50 @@ mod tests {
 
         assert!(process_block_matches(&rule, "C:/app.exe"));
         assert!(!process_block_matches(&rule, "C:/other.exe"));
+    }
+
+    #[test]
+    fn socket_kill_target_accepts_established_ipv4_connections() {
+        let parsed = socket_kill_target(&conn(
+            "192.168.1.10:50000",
+            "8.8.8.8:443",
+            "ESTABLISHED",
+        ))
+        .unwrap();
+        assert_eq!(parsed.local.to_string(), "192.168.1.10:50000");
+        assert_eq!(parsed.remote.to_string(), "8.8.8.8:443");
+    }
+
+    #[test]
+    fn socket_kill_target_rejects_listen_rows() {
+        let err = socket_kill_target(&conn(
+            "0.0.0.0:80",
+            "0.0.0.0:0",
+            "LISTEN",
+        ))
+        .unwrap_err();
+        assert!(matches!(err, SocketKillError::UnsupportedStatus(_)));
+    }
+
+    #[test]
+    fn socket_kill_target_rejects_invalid_remote() {
+        let err = socket_kill_target(&conn(
+            "192.168.1.10:50000",
+            "not-an-endpoint",
+            "ESTABLISHED",
+        ))
+        .unwrap_err();
+        assert!(matches!(err, SocketKillError::InvalidRemoteAddr(_)));
+    }
+
+    #[test]
+    fn socket_kill_target_rejects_ipv6_for_now() {
+        let err = socket_kill_target(&conn(
+            "[::1]:50000",
+            "[2606:4700:4700::1111]:443",
+            "ESTABLISHED",
+        ))
+        .unwrap_err();
+        assert!(matches!(err, SocketKillError::UnsupportedAddressFamily));
     }
 }

--- a/src/auto_response.rs
+++ b/src/auto_response.rs
@@ -1,0 +1,313 @@
+//! Optional, UI-layer auto-response policy engine.
+//!
+//! This module intentionally starts conservative:
+//! - disabled by default
+//! - dry-run by default
+//! - automation is suppressed for trusted processes
+//! - actions require strong corroborating signals, not just a high score
+//! - actions are cooldown-limited per target to avoid thrashing
+
+use crate::{
+    active_response,
+    config::{normalise_name, Config},
+    types::ConnInfo,
+};
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Default)]
+pub struct EngineState {
+    cooldowns: HashMap<String, Instant>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlannedAction {
+    KillConnection,
+    BlockRemote {
+        target: String,
+        preset: active_response::DurationPreset,
+    },
+    BlockProcess {
+        pid: u32,
+        path: String,
+        preset: active_response::DurationPreset,
+    },
+}
+
+pub fn maybe_apply(conn: &ConnInfo, cfg: &Config, state: &mut EngineState) -> Option<String> {
+    let action = plan(conn, cfg)?;
+    let cooldown = Duration::from_secs(cfg.auto_response_cooldown_secs.max(1));
+    if !state.try_acquire(cooldown_key(&action), cooldown) {
+        return None;
+    }
+
+    let summary = describe_action(&action, conn);
+    if cfg.auto_response_dry_run {
+        tracing::warn!(
+            pid = conn.pid,
+            proc_name = %conn.proc_name,
+            score = conn.score,
+            local_addr = %conn.local_addr,
+            remote_addr = %conn.remote_addr,
+            action = %summary,
+            "auto-response dry run"
+        );
+        return Some(format!("Auto-response dry run: {summary}."));
+    }
+
+    let result = execute(&action, conn);
+    match &result {
+        Ok(message) => {
+            tracing::warn!(
+                pid = conn.pid,
+                proc_name = %conn.proc_name,
+                score = conn.score,
+                local_addr = %conn.local_addr,
+                remote_addr = %conn.remote_addr,
+                action = %summary,
+                result = %message,
+                "auto-response executed"
+            );
+            Some(format!("Auto-response: {message}"))
+        }
+        Err(err) => {
+            tracing::warn!(
+                pid = conn.pid,
+                proc_name = %conn.proc_name,
+                score = conn.score,
+                local_addr = %conn.local_addr,
+                remote_addr = %conn.remote_addr,
+                action = %summary,
+                error = %err,
+                "auto-response failed"
+            );
+            Some(format!("Auto-response failed: {summary} ({err})"))
+        }
+    }
+}
+
+pub fn plan(conn: &ConnInfo, cfg: &Config) -> Option<PlannedAction> {
+    if !cfg.auto_response_enabled || conn.score < cfg.auto_response_min_score {
+        return None;
+    }
+    if is_trusted_process(conn, cfg) {
+        return None;
+    }
+
+    let signal_strength = signal_strength(conn);
+    if signal_strength < 2 {
+        return None;
+    }
+
+    if cfg.auto_kill_connection && active_response::can_kill_connection(conn) {
+        return Some(PlannedAction::KillConnection);
+    }
+
+    if cfg.auto_block_remote {
+        if let Some(target) = active_response::extract_remote_target(&conn.remote_addr) {
+            return Some(PlannedAction::BlockRemote {
+                target,
+                preset: active_response::DurationPreset::OneHour,
+            });
+        }
+    }
+
+    if cfg.auto_block_process && signal_strength >= 3 && !conn.proc_path.trim().is_empty() {
+        return Some(PlannedAction::BlockProcess {
+            pid: conn.pid,
+            path: conn.proc_path.clone(),
+            preset: active_response::DurationPreset::OneHour,
+        });
+    }
+
+    None
+}
+
+fn execute(action: &PlannedAction, conn: &ConnInfo) -> Result<String, String> {
+    match action {
+        PlannedAction::KillConnection => active_response::kill_connection(conn)
+            .map_err(|err| err.to_string()),
+        PlannedAction::BlockRemote { target, preset } => {
+            active_response::block_remote(target, *preset)
+        }
+        PlannedAction::BlockProcess { pid, path, preset } => {
+            active_response::block_process(*pid, path, *preset)
+        }
+    }
+}
+
+fn describe_action(action: &PlannedAction, conn: &ConnInfo) -> String {
+    match action {
+        PlannedAction::KillConnection => {
+            format!("would kill connection {} -> {}", conn.local_addr, conn.remote_addr)
+        }
+        PlannedAction::BlockRemote { target, .. } => {
+            format!("would block remote {target} for 1 hour")
+        }
+        PlannedAction::BlockProcess { path, .. } => {
+            format!("would block process traffic for {path} for 1 hour")
+        }
+    }
+}
+
+fn is_trusted_process(conn: &ConnInfo, cfg: &Config) -> bool {
+    let key = normalise_name(&conn.proc_name);
+    cfg.trusted_processes
+        .iter()
+        .any(|trusted| trusted.eq_ignore_ascii_case(&key))
+}
+
+fn signal_strength(conn: &ConnInfo) -> u8 {
+    let mut strength = 0u8;
+    let mut has_primary_signal = false;
+
+    if conn.reputation_hit.is_some() {
+        strength += 2;
+        has_primary_signal = true;
+    }
+    if conn.recently_dropped {
+        strength += 1;
+        has_primary_signal = true;
+    }
+    if conn.dga_like {
+        strength += 1;
+        has_primary_signal = true;
+    }
+    if conn.pre_login {
+        strength += 1;
+    }
+    if conn.publisher.trim().is_empty() {
+        strength += 1;
+    }
+    if conn
+        .reasons
+        .iter()
+        .any(|reason| reason.to_ascii_lowercase().contains("beacon"))
+    {
+        strength += 1;
+        has_primary_signal = true;
+    }
+    if conn
+        .reasons
+        .iter()
+        .any(|reason| reason.to_ascii_lowercase().contains("malware port"))
+    {
+        strength += 1;
+    }
+
+    if has_primary_signal {
+        strength
+    } else {
+        0
+    }
+}
+
+fn cooldown_key(action: &PlannedAction) -> String {
+    match action {
+        PlannedAction::KillConnection => "kill-connection".to_string(),
+        PlannedAction::BlockRemote { target, .. } => format!("block-remote:{target}"),
+        PlannedAction::BlockProcess { path, .. } => format!("block-process:{path}"),
+    }
+}
+
+impl EngineState {
+    fn try_acquire(&mut self, key: String, cooldown: Duration) -> bool {
+        let now = Instant::now();
+        self.cooldowns
+            .retain(|_, at| now.duration_since(*at) < cooldown.saturating_mul(2));
+        if let Some(previous) = self.cooldowns.get(&key) {
+            if now.duration_since(*previous) < cooldown {
+                return false;
+            }
+        }
+        self.cooldowns.insert(key, now);
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_conn() -> ConnInfo {
+        ConnInfo {
+            timestamp: "12:00:00".into(),
+            proc_name: "evil.exe".into(),
+            pid: 4242,
+            proc_path: "C:/Temp/evil.exe".into(),
+            proc_user: "user".into(),
+            parent_name: "cmd.exe".into(),
+            parent_pid: 123,
+            service_name: String::new(),
+            publisher: String::new(),
+            local_addr: "192.168.1.10:50000".into(),
+            remote_addr: "8.8.8.8:443".into(),
+            status: "ESTABLISHED".into(),
+            score: 12,
+            reasons: vec!["beaconing cadence".into()],
+            ancestor_chain: vec![("cmd.exe".into(), 123)],
+            pre_login: false,
+            hostname: Some("abcd1234.bad.example".into()),
+            country: None,
+            asn: None,
+            asn_org: None,
+            reputation_hit: Some("feed.txt".into()),
+            recently_dropped: false,
+            long_lived: false,
+            dga_like: true,
+        }
+    }
+
+    #[test]
+    fn disabled_config_never_plans() {
+        let cfg = Config::default();
+        assert_eq!(plan(&sample_conn(), &cfg), None);
+    }
+
+    #[test]
+    fn trusted_process_suppresses_automation() {
+        let mut cfg = Config::default();
+        cfg.auto_response_enabled = true;
+        cfg.auto_block_remote = true;
+        cfg.trusted_processes.push("evil".into());
+        assert_eq!(plan(&sample_conn(), &cfg), None);
+    }
+
+    #[test]
+    fn plans_remote_block_when_enabled_and_signals_are_strong() {
+        let mut cfg = Config::default();
+        cfg.auto_response_enabled = true;
+        cfg.auto_block_remote = true;
+        let planned = plan(&sample_conn(), &cfg).unwrap();
+        assert!(matches!(
+            planned,
+            PlannedAction::BlockRemote {
+                target,
+                preset: active_response::DurationPreset::OneHour,
+            } if target == "8.8.8.8"
+        ));
+    }
+
+    #[test]
+    fn process_block_requires_stronger_signal_and_known_path() {
+        let mut cfg = Config::default();
+        cfg.auto_response_enabled = true;
+        cfg.auto_block_process = true;
+        let planned = plan(&sample_conn(), &cfg).unwrap();
+        assert!(matches!(
+            planned,
+            PlannedAction::BlockProcess {
+                pid: 4242,
+                ref path,
+                preset: active_response::DurationPreset::OneHour,
+            } if path == "C:/Temp/evil.exe"
+        ));
+    }
+
+    #[test]
+    fn cooldown_suppresses_duplicate_actions() {
+        let mut state = EngineState::default();
+        assert!(state.try_acquire("k".into(), Duration::from_secs(60)));
+        assert!(!state.try_acquire("k".into(), Duration::from_secs(60)));
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,6 +76,24 @@ pub struct Config {
     /// score under 3.5; random-looking DGA output scores 4.0+.
     #[serde(default = "default_dga_threshold")]
     pub dga_entropy_threshold: f32,
+
+    // ── Phase 12: Optional auto response ─────────────────────────────────────
+    #[serde(default)]
+    pub auto_response_enabled: bool,
+    #[serde(default)]
+    pub auto_response_dry_run: bool,
+    #[serde(default)]
+    pub auto_kill_connection: bool,
+    #[serde(default)]
+    pub auto_block_remote: bool,
+    #[serde(default)]
+    pub auto_block_process: bool,
+    #[serde(default)]
+    pub auto_isolate_machine: bool,
+    #[serde(default = "default_auto_response_min_score")]
+    pub auto_response_min_score: u8,
+    #[serde(default = "default_auto_response_cooldown_secs")]
+    pub auto_response_cooldown_secs: u64,
 }
 
 fn default_true() -> bool {
@@ -89,6 +107,12 @@ fn default_long_lived_threshold() -> u64 {
 }
 fn default_dga_threshold() -> f32 {
     3.2
+}
+fn default_auto_response_min_score() -> u8 {
+    10
+}
+fn default_auto_response_cooldown_secs() -> u64 {
+    300
 }
 
 impl Default for Config {
@@ -244,6 +268,16 @@ impl Default for Config {
             long_lived_secs: 3600,
             reverse_dns_enabled: false,
             dga_entropy_threshold: 3.2,
+
+            // Phase 12 defaults (safe / disabled)
+            auto_response_enabled: false,
+            auto_response_dry_run: true,
+            auto_kill_connection: false,
+            auto_block_remote: false,
+            auto_block_process: false,
+            auto_isolate_machine: false,
+            auto_response_min_score: 10,
+            auto_response_cooldown_secs: 300,
         }
     }
 }
@@ -386,5 +420,18 @@ mod tests {
             loaded.trusted_processes,
             vec!["b".to_string(), "c".to_string()]
         );
+    }
+
+    #[test]
+    fn auto_response_defaults_are_safe() {
+        let cfg = Config::default();
+        assert!(!cfg.auto_response_enabled);
+        assert!(cfg.auto_response_dry_run);
+        assert!(!cfg.auto_kill_connection);
+        assert!(!cfg.auto_block_remote);
+        assert!(!cfg.auto_block_process);
+        assert!(!cfg.auto_isolate_machine);
+        assert_eq!(cfg.auto_response_min_score, 10);
+        assert_eq!(cfg.auto_response_cooldown_secs, 300);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@
 )]
 
 mod active_response;
+mod auto_response;
 mod autostart;
 mod beacon;
 mod blocklist;

--- a/src/ui/inspector.rs
+++ b/src/ui/inspector.rs
@@ -20,6 +20,7 @@ pub enum Action {
     RequestAdmin,
     BlockRemote(active_response::DurationPreset),
     BlockProcess(active_response::DurationPreset),
+    KillConnection,
     UnblockRemote,
     UnblockProcess,
     IsolateMachine,
@@ -76,6 +77,10 @@ fn show_detail(ui: &mut Ui, sel: &ProcessSelection, kill_confirm: bool) -> Optio
         .and_then(active_response::remote_block_remaining);
     let process_blocked = active_response::is_process_blocked(sel.pid, &sel.proc_path);
     let process_remaining = active_response::process_block_remaining(sel.pid, &sel.proc_path);
+    let connection_kill_enabled = sel
+        .selected_connection
+        .as_ref()
+        .is_some_and(active_response::can_kill_connection);
     let isolated = response_status.isolated;
 
     egui::ScrollArea::vertical()
@@ -232,6 +237,24 @@ fn show_detail(ui: &mut Ui, sel: &ProcessSelection, kill_confirm: bool) -> Optio
                         .color(theme::TEXT3)
                         .size(10.5),
                 );
+            }
+
+            ui.add_space(6.0);
+            let kill_conn_resp = ui.add_enabled(
+                connection_kill_enabled,
+                danger_btn("Kill connection"),
+            );
+            let kill_conn_resp = if connection_kill_enabled {
+                kill_conn_resp
+                    .on_hover_cursor(egui::CursorIcon::PointingHand)
+                    .on_hover_text("Immediately terminate the selected live TCP connection.")
+            } else {
+                kill_conn_resp.on_hover_text(
+                    "Select an IPv4 TCP connection with a killable state while Vigil is running as administrator.",
+                )
+            };
+            if kill_conn_resp.clicked() {
+                action = Some(Action::KillConnection);
             }
 
             ui.add_space(8.0);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -14,6 +14,7 @@ pub mod tab_bar;
 pub mod theme;
 
 use crate::active_response;
+use crate::auto_response;
 use crate::config::Config;
 use crate::tray::TrayCmd;
 use crate::types::{ConnEvent, ConnInfo};
@@ -135,6 +136,7 @@ enum PendingResponse {
         path: String,
         preset: active_response::DurationPreset,
     },
+    KillConnection(ConnInfo),
     UnblockRemote(String),
     UnblockProcess {
         pid: u32,
@@ -185,6 +187,7 @@ pub struct VigilApp {
     response_status: active_response::Status,
     response_message: Option<(String, std::time::Instant)>,
     admin_message: Option<(String, std::time::Instant)>,
+    auto_response_state: auto_response::EngineState,
     exit_requested: bool,
     last_response_reconcile: std::time::Instant,
     paused: bool,
@@ -236,6 +239,7 @@ impl VigilApp {
             response_status: active_response::status(),
             response_message: None,
             admin_message: None,
+            auto_response_state: auto_response::EngineState::default(),
             exit_requested: false,
             last_response_reconcile: std::time::Instant::now(),
             paused: false,
@@ -261,10 +265,12 @@ impl VigilApp {
                             push_capped(&mut self.activity, info.clone(), ACTIVITY_CAP);
                             push_capped(&mut self.alerts, info.clone(), ALERTS_CAP);
                             self.unseen_alerts += 1;
-                            let _ = self.tray_tx.try_send(TrayCmd::Alert(Box::new(info)));
+                            let _ = self.tray_tx.try_send(TrayCmd::Alert(Box::new(info.clone())));
+                            self.maybe_apply_auto_response(&info);
                         }
                         ConnEvent::New(info) => {
-                            push_capped(&mut self.activity, info, ACTIVITY_CAP);
+                            push_capped(&mut self.activity, info.clone(), ACTIVITY_CAP);
+                            self.maybe_apply_auto_response(&info);
                         }
                         ConnEvent::Closed { .. } => {}
                     }
@@ -277,6 +283,14 @@ impl VigilApp {
             }
         }
         handled
+    }
+
+    fn maybe_apply_auto_response(&mut self, info: &ConnInfo) {
+        let cfg = self.cfg.read().unwrap().clone();
+        if let Some(message) = auto_response::maybe_apply(info, &cfg, &mut self.auto_response_state) {
+            self.response_message = Some((message, std::time::Instant::now()));
+            self.response_status = active_response::status();
+        }
     }
 
     // ── Inspector action handler ──────────────────────────────────────────────
@@ -333,6 +347,13 @@ impl VigilApp {
                             path: info.proc_path,
                             preset,
                         });
+                    }
+                }
+            }
+            inspector::Action::KillConnection => {
+                if let Some(info) = selected_info {
+                    if let Some(conn) = info.selected_connection {
+                        self.response_confirm = Some(PendingResponse::KillConnection(conn));
                     }
                 }
             }
@@ -811,6 +832,14 @@ impl VigilApp {
                     label.to_string(),
                 )
             }
+            PendingResponse::KillConnection(conn) => (
+                "Kill connection",
+                format!(
+                    "Immediately terminate the live TCP connection {} -> {}?",
+                    conn.local_addr, conn.remote_addr
+                ),
+                "Kill connection".to_string(),
+            ),
             PendingResponse::UnblockRemote(target) => (
                 "Remove remote block",
                 format!("Remove the temporary firewall rule for {target}?"),
@@ -898,6 +927,12 @@ impl VigilApp {
                 match active_response::block_process(*pid, path, *preset) {
                     Ok(msg) => msg,
                     Err(err) => format!("Could not block {path}: {err}"),
+                }
+            }
+            PendingResponse::KillConnection(conn) => {
+                match active_response::kill_connection(conn) {
+                    Ok(msg) => msg,
+                    Err(err) => format!("Could not kill {} -> {}: {err}", conn.local_addr, conn.remote_addr),
                 }
             }
             PendingResponse::UnblockRemote(target) => match active_response::unblock_remote(target)

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -21,6 +21,14 @@ pub struct SettingsDraft {
     pub new_trusted_input: String,
     /// UI-only filter string for the trusted processes table; never persisted.
     pub trusted_filter: String,
+    pub auto_response_enabled: bool,
+    pub auto_response_dry_run: bool,
+    pub auto_kill_connection: bool,
+    pub auto_block_remote: bool,
+    pub auto_block_process: bool,
+    pub auto_isolate_machine: bool,
+    pub auto_response_min_score: u8,
+    pub auto_response_cooldown_secs: u64,
     pub status_msg: Option<(String, std::time::Instant)>,
 }
 
@@ -34,6 +42,14 @@ impl SettingsDraft {
             trusted_processes: cfg.trusted_processes.clone(),
             new_trusted_input: String::new(),
             trusted_filter: String::new(),
+            auto_response_enabled: cfg.auto_response_enabled,
+            auto_response_dry_run: cfg.auto_response_dry_run,
+            auto_kill_connection: cfg.auto_kill_connection,
+            auto_block_remote: cfg.auto_block_remote,
+            auto_block_process: cfg.auto_block_process,
+            auto_isolate_machine: cfg.auto_isolate_machine,
+            auto_response_min_score: cfg.auto_response_min_score,
+            auto_response_cooldown_secs: cfg.auto_response_cooldown_secs,
             status_msg: None,
         }
     }
@@ -44,6 +60,14 @@ impl SettingsDraft {
         cfg.log_all_connections = self.log_all_connections;
         cfg.autostart = self.autostart;
         cfg.trusted_processes = self.trusted_processes.clone();
+        cfg.auto_response_enabled = self.auto_response_enabled;
+        cfg.auto_response_dry_run = self.auto_response_dry_run;
+        cfg.auto_kill_connection = self.auto_kill_connection;
+        cfg.auto_block_remote = self.auto_block_remote;
+        cfg.auto_block_process = self.auto_block_process;
+        cfg.auto_isolate_machine = self.auto_isolate_machine;
+        cfg.auto_response_min_score = self.auto_response_min_score;
+        cfg.auto_response_cooldown_secs = self.auto_response_cooldown_secs;
         // trusted_filter is intentionally not persisted
     }
 }
@@ -118,6 +142,122 @@ fn inner(ui: &mut egui::Ui, draft: &mut SettingsDraft, changed: &mut bool) {
             .changed();
     });
 
+    // ── Auto response ─────────────────────────────────────────────────────────
+    ui.add_space(16.0);
+    section_header(ui, "Auto response");
+    ui.label(
+        RichText::new(
+            "Optional and disabled by default. Vigil only auto-acts when this is enabled, the selected action type is enabled, the process is not trusted, and strong corroborating signals are present.",
+        )
+        .color(theme::TEXT2)
+        .size(12.0),
+    );
+    ui.add_space(8.0);
+
+    setting_row(ui, label_w, "Enable auto response", |ui| {
+        *changed |= ui
+            .checkbox(
+                &mut draft.auto_response_enabled,
+                RichText::new("allow Vigil to take automated containment actions")
+                    .color(theme::TEXT2)
+                    .size(11.5),
+            )
+            .changed();
+    });
+
+    setting_row(ui, label_w, "Dry run", |ui| {
+        *changed |= ui
+            .checkbox(
+                &mut draft.auto_response_dry_run,
+                RichText::new("log and surface planned actions without executing them")
+                    .color(theme::TEXT2)
+                    .size(11.5),
+            )
+            .changed();
+    });
+
+    ui.add_enabled_ui(draft.auto_response_enabled, |ui| {
+        setting_row(ui, label_w, "Minimum score", |ui| {
+            ui.horizontal(|ui| {
+                let resp = ui.add(
+                    egui::Slider::new(&mut draft.auto_response_min_score, 6_u8..=20_u8)
+                        .clamping(egui::SliderClamping::Always),
+                );
+                *changed |= resp.changed();
+                ui.label(
+                    RichText::new(format!("  auto-response threshold: {}", draft.auto_response_min_score))
+                        .color(theme::TEXT3)
+                        .size(11.0),
+                );
+            });
+        });
+
+        setting_row(ui, label_w, "Cooldown", |ui| {
+            ui.horizontal(|ui| {
+                let resp = ui.add(
+                    egui::Slider::new(&mut draft.auto_response_cooldown_secs, 30_u64..=3600_u64)
+                        .suffix(" s")
+                        .clamping(egui::SliderClamping::Always),
+                );
+                *changed |= resp.changed();
+                ui.label(
+                    RichText::new("  suppress duplicate actions for the same target")
+                        .color(theme::TEXT3)
+                        .size(11.0),
+                );
+            });
+        });
+
+        setting_row(ui, label_w, "Auto kill connection", |ui| {
+            *changed |= ui
+                .checkbox(
+                    &mut draft.auto_kill_connection,
+                    RichText::new("terminate a live IPv4 TCP connection when high-confidence signals match")
+                        .color(theme::TEXT2)
+                        .size(11.5),
+                )
+                .changed();
+        });
+
+        setting_row(ui, label_w, "Auto block remote", |ui| {
+            *changed |= ui
+                .checkbox(
+                    &mut draft.auto_block_remote,
+                    RichText::new("optionally add a temporary 1-hour firewall rule for a suspicious remote IP")
+                        .color(theme::TEXT2)
+                        .size(11.5),
+                )
+                .changed();
+        });
+
+        setting_row(ui, label_w, "Auto block process", |ui| {
+            *changed |= ui
+                .checkbox(
+                    &mut draft.auto_block_process,
+                    RichText::new("optionally add temporary process firewall rules for stronger high-confidence matches")
+                        .color(theme::TEXT2)
+                        .size(11.5),
+                )
+                .changed();
+        });
+
+        setting_row(ui, label_w, "Auto isolate machine", |ui| {
+            ui.label(
+                RichText::new("reserved for future policy expansion; kept disabled in the current release")
+                    .color(theme::TEXT3)
+                    .size(11.0),
+            );
+        });
+    });
+
+    if !draft.auto_response_enabled {
+        ui.label(
+            RichText::new("Auto response is currently disabled, so Vigil will only surface recommendations and manual actions.")
+                .color(theme::TEXT3)
+                .size(10.8),
+        );
+    }
+
     // ── Startup ───────────────────────────────────────────────────────────────
     ui.add_space(16.0);
     section_header(ui, "Startup");
@@ -147,7 +287,7 @@ fn inner(ui: &mut egui::Ui, draft: &mut SettingsDraft, changed: &mut bool) {
     ui.add_space(6.0);
     ui.label(
         RichText::new(
-            "Trusted processes are exempt from routine penalties. They still alert on severe signals such as malware ports or suspicious ancestry. Matching is case-insensitive and ignores .exe.",
+            "Trusted processes are exempt from routine penalties and automatic response. They still alert on severe signals such as malware ports or suspicious ancestry. Matching is case-insensitive and ignores .exe.",
         )
         .color(theme::TEXT2)
         .size(12.0),
@@ -343,7 +483,7 @@ fn inner(ui: &mut egui::Ui, draft: &mut SettingsDraft, changed: &mut bool) {
                                                 );
                                                 ui.label(
                                                     RichText::new(
-                                                        "Trusted for routine connections",
+                                                        "Trusted for routine connections and automation suppression",
                                                     )
                                                     .color(theme::TEXT3)
                                                     .size(9.6),


### PR DESCRIPTION
## Summary
- add socket-level TCP connection termination to active response
- wire a manual `Kill connection` action into the inspector UI
- add an optional UI-layer auto-response policy engine with cooldowns and dry-run mode
- add config and settings controls for auto-response, all disabled by default

## Notes
- auto-response remains conservative: disabled by default, dry-run by default, and suppressed for trusted processes
- auto block actions are optional and off by default, per repo safety requirements
- this branch diverged from `master` after it moved ahead by 2 commits, so GitHub may require a rebase/merge before landing

## What to test
- manual `Kill connection` on an admin/elevated Windows session
- manual block/unblock remote and process actions still work
- enabling auto-response in dry-run mode produces UI/log messages without containment
- enabling `Auto kill connection` only acts on strong-signal, non-trusted processes
- trusted processes remain exempt from automation
