### PR TITLE
Add bundled all-platforms asset to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ name: Release
 #   Windows  →  Vigil-Setup-<ver>-x86_64.exe   (Inno Setup wizard)
 #   macOS    →  Vigil-<ver>-aarch64.dmg         (drag-to-Applications DMG)
 #   Linux    →  Vigil-<ver>-x86_64.AppImage     (portable, double-click to run)
+#   Bundle   →  Vigil-<ver>-all-supported-os.zip (all three installers together)
 on:
   push:
     tags: ["v*"]
@@ -201,6 +202,19 @@ jobs:
           pattern: installer-*
           path: dist/
           merge-multiple: true
+
+      - name: Build all-platforms bundle
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          mkdir -p dist/bundle
+          cp dist/*.exe dist/bundle/ 2>/dev/null || true
+          cp dist/*.dmg dist/bundle/ 2>/dev/null || true
+          cp dist/*.AppImage dist/bundle/ 2>/dev/null || true
+          (
+            cd dist/bundle
+            zip -r "../Vigil-${VERSION}-all-supported-os.zip" .
+          )
 
       - name: List release assets
         run: ls -lh dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,14 +214,9 @@ jobs:
         run: |
           VERSION="${{ github.ref_name }}"
           VERSION="${VERSION#v}"
-          mkdir -p dist/bundle
-          cp dist/*.exe dist/bundle/ 2>/dev/null || true
-          cp dist/*.dmg dist/bundle/ 2>/dev/null || true
-          cp dist/*.AppImage dist/bundle/ 2>/dev/null || true
-          (
-            cd dist/bundle
-            zip -r "../Vigil-${VERSION}-all-supported-os.zip" .
-          )
+
+          zip -j "dist/Vigil-${VERSION}-all-supported-os.zip" \
+            dist/*.exe dist/*.dmg dist/*.AppImage
 
           cp dist/Vigil-Setup-${VERSION}-x86_64.exe dist/Vigil-latest-windows-x86_64.exe
           cp dist/Vigil-${VERSION}-aarch64.dmg dist/Vigil-latest-macos-aarch64.dmg
@@ -237,4 +232,4 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: Vigil ${{ github.ref_name }}
           generate_release_notes: true
-          files: dist/**
+          files: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,13 @@ name: Release
 #   macOS    →  Vigil-<ver>-aarch64.dmg         (drag-to-Applications DMG)
 #   Linux    →  Vigil-<ver>-x86_64.AppImage     (portable, double-click to run)
 #   Bundle   →  Vigil-<ver>-all-supported-os.zip (all three installers together)
+#
+# Stable aliases are also published so the README can point directly to the
+# latest assets without knowing the version string:
+#   Vigil-latest-windows-x86_64.exe
+#   Vigil-latest-macos-aarch64.dmg
+#   Vigil-latest-linux-x86_64.AppImage
+#   Vigil-latest-all-supported-os.zip
 on:
   push:
     tags: ["v*"]
@@ -203,7 +210,7 @@ jobs:
           path: dist/
           merge-multiple: true
 
-      - name: Build all-platforms bundle
+      - name: Build all-platforms bundle and stable aliases
         run: |
           VERSION="${{ github.ref_name }}"
           VERSION="${VERSION#v}"
@@ -215,6 +222,11 @@ jobs:
             cd dist/bundle
             zip -r "../Vigil-${VERSION}-all-supported-os.zip" .
           )
+
+          cp dist/Vigil-Setup-${VERSION}-x86_64.exe dist/Vigil-latest-windows-x86_64.exe
+          cp dist/Vigil-${VERSION}-aarch64.dmg dist/Vigil-latest-macos-aarch64.dmg
+          cp dist/Vigil-${VERSION}-x86_64.AppImage dist/Vigil-latest-linux-x86_64.AppImage
+          cp dist/Vigil-${VERSION}-all-supported-os.zip dist/Vigil-latest-all-supported-os.zip
 
       - name: List release assets
         run: ls -lh dist/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Real-time network threat monitor for Windows, macOS, and Linux.
 
+## Download the latest build
+
+- [Windows installer](https://github.com/YMRYMR/vigil/releases/latest/download/Vigil-latest-windows-x86_64.exe)
+- [macOS DMG](https://github.com/YMRYMR/vigil/releases/latest/download/Vigil-latest-macos-aarch64.dmg)
+- [Linux AppImage](https://github.com/YMRYMR/vigil/releases/latest/download/Vigil-latest-linux-x86_64.AppImage)
+- [All supported OSs bundle](https://github.com/YMRYMR/vigil/releases/latest/download/Vigil-latest-all-supported-os.zip)
+
 Vigil watches every TCP/UDP connection on your machine, scores each one for
 suspicious behaviour, and alerts you — via a system tray icon, desktop
 notification, and a full GUI — the moment something looks wrong.


### PR DESCRIPTION
Adds a fourth release asset to the existing tag-based workflow: `Vigil-<version>-all-supported-os.zip`, built from the Windows, macOS, and Linux installers already produced by the workflow.