### PR TITLE
[codex] harden config and service paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,9 @@ editable in-app via the **Settings** tab:
 Vigil ships with a curated list of common trusted processes (browsers,
 Windows system services, antivirus, communication apps, etc.) so you get
 useful alerts out of the box without tuning. On first run that list is
-written into `vigil.json` as the starting config, and any later edits you
-make in-app persist immediately. You can add or remove entries in the
+written into `vigil.json` in the per-user Vigil data directory as the
+starting config, and any later edits you make in-app persist immediately.
+You can add or remove entries in the
 **Settings → Trusted Processes** grid, or click **Trust** in the Inspector
 panel while a real process with a known executable location is selected.
 The Settings tab also includes a `Reset shipped defaults` button if you want

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Screenshot captured from the current Vigil UI by Codex.
   remote IP for 1 hour, 24 hours, or permanently, blocking a process by
   executable path, or isolating the machine, with confirmation prompts,
   live countdowns for temporary blocks, and one-click unblock buttons
-- **Rolling daily log** at `<install-dir>/logs/vigil.YYYY-MM-DD`
+- **Rolling daily log** at the per-user Vigil data directory under `logs/vigil.YYYY-MM-DD`
 - **Autostart at login** enabled on first run (configurable in Settings);
   if Vigil is launched elevated on Windows, future autostart uses a
   highest-privilege scheduled task so it keeps admin visibility
@@ -141,7 +141,7 @@ custom icon in the taskbar.
 
 ## Configuration
 
-Settings are stored in `vigil.json` next to the executable and are fully
+Settings are stored in `vigil.json` in the per-user Vigil data directory and are fully
 editable in-app via the **Settings** tab:
 
 | Setting | Default | Description |
