### PR TITLE
Document response actions, add audit log, and improve IPv6 handling

### DIFF
--- a/src/active_response.rs
+++ b/src/active_response.rs
@@ -8,8 +8,9 @@
 //! The module persists a tiny state file so rules can be reconciled and
 //! expired later, and so the UI can reflect the current status after restarts.
 
-use crate::types::ConnInfo;
+use crate::{audit, types::ConnInfo};
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::process::Command;
@@ -74,7 +75,7 @@ impl std::fmt::Display for SocketKillError {
             Self::InvalidLocalAddr(addr) => write!(f, "invalid local address: {addr}"),
             Self::InvalidRemoteAddr(addr) => write!(f, "invalid remote address: {addr}"),
             Self::UnsupportedAddressFamily => {
-                write!(f, "socket kill currently supports IPv4 TCP only")
+                write!(f, "live socket kill currently supports IPv4 TCP only on Windows")
             }
             Self::UnsupportedProtocol => {
                 write!(f, "socket kill currently supports TCP connections only")
@@ -145,10 +146,18 @@ pub fn kill_connection(conn: &ConnInfo) -> Result<String, SocketKillError> {
     }
     let target = socket_kill_target(conn)?;
     platform::kill_tcp_connection(&target)?;
-    Ok(format!(
-        "Killed TCP connection {} -> {}.",
-        target.local, target.remote
-    ))
+    let message = format!("Killed TCP connection {} -> {}.", target.local, target.remote);
+    audit::record(
+        "kill_connection",
+        "success",
+        json!({
+            "local_addr": target.local.to_string(),
+            "remote_addr": target.remote.to_string(),
+            "pid": conn.pid,
+            "proc_name": conn.proc_name,
+        }),
+    );
+    Ok(message)
 }
 
 pub fn reconcile() {
@@ -190,11 +199,21 @@ pub fn block_remote(target: &str, preset: DurationPreset) -> Result<String, Stri
     });
     save_state(&state)?;
 
-    Ok(match preset {
+    let message = match preset {
         DurationPreset::OneHour => format!("Blocked {target} for 1 hour."),
         DurationPreset::OneDay => format!("Blocked {target} for 24 hours."),
         DurationPreset::Permanent => format!("Blocked {target} until removed."),
-    })
+    };
+    audit::record(
+        "block_remote",
+        "success",
+        json!({
+            "target": target,
+            "duration": format!("{:?}", preset),
+            "rule_name": rule_name,
+        }),
+    );
+    Ok(message)
 }
 
 pub fn unblock_remote(target: &str) -> Result<String, String> {
@@ -222,12 +241,18 @@ pub fn unblock_remote(target: &str) -> Result<String, String> {
             "Could not remove the firewall rule for {target}; it was kept in state so Vigil can retry."
         ));
     }
-    if removed > 0 {
+    let message = if removed > 0 {
         save_state(&state)?;
-        Ok(format!("Removed {removed} block rule(s) for {target}."))
+        format!("Removed {removed} block rule(s) for {target}.")
     } else {
-        Ok(format!("No active block rule found for {target}."))
-    }
+        format!("No active block rule found for {target}.")
+    };
+    audit::record(
+        "unblock_remote",
+        if removed > 0 { "success" } else { "noop" },
+        json!({ "target": target, "removed_rules": removed }),
+    );
+    Ok(message)
 }
 
 pub fn block_process(pid: u32, path: &str, preset: DurationPreset) -> Result<String, String> {
@@ -255,17 +280,29 @@ pub fn block_process(pid: u32, path: &str, preset: DurationPreset) -> Result<Str
     state.blocked_processes.push(BlockedProcess {
         pid,
         path: path.clone(),
-        inbound_rule_name,
-        outbound_rule_name,
+        inbound_rule_name: inbound_rule_name.clone(),
+        outbound_rule_name: outbound_rule_name.clone(),
         expires_at_unix,
     });
     save_state(&state)?;
 
-    Ok(match preset {
+    let message = match preset {
         DurationPreset::OneHour => format!("Blocked {path} for 1 hour."),
         DurationPreset::OneDay => format!("Blocked {path} for 24 hours."),
         DurationPreset::Permanent => format!("Blocked {path} until removed."),
-    })
+    };
+    audit::record(
+        "block_process",
+        "success",
+        json!({
+            "pid": pid,
+            "path": path,
+            "duration": format!("{:?}", preset),
+            "inbound_rule_name": inbound_rule_name,
+            "outbound_rule_name": outbound_rule_name,
+        }),
+    );
+    Ok(message)
 }
 
 pub fn unblock_process(pid: u32, path: &str) -> Result<String, String> {
@@ -295,16 +332,18 @@ pub fn unblock_process(pid: u32, path: &str) -> Result<String, String> {
             "Could not remove the firewall rules for PID {pid} ({path}); they were kept in state so Vigil can retry."
         ));
     }
-    if removed > 0 {
+    let message = if removed > 0 {
         save_state(&state)?;
-        Ok(format!(
-            "Removed {removed} process block(s) for PID {pid} ({path})."
-        ))
+        format!("Removed {removed} process block(s) for PID {pid} ({path}).")
     } else {
-        Ok(format!(
-            "No active process block found for PID {pid} ({path})."
-        ))
-    }
+        format!("No active process block found for PID {pid} ({path}).")
+    };
+    audit::record(
+        "unblock_process",
+        if removed > 0 { "success" } else { "noop" },
+        json!({ "pid": pid, "path": path, "removed_rules": removed }),
+    );
+    Ok(message)
 }
 
 pub fn isolate_machine() -> Result<String, String> {
@@ -318,6 +357,11 @@ pub fn isolate_machine() -> Result<String, String> {
     state.isolated = true;
     save_state(&state)?;
 
+    audit::record(
+        "isolate_machine",
+        "success",
+        json!({ "inbound_rule_name": ISOLATE_RULE_IN, "outbound_rule_name": ISOLATE_RULE_OUT }),
+    );
     Ok("Network isolation enabled.".into())
 }
 
@@ -335,6 +379,7 @@ pub fn restore_machine() -> Result<String, String> {
     state.isolated = false;
     save_state(&state)?;
 
+    audit::record("restore_machine", "success", json!({}));
     Ok("Network isolation removed.".into())
 }
 
@@ -396,11 +441,7 @@ pub fn process_block_remaining(_pid: u32, path: &str) -> Option<Duration> {
 }
 
 pub fn extract_remote_target(remote_addr: &str) -> Option<String> {
-    let (host, port) = remote_addr.rsplit_once(':')?;
-    if host.is_empty() || !port.chars().all(|c| c.is_ascii_digit()) {
-        return None;
-    }
-    Some(host.to_string())
+    socket_addr_from_text(remote_addr).map(|addr| addr.ip().to_string())
 }
 
 fn ensure_modifiable() -> Result<(), String> {
@@ -427,19 +468,19 @@ fn socket_kill_target(conn: &ConnInfo) -> Result<SocketKillTarget, SocketKillErr
         return Err(SocketKillError::UnsupportedStatus(conn.status.clone()));
     }
 
-    let local = conn
-        .local_addr
-        .parse::<SocketAddr>()
+    let local = socket_addr_from_text(&conn.local_addr)
         .map_err(|_| SocketKillError::InvalidLocalAddr(conn.local_addr.clone()))?;
-    let remote = conn
-        .remote_addr
-        .parse::<SocketAddr>()
+    let remote = socket_addr_from_text(&conn.remote_addr)
         .map_err(|_| SocketKillError::InvalidRemoteAddr(conn.remote_addr.clone()))?;
 
     match (local.ip(), remote.ip()) {
         (IpAddr::V4(_), IpAddr::V4(_)) => Ok(SocketKillTarget { local, remote }),
         _ => Err(SocketKillError::UnsupportedAddressFamily),
     }
+}
+
+fn socket_addr_from_text(text: &str) -> Result<SocketAddr, std::net::AddrParseError> {
+    text.trim().parse::<SocketAddr>()
 }
 
 fn normalise_target(target: &str) -> Result<String, String> {
@@ -735,7 +776,11 @@ mod platform {
         Err("Active response is not implemented on this platform.".into())
     }
 
-    pub fn add_block_program_rule(_rule_name: &str, _path: &str, _dir: &str) -> Result<(), String> {
+    pub fn add_block_program_rule(
+        _rule_name: &str,
+        _path: &str,
+        _dir: &str,
+    ) -> Result<(), String> {
         Err("Active response is not implemented on this platform.".into())
     }
 
@@ -865,23 +910,15 @@ mod tests {
 
     #[test]
     fn socket_kill_target_rejects_listen_rows() {
-        let err = socket_kill_target(&conn(
-            "0.0.0.0:80",
-            "0.0.0.0:0",
-            "LISTEN",
-        ))
-        .unwrap_err();
+        let err = socket_kill_target(&conn("0.0.0.0:80", "0.0.0.0:0", "LISTEN")).unwrap_err();
         assert!(matches!(err, SocketKillError::UnsupportedStatus(_)));
     }
 
     #[test]
     fn socket_kill_target_rejects_invalid_remote() {
-        let err = socket_kill_target(&conn(
-            "192.168.1.10:50000",
-            "not-an-endpoint",
-            "ESTABLISHED",
-        ))
-        .unwrap_err();
+        let err =
+            socket_kill_target(&conn("192.168.1.10:50000", "not-an-endpoint", "ESTABLISHED"))
+                .unwrap_err();
         assert!(matches!(err, SocketKillError::InvalidRemoteAddr(_)));
     }
 
@@ -894,5 +931,14 @@ mod tests {
         ))
         .unwrap_err();
         assert!(matches!(err, SocketKillError::UnsupportedAddressFamily));
+    }
+
+    #[test]
+    fn extract_remote_target_supports_ipv4_and_ipv6() {
+        assert_eq!(extract_remote_target("8.8.8.8:443").as_deref(), Some("8.8.8.8"));
+        assert_eq!(
+            extract_remote_target("[2606:4700:4700::1111]:443").as_deref(),
+            Some("2606:4700:4700::1111")
+        );
     }
 }