@@ -206,6 +206,7 @@ Each line follows the format:
 ```
 
 Open the log folder via the tray icon context menu → **Open Logs Folder**.
+The folder is inside the per-user Vigil data directory.
 
 ---
 
@@ -252,7 +253,7 @@ All of it is off by default; point the config at your data to enable it.
 
 Download the free MaxMind GeoLite2-City and GeoLite2-ASN `.mmdb` files
 from https://www.maxmind.com/en/geolite2/signup and drop them anywhere
-on disk. Then edit `vigil.json` next to the binary:
+on disk. Then edit the `vigil.json` file in the per-user Vigil data directory:
 
 ```json
 {

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -445,8 +445,14 @@ Make Vigil useful beyond a single endpoint.
 
 Vigil must resist tampering to be trustworthy.
 
+- [ ] **Protected policy store** — split UI preferences from security policy; keep
+      trusted-processes, allowlists, blocklists, thresholds, and response defaults
+      in an admin-owned location that normal user-mode malware cannot edit
+- [ ] **Policy integrity verification** — sign the security policy and reject
+      tampered or unsigned policy files on load; surface a visible tamper warning
+- [ ] **Privilege-gated policy edits** — changes that weaken protection require
+      elevation and are only committed by the privileged service / admin context
 - [ ] **Self-protection** — prevent non-admin processes from killing Vigil (Windows: PPL / protected process light; Linux: `PR_SET_DUMPABLE=0` + seccomp)
-- [ ] **Config signing** — require signed config changes; reject tampered `config.json`
 - [ ] **Tamper-evident audit log** — hash-chained append-only log of every alert and user action; detect truncation
 - [ ] **Secure update channel** — signed release bundles (minisign / cosign); auto-verify before replacing binary
 - [ ] **Sandboxed providers** — move file-watcher and DLL-enumeration helpers into separate low-privilege worker processes; IPC over a pipe
@@ -471,4 +477,4 @@ Vigil must resist tampering to be trustworthy.
 | 3.0.0 | 11  | Active response: per-process block, machine isolation, rule engine | 🔲 Backlog |
 | 3.x   | 12  | Detection depth: behavioural baselines, script inspection, JA3 | 🔲 Backlog |
 | 4.x   | 13  | Integration & fleet: SIEM, webhooks, central server | 🔲 Backlog |
-| 4.x   | 14  | Hardening & self-defence | 🔲 Backlog |
+| 4.x   | 14  | Hardening & self-defence, protected policy store, signed policy | 🔲 Backlog |

--- a/src/active_response.rs
+++ b/src/active_response.rs
@@ -390,10 +390,7 @@ fn stable_hash(text: &str) -> u64 {
 }
 
 fn state_path() -> PathBuf {
-    crate::config::config_path()
-        .parent()
-        .map(|dir| dir.join(STATE_FILE))
-        .unwrap_or_else(|| PathBuf::from(STATE_FILE))
+    crate::config::data_dir().join(STATE_FILE)
 }
 
 fn load_state() -> Result<State, String> {
@@ -408,6 +405,10 @@ fn load_state() -> Result<State, String> {
 
 fn save_state(state: &State) -> Result<(), String> {
     let path = state_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
+    }
     let json = serde_json::to_string_pretty(state)
         .map_err(|e| format!("failed to serialise active-response state: {e}"))?;
     std::fs::write(&path, json).map_err(|e| format!("failed to write {}: {e}", path.display()))

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@
 //! After that, the file is treated as authoritative so user edits persist
 //! exactly as saved.
 //!
-//! The config file lives next to the binary:  `<exe_dir>/vigil.json`
+//! The config file lives in the per-user app-data directory.
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -250,12 +250,50 @@ impl Default for Config {
 
 // ── Persistence ───────────────────────────────────────────────────────────────
 
-/// Returns the path to `vigil.json` next to the running binary.
-pub fn config_path() -> PathBuf {
+/// Returns the per-user application data directory for Vigil.
+///
+/// This is writable in the installed-app case and avoids keeping config or
+/// runtime state next to the executable.
+pub fn data_dir() -> PathBuf {
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(dir) = std::env::var_os("LOCALAPPDATA") {
+            return PathBuf::from(dir).join("Vigil");
+        }
+        if let Some(dir) = std::env::var_os("APPDATA") {
+            return PathBuf::from(dir).join("Vigil");
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home)
+                .join("Library")
+                .join("Application Support")
+                .join("Vigil");
+        }
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+            return PathBuf::from(xdg).join("vigil");
+        }
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home).join(".config").join("vigil");
+        }
+    }
+
     std::env::current_exe()
         .ok()
-        .and_then(|p| p.parent().map(|d| d.join("vigil.json")))
-        .unwrap_or_else(|| PathBuf::from("vigil.json"))
+        .and_then(|p| p.parent().map(|d| d.join("vigil-data")))
+        .unwrap_or_else(|| PathBuf::from("vigil-data"))
+}
+
+/// Returns the path to `vigil.json` in the per-user data directory.
+pub fn config_path() -> PathBuf {
+    data_dir().join("vigil.json")
 }
 
 impl Config {
@@ -275,6 +313,12 @@ impl Config {
     /// Save to disk. Logs a warning on failure but never panics.
     pub fn save(&self) {
         let path = config_path();
+        if let Some(parent) = path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                tracing::warn!("failed to create config directory: {e}");
+                return;
+            }
+        }
         match serde_json::to_string_pretty(self) {
             Ok(json) => {
                 if let Err(e) = std::fs::write(&path, json) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -372,10 +372,12 @@ mod tests {
 
     #[test]
     fn load_uses_stored_values_exactly() {
-        let mut stored = Config::default();
-        stored.alert_threshold = 7;
-        stored.poll_interval_secs = 10;
-        stored.trusted_processes = vec!["b".into(), "c".into()];
+        let stored = Config {
+            alert_threshold: 7,
+            poll_interval_secs: 10,
+            trusted_processes: vec!["b".into(), "c".into()],
+            ..Config::default()
+        };
 
         let json = serde_json::to_string(&stored).unwrap();
         let loaded: Config = serde_json::from_str(&json).unwrap();

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,7 +1,7 @@
 //! Logging initialisation.
 //!
 //! Sets up a `tracing-subscriber` with a rolling daily file appender.
-//! Log files land in `<exe_dir>/logs/vigil.YYYY-MM-DD`.
+//! Log files land in the per-user data directory under `logs/`.
 //!
 //! Returns the log directory path (for the "Open Logs Folder" tray item)
 //! and a `WorkerGuard` that must be kept alive for the lifetime of the
@@ -33,7 +33,8 @@ pub struct LogGuard {
 ///
 /// Returns `(log_dir, guard)`.  Keep `guard` alive until the process exits.
 pub fn init() -> (PathBuf, LogGuard) {
-    let log_dir = exe_dir().join("logs");
+    let log_dir = crate::config::data_dir().join("logs");
+    let _ = std::fs::create_dir_all(&log_dir);
 
     let appender = tracing_appender::rolling::daily(&log_dir, "vigil");
     let (writer, guard) = tracing_appender::non_blocking(appender);
@@ -50,11 +51,3 @@ pub fn init() -> (PathBuf, LogGuard) {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-fn exe_dir() -> PathBuf {
-    std::env::current_exe()
-        .unwrap_or_default()
-        .parent()
-        .unwrap_or(std::path::Path::new("."))
-        .to_path_buf()
-}

--- a/src/service.rs
+++ b/src/service.rs
@@ -109,6 +109,7 @@ mod platform {
                 .into());
         }
 
+        let exe = xml_escape(&exe.display().to_string());
         let plist = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -123,7 +124,7 @@ mod platform {
 </dict>
 </plist>
 "#,
-            exe = exe.display(),
+            exe = exe,
         );
         let path = plist_path();
         std::fs::write(&path, plist.as_bytes())
@@ -174,6 +175,14 @@ mod platform {
         }
         unsafe { getuid() == 0 }
     }
+
+    fn xml_escape(text: &str) -> String {
+        text.replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
+            .replace('\"', "&quot;")
+            .replace('\'', "&apos;")
+    }
 }
 
 // ── Linux ─────────────────────────────────────────────────────────────────────
@@ -198,6 +207,7 @@ mod platform {
                 .into());
         }
 
+        let exe = systemd_quote(&exe.display().to_string());
         let unit = format!(
             "[Unit]\n\
              Description=Vigil network monitor\n\
@@ -213,7 +223,7 @@ mod platform {
              \n\
              [Install]\n\
              WantedBy=multi-user.target\n",
-            exe = exe.display(),
+            exe = exe,
         );
         let path = unit_path();
         std::fs::write(&path, unit.as_bytes())
@@ -259,6 +269,10 @@ mod platform {
             fn getuid() -> u32;
         }
         unsafe { getuid() == 0 }
+    }
+
+    fn systemd_quote(text: &str) -> String {
+        format!("\"{}\"", text.replace('\"', "\\\""))
     }
 }
 


### PR DESCRIPTION
Harden Vigil by moving config, logs, and active-response state out of the executable directory, making those directories explicit and writable, and tightening macOS/Linux service path handling.

Credit: Codex (GPT-5.4-Mini).