--- a/src/active_response.rs
+++ b/src/active_response.rs
@@ -441,7 +441,26 @@ pub fn process_block_remaining(_pid: u32, path: &str) -> Option<Duration> {
 }
 
 pub fn extract_remote_target(remote_addr: &str) -> Option<String> {
-    socket_addr_from_text(remote_addr).map(|addr| addr.ip().to_string())
+    if let Ok(addr) = socket_addr_from_text(remote_addr) {
+        return Some(addr.ip().to_string());
+    }
+
+    let trimmed = remote_addr.trim();
+    let (host, port) = trimmed.rsplit_once(':')?;
+    if host.is_empty() || !port.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+
+    let host = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+
+    if host.parse::<IpAddr>().is_ok() {
+        Some(host.to_string())
+    } else {
+        None
+    }
 }
 
 fn ensure_modifiable() -> Result<(), String> {
@@ -938,6 +957,10 @@ mod tests {
         assert_eq!(extract_remote_target("8.8.8.8:443").as_deref(), Some("8.8.8.8"));
         assert_eq!(
             extract_remote_target("[2606:4700:4700::1111]:443").as_deref(),
+            Some("2606:4700:4700::1111")
+        );
+        assert_eq!(
+            extract_remote_target("2606:4700:4700::1111:443").as_deref(),
             Some("2606:4700:4700::1111")
         );
     }

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1,0 +1,59 @@
+//! Lightweight audit log for active and automatic response actions.
+//!
+//! Records are appended as JSON Lines to `<exe_dir>/logs/vigil-audit.jsonl` so
+//! operators can review what Vigil actually did (or would have done in dry run)
+//! without scraping the general tracing log.
+
+use serde::Serialize;
+use serde_json::Value;
+use std::fs::{create_dir_all, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+
+#[derive(Debug, Serialize)]
+struct AuditRecord<'a> {
+    timestamp: String,
+    action: &'a str,
+    outcome: &'a str,
+    details: Value,
+}
+
+pub fn record(action: &str, outcome: &str, details: Value) {
+    let record = AuditRecord {
+        timestamp: chrono::Local::now().to_rfc3339(),
+        action,
+        outcome,
+        details,
+    };
+
+    let Ok(line) = serde_json::to_string(&record) else {
+        tracing::warn!(action, outcome, "failed to serialise audit record");
+        return;
+    };
+
+    let path = audit_path();
+    if let Some(parent) = path.parent() {
+        if let Err(err) = create_dir_all(parent) {
+            tracing::warn!(%err, path = %path.display(), "failed to create audit log directory");
+            return;
+        }
+    }
+
+    match OpenOptions::new().create(true).append(true).open(&path) {
+        Ok(mut file) => {
+            if let Err(err) = writeln!(file, "{line}") {
+                tracing::warn!(%err, path = %path.display(), "failed to append audit record");
+            }
+        }
+        Err(err) => {
+            tracing::warn!(%err, path = %path.display(), "failed to open audit log");
+        }
+    }
+}
+
+fn audit_path() -> PathBuf {
+    crate::config::config_path()
+        .parent()
+        .map(|dir| dir.join("logs").join("vigil-audit.jsonl"))
+        .unwrap_or_else(|| PathBuf::from("logs").join("vigil-audit.jsonl"))
+}

--- a/src/auto_response.rs
+++ b/src/auto_response.rs
@@ -8,10 +8,11 @@
 //! - actions are cooldown-limited per target to avoid thrashing
 
 use crate::{
-    active_response,
+    active_response, audit,
     config::{normalise_name, Config},
     types::ConnInfo,
 };
+use serde_json::json;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
@@ -37,7 +38,7 @@ pub enum PlannedAction {
 pub fn maybe_apply(conn: &ConnInfo, cfg: &Config, state: &mut EngineState) -> Option<String> {
     let action = plan(conn, cfg)?;
     let cooldown = Duration::from_secs(cfg.auto_response_cooldown_secs.max(1));
-    if !state.try_acquire(cooldown_key(&action), cooldown) {
+    if !state.try_acquire(cooldown_key(&action, conn), cooldown) {
         return None;
     }
 
@@ -51,6 +52,18 @@ pub fn maybe_apply(conn: &ConnInfo, cfg: &Config, state: &mut EngineState) -> Op
             remote_addr = %conn.remote_addr,
             action = %summary,
             "auto-response dry run"
+        );
+        audit::record(
+            "auto_response",
+            "dry_run",
+            json!({
+                "summary": summary,
+                "pid": conn.pid,
+                "proc_name": conn.proc_name,
+                "local_addr": conn.local_addr,
+                "remote_addr": conn.remote_addr,
+                "score": conn.score,
+            }),
         );
         return Some(format!("Auto-response dry run: {summary}."));
     }
@@ -68,6 +81,19 @@ pub fn maybe_apply(conn: &ConnInfo, cfg: &Config, state: &mut EngineState) -> Op
                 result = %message,
                 "auto-response executed"
             );
+            audit::record(
+                "auto_response",
+                "success",
+                json!({
+                    "summary": summary,
+                    "message": message,
+                    "pid": conn.pid,
+                    "proc_name": conn.proc_name,
+                    "local_addr": conn.local_addr,
+                    "remote_addr": conn.remote_addr,
+                    "score": conn.score,
+                }),
+            );
             Some(format!("Auto-response: {message}"))
         }
         Err(err) => {
@@ -80,6 +106,19 @@ pub fn maybe_apply(conn: &ConnInfo, cfg: &Config, state: &mut EngineState) -> Op
                 action = %summary,
                 error = %err,
                 "auto-response failed"
+            );
+            audit::record(
+                "auto_response",
+                "failure",
+                json!({
+                    "summary": summary,
+                    "error": err,
+                    "pid": conn.pid,
+                    "proc_name": conn.proc_name,
+                    "local_addr": conn.local_addr,
+                    "remote_addr": conn.remote_addr,
+                    "score": conn.score,
+                }),
             );
             Some(format!("Auto-response failed: {summary} ({err})"))
         }
@@ -139,13 +178,13 @@ fn execute(action: &PlannedAction, conn: &ConnInfo) -> Result<String, String> {
 fn describe_action(action: &PlannedAction, conn: &ConnInfo) -> String {
     match action {
         PlannedAction::KillConnection => {
-            format!("would kill connection {} -> {}", conn.local_addr, conn.remote_addr)
+            format!("kill connection {} -> {}", conn.local_addr, conn.remote_addr)
         }
         PlannedAction::BlockRemote { target, .. } => {
-            format!("would block remote {target} for 1 hour")
+            format!("block remote {target} for 1 hour")
         }
         PlannedAction::BlockProcess { path, .. } => {
-            format!("would block process traffic for {path} for 1 hour")
+            format!("block process traffic for {path} for 1 hour")
         }
     }
 }
@@ -202,9 +241,11 @@ fn signal_strength(conn: &ConnInfo) -> u8 {
     }
 }
 
-fn cooldown_key(action: &PlannedAction) -> String {
+fn cooldown_key(action: &PlannedAction, conn: &ConnInfo) -> String {
     match action {
-        PlannedAction::KillConnection => "kill-connection".to_string(),
+        PlannedAction::KillConnection => {
+            format!("kill-connection:{}:{}", conn.local_addr, conn.remote_addr)
+        }
         PlannedAction::BlockRemote { target, .. } => format!("block-remote:{target}"),
         PlannedAction::BlockProcess { path, .. } => format!("block-process:{path}"),
     }
@@ -309,5 +350,15 @@ mod tests {
         let mut state = EngineState::default();
         assert!(state.try_acquire("k".into(), Duration::from_secs(60)));
         assert!(!state.try_acquire("k".into(), Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn kill_connection_cooldown_is_per_socket() {
+        let conn_a = sample_conn();
+        let mut conn_b = sample_conn();
+        conn_b.remote_addr = "1.1.1.1:443".into();
+        let mut state = EngineState::default();
+        assert!(state.try_acquire(cooldown_key(&PlannedAction::KillConnection, &conn_a), Duration::from_secs(60)));
+        assert!(state.try_acquire(cooldown_key(&PlannedAction::KillConnection, &conn_b), Duration::from_secs(60)));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@
 )]
 
 mod active_response;
+mod audit;
 mod auto_response;
 mod autostart;
 mod beacon;

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -18,6 +18,7 @@ pub fn show(ui: &mut egui::Ui) {
                     field_row(ui, "Trust", "Add the process to the trusted list. Disabled when Vigil does not know the executable location.");
                     field_row(ui, "Open loc", "Open the executable's folder in the system file manager. Disabled when no location is known.");
                     field_row(ui, "Kill", "Terminate the process after confirmation. Unresolved PID placeholder rows are not killable.");
+                    field_row(ui, "Kill connection", "Immediately terminate the selected live TCP socket. On Windows this is currently available for IPv4 TCP connections when Vigil is elevated.");
                 });
 
                 ui.columns(2, |cols| {
@@ -49,19 +50,39 @@ pub fn show(ui: &mut egui::Ui) {
                                 "Vigil also watches for persistence-style behaviour: autorun keys, pre-login connections, file drops in watched directories, and long-lived connections that stay open past the configured threshold.",
                             );
                         });
+
+                        card(ui, "Audit trail", |ui| {
+                            body(
+                                ui,
+                                "Manual and automatic response actions append JSON Lines to logs/vigil-audit.jsonl next to the normal daily logs. Each record includes a timestamp, action, outcome, and structured details such as PID, process name, and endpoints.",
+                            );
+                        });
                     });
 
                     cols[1].vertical(|ui| {
                         card(ui, "Active response", |ui| {
                             body(
                                 ui,
-                                "Phase 11 starts with reversible intervention: block a remote IP for 1 hour, 24 hours, or permanently, block a process by executable path, or isolate the machine with firewall rules. Active blocks show a countdown and a quick unblock action. All actions require administrator privileges on Windows and always ask for confirmation.",
+                                "Vigil supports reversible intervention: kill a live connection, block a remote IP for 1 hour, 24 hours, or permanently, block a process by executable path, or isolate the machine with firewall rules. Active blocks show a countdown and a quick unblock action. All actions require administrator privileges on Windows and ask for confirmation.",
                             );
                             ui.add_space(6.0);
-                            bullet(ui, "Block remote", "Choose a 1h, 24h, or permanent block for the selected connection's remote IP through the Windows firewall.");
+                            bullet(ui, "Kill connection", "Terminate the selected live TCP socket immediately. Current Windows implementation uses the IPv4 TCP delete-TCB path.");
+                            bullet(ui, "Block remote", "Choose a 1h, 24h, or permanent block for the selected connection's remote IP through the Windows firewall. IPv4 and IPv6 remote addresses are supported.");
                             bullet(ui, "Block process", "Choose a 1h, 24h, or permanent block for all traffic from the selected executable path.");
                             bullet(ui, "Isolate network", "Add reversible firewall rules that block inbound and outbound traffic.");
                             bullet(ui, "Restore network", "Remove the isolation rules and return to normal traffic flow.");
+                        });
+
+                        card(ui, "Auto response", |ui| {
+                            body(
+                                ui,
+                                "Automatic response is optional and disabled by default. Dry run is enabled by default, trusted processes suppress automation, and the engine requires strong corroborating signals in addition to the score threshold.",
+                            );
+                            ui.add_space(6.0);
+                            bullet(ui, "Dry run", "Surface the planned action in the UI and audit log without executing containment.");
+                            bullet(ui, "Cooldown", "Suppress repeated automatic actions against the same target for the configured window.");
+                            bullet(ui, "Trusted processes", "Processes in the trusted list never receive automatic containment.");
+                            bullet(ui, "Escalation", "Enable connection kill first, then remote or process blocking only if you accept the higher blast radius.");
                         });
 
                         card(ui, "Telemetry and reputation", |ui| {
@@ -111,7 +132,7 @@ pub fn show(ui: &mut egui::Ui) {
                             bullet(
                                 ui,
                                 "Settings",
-                                "Trusted-process edits auto-save, and the shipped defaults can be restored from the settings panel.",
+                                "Trusted-process edits and auto-response settings auto-save, and the shipped defaults can be restored from the settings panel.",
                             );
                             bullet(
                                 ui,
@@ -151,17 +172,36 @@ pub fn show(ui: &mut egui::Ui) {
                     field_row(ui, "Trust", "Add the process to the trusted list. Disabled when Vigil does not know the executable location.");
                     field_row(ui, "Open loc", "Open the executable's folder in the system file manager. Disabled when no location is known.");
                     field_row(ui, "Kill", "Terminate the process after confirmation. Unresolved PID placeholder rows are not killable.");
+                    field_row(ui, "Kill connection", "Immediately terminate the selected live TCP socket. On Windows this is currently available for IPv4 TCP connections when Vigil is elevated.");
                 });
                 card(ui, "Active response", |ui| {
                     body(
                         ui,
-                        "Phase 11 starts with reversible intervention: block a remote IP for 1 hour, 24 hours, or permanently, block a process by executable path, or isolate the machine with firewall rules. Active blocks show a countdown and a quick unblock action. All actions require administrator privileges on Windows and always ask for confirmation.",
+                        "Vigil supports reversible intervention: kill a live connection, block a remote IP for 1 hour, 24 hours, or permanently, block a process by executable path, or isolate the machine with firewall rules. Active blocks show a countdown and a quick unblock action. All actions require administrator privileges on Windows and ask for confirmation.",
                     );
                     ui.add_space(6.0);
-                    bullet(ui, "Block remote", "Choose a 1h, 24h, or permanent block for the selected connection's remote IP through the Windows firewall.");
+                    bullet(ui, "Kill connection", "Terminate the selected live TCP socket immediately. Current Windows implementation uses the IPv4 TCP delete-TCB path.");
+                    bullet(ui, "Block remote", "Choose a 1h, 24h, or permanent block for the selected connection's remote IP through the Windows firewall. IPv4 and IPv6 remote addresses are supported.");
                     bullet(ui, "Block process", "Choose a 1h, 24h, or permanent block for all traffic from the selected executable path.");
                     bullet(ui, "Isolate network", "Add reversible firewall rules that block inbound and outbound traffic.");
                     bullet(ui, "Restore network", "Remove the isolation rules and return to normal traffic flow.");
+                });
+                card(ui, "Auto response", |ui| {
+                    body(
+                        ui,
+                        "Automatic response is optional and disabled by default. Dry run is enabled by default, trusted processes suppress automation, and the engine requires strong corroborating signals in addition to the score threshold.",
+                    );
+                    ui.add_space(6.0);
+                    bullet(ui, "Dry run", "Surface the planned action in the UI and audit log without executing containment.");
+                    bullet(ui, "Cooldown", "Suppress repeated automatic actions against the same target for the configured window.");
+                    bullet(ui, "Trusted processes", "Processes in the trusted list never receive automatic containment.");
+                    bullet(ui, "Escalation", "Enable connection kill first, then remote or process blocking only if you accept the higher blast radius.");
+                });
+                card(ui, "Audit trail", |ui| {
+                    body(
+                        ui,
+                        "Manual and automatic response actions append JSON Lines to logs/vigil-audit.jsonl next to the normal daily logs.",
+                    );
                 });
                 card(ui, "Persistence signals", |ui| {
                     body(
@@ -215,7 +255,7 @@ pub fn show(ui: &mut egui::Ui) {
                     bullet(
                         ui,
                         "Settings",
-                        "Trusted-process edits auto-save, and the shipped defaults can be restored from the settings panel.",
+                        "Trusted-process edits and auto-response settings auto-save, and the shipped defaults can be restored from the settings panel.",
                     );
                     bullet(
                         ui,
@@ -260,11 +300,12 @@ fn hero(ui: &mut egui::Ui) {
                 chip(ui, "Real-time monitoring");
                 chip(ui, "Offline enrichment");
                 chip(ui, "High-signal triage");
+                chip(ui, "Audit trail");
             });
             ui.add_space(10.0);
             ui.label(
                 RichText::new(
-                    "A quick operational guide: what Vigil watches, how the score is built, and where the important controls live.",
+                    "A quick operational guide: what Vigil watches, how the score is built, where the important controls live, and what gets recorded when you respond.",
                 )
                 .color(theme::TEXT2)
                 .size(12.0),


### PR DESCRIPTION
## Summary
- document kill connection, auto-response safety, audit logging, and current IPv6 behavior in the Help tab
- add a dedicated JSONL audit log for manual and automatic response actions
- make remote target extraction IPv6-safe for firewall actions and improve auto-response cooldown scoping per socket

## Notes
- stale PR cleanup was already effectively done before this branch: PR #4 is merged and closed, and the remaining stale branches are already fully contained in `master`
- I cannot delete Git branches through this connector, so branch cleanup itself remains a manual GitHub UI step
- live socket kill remains IPv4-only on Windows because Microsoft documents `SetTcpEntry` against `MIB_TCPROW` (IPv4), while the public Learn docs expose separate IPv6 TCP table structs but not an equivalent delete-TCB setter

## What to test
- Help tab mentions kill connection, audit log location, auto-response defaults, and IPv6 behavior
- manual block remote works for IPv4 and IPv6 remote endpoints
- audit records append to `logs/vigil-audit.jsonl` for manual response actions
- auto-response dry-run and execution events append audit records with structured details
- per-socket auto-response cooldown no longer suppresses unrelated connection kills
