### PR TITLE
Harden panic isolation recovery and UX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,6 +198,8 @@ jobs:
     name: Publish release
     needs: [build-windows, build-macos, build-linux]
     runs-on: ubuntu-latest
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     permissions:
       contents: write
       id-token: write
@@ -226,6 +228,11 @@ jobs:
           cp dist/Vigil-${VERSION}-x86_64.AppImage dist/Vigil-latest-linux-x86_64.AppImage
           cp dist/Vigil-${VERSION}-all-supported-os.zip dist/Vigil-latest-all-supported-os.zip
 
+      - name: Hash release assets
+        id: hash
+        shell: bash
+        run: echo "hashes=$(sha256sum dist/* | base64 -w0)" >> "$GITHUB_OUTPUT"
+
       - name: List release assets
         run: ls -lh dist/
 
@@ -241,3 +248,15 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-path: dist/*
+
+  slsa-provenance:
+    name: Generate SLSA provenance
+    needs: publish
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: ${{ needs.publish.outputs.hashes }}
+      upload-assets: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3515,6 +3515,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3608,6 +3614,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4281,6 +4300,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4435,6 +4460,7 @@ dependencies = [
  "png 0.17.16",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sysinfo",
  "tokio",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Real-time network threat monitor for Windows, macOS, and Linux.
 
+<p><strong><font color="red">WARNING! The current version of Vigil works only as a monitor; all active features, like the panic button, are under heavy development.</font></strong></p>
+
 ## Download the latest build
 
 - [Windows installer](https://github.com/YMRYMR/vigil/releases/latest/download/Vigil-latest-windows-x86_64.exe)
@@ -193,20 +195,27 @@ The top bar also reflects privilege state: it shows an `Admin` badge when
 Vigil is elevated, or a `Run as Admin` button that relaunches the app with
 UAC if it is not.
 
-When Vigil is running with administrator privileges on Windows, the Inspector
-can now take reversible action:
+When Vigil is running with administrator privileges, the Inspector can take
+reversible action:
 
 - **Kill connection** immediately tears down the selected live TCP socket.
 - **Suspend process** freezes the selected PID without killing it; **Resume process** continues it later.
-- **Block remote** lets you choose a 1 hour, 24 hour, or permanent outbound
+- **Block remote** (Windows) lets you choose a 1 hour, 24 hour, or permanent outbound
   firewall rule for the selected connection's remote IP. Temporary blocks show
   a live countdown and an inline unblock button.
-- **Block process** lets you choose a 1 hour, 24 hour, or permanent firewall
+- **Block process** (Windows) lets you choose a 1 hour, 24 hour, or permanent firewall
   rule for all traffic from the selected executable path. Temporary blocks
   show a live countdown and an inline unblock button.
-- **Isolate network** adds reversible firewall rules that block inbound and
-  outbound traffic for the machine.
-- All actions require confirmation and can be undone from the same UI.
+- **Isolate network** (Windows, Linux, macOS) now uses strict containment:
+  it first applies firewall-level isolation and verifies outbound reachability.
+  If outbound traffic is still possible, Vigil falls back to emergency adapter
+  cutoff and keeps snapshot state for restore.
+- **Restore network** restores the saved firewall and adapter state.
+- **Isolation failsafe**: isolation always carries an auto-restore deadline,
+  and Vigil always arms break-glass recovery while isolation is active so a
+  crash can restore networking from saved state.
+- Isolation/restore run immediately from the panic button; confirmation remains
+  for destructive process/connection actions.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ downloaded file with:
 gh attestation verify PATH/TO/FILE -R YMRYMR/vigil
 ```
 
+The release workflow also emits SLSA3 provenance for the published assets via
+the GitHub Actions SLSA generator. That provenance is attached to the release
+for users who prefer `slsa-verifier`-style supply-chain checks.
+
 Vigil watches every TCP/UDP connection on your machine, scores each one for
 suspicious behaviour, and alerts you — via a system tray icon, desktop
 notification, and a full GUI — the moment something looks wrong.

--- a/src/active_response.rs
+++ b/src/active_response.rs
@@ -8,7 +8,7 @@
 use crate::{audit, quarantine, types::ConnInfo};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, SocketAddr, TcpStream};
 use std::path::PathBuf;
 use std::process::Command;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -19,6 +19,7 @@ const PROCESS_BLOCK_RULE_PREFIX: &str = "Vigil Proc Block";
 const DOMAIN_MARKER_PREFIX: &str = "# Vigil Domain Block";
 const ISOLATE_RULE_IN: &str = "Vigil Isolate In";
 const ISOLATE_RULE_OUT: &str = "Vigil Isolate Out";
+const ISOLATION_MAX_SECS: u64 = 60 * 60;
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct Status {
@@ -41,6 +42,14 @@ struct State {
     suspended_processes: Vec<SuspendedProcess>,
     #[serde(default)]
     autorun_snapshot: Option<AutorunSnapshot>,
+    #[serde(default)]
+    firewall_snapshot: Option<FirewallSnapshot>,
+    #[serde(default)]
+    network_snapshot: Option<NetworkSnapshot>,
+    #[serde(default)]
+    isolation_started_unix: Option<u64>,
+    #[serde(default)]
+    isolation_expires_unix: Option<u64>,
     isolated: bool,
 }
 
@@ -82,6 +91,41 @@ struct AutorunEntry {
     key_path: String,
     value_name: String,
     value_data: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct FirewallProfileState {
+    name: String,
+    enabled: bool,
+    inbound_action: String,
+    outbound_action: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct FirewallSnapshot {
+    profiles: Vec<FirewallProfileState>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct NetworkAdapterState {
+    name: String,
+    #[serde(default)]
+    is_wireless: bool,
+    #[serde(default)]
+    wifi_profile: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct NetworkSnapshot {
+    adapters: Vec<NetworkAdapterState>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct TcpSessionState {
+    local_address: String,
+    local_port: u16,
+    remote_address: String,
+    remote_port: u16,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -141,13 +185,15 @@ impl DurationPreset {
 
 pub fn status() -> Status {
     let state = load_state().unwrap_or_default();
+    let isolated =
+        state.isolated || state.firewall_snapshot.is_some() || state.network_snapshot.is_some();
     Status {
         blocked_rules: state.blocked.len() + state.blocked_processes.len(),
         blocked_processes: state.blocked_processes.len(),
         blocked_domains: state.blocked_domains.len(),
         suspended_processes: state.suspended_processes.len(),
         frozen_autoruns: state.autorun_snapshot.is_some(),
-        isolated: state.isolated,
+        isolated,
     }
 }
 pub fn has_frozen_autoruns() -> bool {
@@ -155,6 +201,9 @@ pub fn has_frozen_autoruns() -> bool {
 }
 pub fn can_modify_firewall() -> bool {
     platform::is_supported() && platform::is_elevated()
+}
+pub fn can_isolate_network() -> bool {
+    platform::supports_isolation() && platform::is_elevated()
 }
 pub fn can_kill_connection(conn: &ConnInfo) -> bool {
     if !platform::is_supported() || !platform::is_elevated() {
@@ -439,13 +488,37 @@ pub fn clear_quarantine_profile(pid: u32, path: &str) -> Result<String, String> 
 }
 
 pub fn reconcile() {
-    if !platform::is_supported() || !platform::is_elevated() {
+    if !platform::is_elevated() {
+        return;
+    }
+    if !platform::is_supported() && !platform::supports_isolation() {
         return;
     }
     let Ok(mut state) = load_state() else {
         return;
     };
     let now = unix_now();
+    let isolation_active =
+        state.isolated || state.firewall_snapshot.is_some() || state.network_snapshot.is_some();
+    let isolation_expired = isolation_active
+        && state
+            .isolation_expires_unix
+            .is_some_and(|expires_at| now >= expires_at);
+    if isolation_expired {
+        if let Err(err) = restore_machine() {
+            audit::record(
+                "reconcile_isolation_timeout",
+                "error",
+                json!({
+                    "error": err,
+                    "expires_at_unix": state.isolation_expires_unix,
+                    "now_unix": now,
+                }),
+            );
+        } else if let Ok(restored_state) = load_state() {
+            state = restored_state;
+        }
+    }
     let changed = reconcile_state(&mut state, now, |rule_name| {
         platform::delete_rule(rule_name).is_ok()
     });
@@ -598,39 +671,196 @@ pub fn unblock_process(pid: u32, path: &str) -> Result<String, String> {
 }
 
 pub fn isolate_machine() -> Result<String, String> {
-    ensure_modifiable()?;
-    let _ = platform::delete_rule(ISOLATE_RULE_IN);
-    let _ = platform::delete_rule(ISOLATE_RULE_OUT);
-    platform::add_block_all_rule(ISOLATE_RULE_IN, "in")?;
-    platform::add_block_all_rule(ISOLATE_RULE_OUT, "out")?;
+    ensure_isolation_modifiable()?;
+    let firewall_snapshot = platform::snapshot_firewall_profiles().ok();
+    let now = unix_now();
+    let cfg = crate::config::Config::load();
+    let timeout_secs = (cfg.break_glass_timeout_mins.clamp(1, 240) * 60).min(ISOLATION_MAX_SECS);
     let mut state = load_state().unwrap_or_default();
+    state.firewall_snapshot = firewall_snapshot.clone();
+    state.network_snapshot = None;
+    state.isolation_started_unix = Some(now);
+    state.isolation_expires_unix = Some(now.saturating_add(timeout_secs));
     state.isolated = true;
     save_state(&state)?;
-    let cfg = crate::config::Config::load();
-    crate::break_glass::sync_watchdog(&cfg);
+    if let Err(err) = crate::break_glass::sync_watchdog(&cfg) {
+        state.firewall_snapshot = None;
+        state.network_snapshot = None;
+        state.isolation_started_unix = None;
+        state.isolation_expires_unix = None;
+        state.isolated = false;
+        let _ = save_state(&state);
+        return Err(format!(
+            "Could not arm crash-recovery watchdog; isolation aborted: {err}"
+        ));
+    }
+    let mut applied = Vec::new();
+    let mut warnings = Vec::new();
+    match platform::apply_firewall_isolation() {
+        Ok(()) => applied.push("firewall profiles hardened".to_string()),
+        Err(err) => warnings.push(format!("firewall profile update failed: {err}")),
+    }
+    match platform::add_block_all_rule(ISOLATE_RULE_IN, "in") {
+        Ok(()) => applied.push("legacy inbound firewall rule added".to_string()),
+        Err(err) => warnings.push(format!("legacy inbound rule failed: {err}")),
+    }
+    match platform::add_block_all_rule(ISOLATE_RULE_OUT, "out") {
+        Ok(()) => applied.push("legacy outbound firewall rule added".to_string()),
+        Err(err) => warnings.push(format!("legacy outbound rule failed: {err}")),
+    }
+    match platform::terminate_active_tcp_connections() {
+        Ok(0) => applied.push("no established TCP sessions were found".to_string()),
+        Ok(count) => applied.push(format!(
+            "reset {count} established TCP session{}",
+            if count == 1 { "" } else { "s" }
+        )),
+        Err(err) => warnings.push(format!("active TCP reset skipped: {err}")),
+    }
+    let mut fallback_used = false;
+    if outbound_probe_reachable() {
+        match platform::snapshot_active_adapters() {
+            Ok(snapshot) => {
+                if snapshot.adapters.is_empty() {
+                    warnings.push("no active adapters were available for emergency cutoff".into());
+                } else {
+                    state.network_snapshot = Some(snapshot.clone());
+                    save_state(&state)?;
+                    match platform::disable_active_adapters(&snapshot) {
+                        Ok(()) => {
+                            fallback_used = true;
+                            applied.push("emergency adapter cutoff applied".to_string());
+                        }
+                        Err(err) => {
+                            warnings.push(format!("emergency adapter cutoff failed: {err}"));
+                        }
+                    }
+                }
+            }
+            Err(err) => warnings.push(format!("adapter snapshot failed: {err}")),
+        }
+    }
+    if outbound_probe_reachable() {
+        if let Some(snapshot) = firewall_snapshot.as_ref() {
+            let _ = platform::restore_firewall_profiles(snapshot);
+        }
+        let recovery_state = load_state().unwrap_or_default();
+        if let Some(snapshot) = recovery_state.network_snapshot.as_ref() {
+            let _ = platform::enable_active_adapters(snapshot);
+        }
+        let _ = platform::delete_rule(ISOLATE_RULE_IN);
+        let _ = platform::delete_rule(ISOLATE_RULE_OUT);
+
+        let mut state = recovery_state;
+        state.firewall_snapshot = None;
+        state.network_snapshot = None;
+        state.isolation_started_unix = None;
+        state.isolation_expires_unix = None;
+        state.isolated = false;
+        let _ = save_state(&state);
+        let _ = crate::break_glass::sync_watchdog(&cfg);
+        let details = if warnings.is_empty() {
+            "outbound connectivity is still reachable".to_string()
+        } else {
+            warnings.join("; ")
+        };
+        return Err(format!("Could not isolate the machine: {details}"));
+    }
+    if let Err(err) = crate::break_glass::sync_watchdog(&cfg) {
+        warnings.push(format!("failsafe watchdog refresh failed: {err}"));
+    }
     audit::record(
         "isolate_machine",
         "success",
-        json!({ "inbound_rule_name": ISOLATE_RULE_IN, "outbound_rule_name": ISOLATE_RULE_OUT }),
+        json!({
+            "firewall_profiles": firewall_snapshot
+                .as_ref()
+                .map(|snapshot| snapshot.profiles.len())
+                .unwrap_or(0),
+            "applied": applied,
+            "warnings": warnings,
+        }),
     );
-    Ok("Network isolation enabled.".into())
+    if warnings.is_empty() && !fallback_used {
+        Ok(format!(
+            "Network isolation enabled (failsafe recovery armed: {} minute{} stale-heartbeat timeout).",
+            timeout_secs / 60,
+            if timeout_secs / 60 == 1 { "" } else { "s" }
+        ))
+    } else if warnings.is_empty() && fallback_used {
+        Ok(format!(
+            "Network isolation enabled via emergency adapter cutoff (failsafe recovery armed: {} minute{} stale-heartbeat timeout).",
+            timeout_secs / 60,
+            if timeout_secs / 60 == 1 { "" } else { "s" }
+        ))
+    } else if fallback_used {
+        Ok(format!(
+            "Network isolation enabled via emergency adapter cutoff with warnings: {} (failsafe recovery armed: {} minute{} stale-heartbeat timeout)",
+            warnings.join("; ")
+            , timeout_secs / 60
+            , if timeout_secs / 60 == 1 { "" } else { "s" }
+        ))
+    } else {
+        Ok(format!(
+            "Network isolation enabled with warnings: {} (failsafe recovery armed: {} minute{} stale-heartbeat timeout)",
+            warnings.join("; "),
+            timeout_secs / 60,
+            if timeout_secs / 60 == 1 { "" } else { "s" }
+        ))
+    }
 }
 pub fn restore_machine() -> Result<String, String> {
-    ensure_modifiable()?;
+    ensure_isolation_modifiable()?;
+    let mut state = load_state().unwrap_or_default();
+    let firewall_snapshot = state.firewall_snapshot.clone();
+    let network_snapshot = state.network_snapshot.clone();
+    let mut warnings = Vec::new();
+    let mut critical_failure = false;
     let in_deleted = platform::delete_rule(ISOLATE_RULE_IN).is_ok();
     let out_deleted = platform::delete_rule(ISOLATE_RULE_OUT).is_ok();
     if !(in_deleted && out_deleted) {
-        return Err(
-            "Could not remove all isolation firewall rules; the state was kept for retry.".into(),
+        warnings.push(
+            "Could not remove all legacy isolation firewall rules; will retry from saved state"
+                .into(),
         );
     }
-    let mut state = load_state().unwrap_or_default();
+    if let Some(snapshot) = firewall_snapshot.as_ref() {
+        if let Err(err) = platform::restore_firewall_profiles(snapshot) {
+            critical_failure = true;
+            warnings.push(format!("firewall profile restore failed: {err}"));
+        }
+    }
+    if let Some(snapshot) = network_snapshot.as_ref() {
+        if let Err(err) = platform::enable_active_adapters(snapshot) {
+            critical_failure = true;
+            warnings.push(format!("adapter restore failed: {err}"));
+        }
+    }
+    if critical_failure {
+        return Err(warnings.join("; "));
+    }
     state.isolated = false;
+    state.firewall_snapshot = None;
+    state.network_snapshot = None;
+    state.isolation_started_unix = None;
+    state.isolation_expires_unix = None;
     save_state(&state)?;
     let cfg = crate::config::Config::load();
-    crate::break_glass::sync_watchdog(&cfg);
-    audit::record("restore_machine", "success", json!({}));
-    Ok("Network isolation removed.".into())
+    if let Err(err) = crate::break_glass::sync_watchdog(&cfg) {
+        warnings.push(format!("break-glass watchdog cleanup failed: {err}"));
+    }
+    audit::record(
+        "restore_machine",
+        "success",
+        json!({ "warnings": warnings }),
+    );
+    if warnings.is_empty() {
+        Ok("Network isolation removed.".into())
+    } else {
+        Ok(format!(
+            "Network isolation removed with warnings: {}",
+            warnings.join("; ")
+        ))
+    }
 }
 
 pub fn is_blocked(target: &str) -> bool {
@@ -759,6 +989,25 @@ fn ensure_modifiable() -> Result<(), String> {
         return Err("Administrator privileges are required for active response.".into());
     }
     Ok(())
+}
+fn ensure_isolation_modifiable() -> Result<(), String> {
+    if !platform::supports_isolation() {
+        return Err("Network isolation is not implemented on this platform.".into());
+    }
+    if !platform::is_elevated() {
+        return Err("Administrator privileges are required for network isolation.".into());
+    }
+    Ok(())
+}
+fn outbound_probe_reachable() -> bool {
+    const PROBE_TARGETS: [&str; 3] = ["1.1.1.1:443", "8.8.8.8:53", "9.9.9.9:443"];
+    let timeout = Duration::from_millis(700);
+    PROBE_TARGETS.iter().any(|target| {
+        target
+            .parse::<SocketAddr>()
+            .ok()
+            .is_some_and(|addr| TcpStream::connect_timeout(&addr, timeout).is_ok())
+    })
 }
 fn socket_kill_target(conn: &ConnInfo) -> Result<SocketKillTarget, SocketKillError> {
     if !conn.status.eq_ignore_ascii_case("ESTABLISHED")
@@ -910,7 +1159,9 @@ fn unix_now() -> u64 {
 mod platform {
     use super::*;
     use std::collections::BTreeMap;
+    use std::ffi::OsStr;
     use std::fs;
+    use std::os::windows::process::CommandExt;
     use windows::Win32::Foundation::{
         CloseHandle, ERROR_ACCESS_DENIED, HANDLE, INVALID_HANDLE_VALUE, NO_ERROR,
     };
@@ -930,6 +1181,7 @@ mod platform {
     };
     use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE};
     use winreg::{RegKey, HKEY};
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
     pub struct AutorunRevertResult {
         pub removed_additions: usize,
         pub restored_entries: usize,
@@ -957,6 +1209,9 @@ mod platform {
         ),
     ];
     pub fn is_supported() -> bool {
+        true
+    }
+    pub fn supports_isolation() -> bool {
         true
     }
     pub fn is_elevated() -> bool {
@@ -1101,6 +1356,105 @@ mod platform {
             restored_entries,
         })
     }
+    pub fn snapshot_firewall_profiles() -> Result<FirewallSnapshot, String> {
+        let output = run_powershell_json(
+            "Get-NetFirewallProfile | Where-Object { $_.Name -in 'Domain','Private','Public' } | Select-Object Name,Enabled,DefaultInboundAction,DefaultOutboundAction | ConvertTo-Json -Depth 2 -Compress",
+        )?;
+        parse_firewall_snapshot(&output)
+    }
+    pub fn apply_firewall_isolation() -> Result<(), String> {
+        for profile in ["Domain", "Private", "Public"] {
+            run_powershell(&format!(
+                "Set-NetFirewallProfile -Profile {} -Enabled True -DefaultInboundAction Block -DefaultOutboundAction Block -ErrorAction Stop",
+                ps_quoted(profile)
+            ))?;
+        }
+        let snapshot = snapshot_firewall_profiles()?;
+        if snapshot.profiles.is_empty()
+            || snapshot.profiles.iter().any(|profile| {
+                !profile.enabled
+                    || !profile.inbound_action.eq_ignore_ascii_case("Block")
+                    || !profile.outbound_action.eq_ignore_ascii_case("Block")
+            })
+        {
+            return Err("firewall policy is not fully enabled and blocked".into());
+        }
+        Ok(())
+    }
+    pub fn restore_firewall_profiles(snapshot: &FirewallSnapshot) -> Result<(), String> {
+        for profile in &snapshot.profiles {
+            run_powershell(&format!(
+                "Set-NetFirewallProfile -Profile {} -Enabled {} -DefaultInboundAction {} -DefaultOutboundAction {}",
+                ps_quoted(&profile.name),
+                if profile.enabled { "True" } else { "False" },
+                profile.inbound_action,
+                profile.outbound_action,
+            ))?;
+        }
+        Ok(())
+    }
+    pub fn snapshot_active_adapters() -> Result<NetworkSnapshot, String> {
+        let wifi_profiles = snapshot_connected_wifi_profiles();
+        let output = run_powershell_json(
+            "$if_indexes = @(); $if_indexes += Get-NetIPConfiguration | Where-Object { $_.IPv4DefaultGateway -ne $null -or $_.IPv6DefaultGateway -ne $null } | Select-Object -ExpandProperty InterfaceIndex; $if_indexes += Get-NetRoute -DestinationPrefix '0.0.0.0/0' -State Alive -ErrorAction SilentlyContinue | Select-Object -ExpandProperty InterfaceIndex; $if_indexes += Get-NetRoute -DestinationPrefix '::/0' -State Alive -ErrorAction SilentlyContinue | Select-Object -ExpandProperty InterfaceIndex; $if_indexes = @($if_indexes | Where-Object { $_ -ne $null } | Sort-Object -Unique); if ($if_indexes.Count -eq 0) { @() | ConvertTo-Json -Compress } else { Get-NetAdapter | Where-Object { $_.Status -eq 'Up' -and $_.Name -ne 'Loopback Pseudo-Interface 1' -and $if_indexes -contains $_.ifIndex } | Select-Object Name,InterfaceDescription,NdisPhysicalMedium | ConvertTo-Json -Compress }",
+        )?;
+        let adapters = parse_adapter_snapshot(&output, &wifi_profiles)?;
+        Ok(NetworkSnapshot { adapters })
+    }
+    pub fn disable_active_adapters(snapshot: &NetworkSnapshot) -> Result<(), String> {
+        for adapter in &snapshot.adapters {
+            run_powershell(&format!(
+                "Disable-NetAdapter -Name {} -Confirm:$false -ErrorAction Stop",
+                ps_quoted(&adapter.name)
+            ))?;
+        }
+        Ok(())
+    }
+    pub fn enable_active_adapters(snapshot: &NetworkSnapshot) -> Result<(), String> {
+        for adapter in &snapshot.adapters {
+            run_powershell(&format!(
+                "Enable-NetAdapter -Name {} -Confirm:$false -ErrorAction Stop",
+                ps_quoted(&adapter.name)
+            ))?;
+            if adapter.is_wireless && adapter.wifi_profile.is_some() {
+                let _ = reconnect_wireless_adapter(&adapter.name, adapter.wifi_profile.as_deref());
+            }
+        }
+        Ok(())
+    }
+    pub fn terminate_active_tcp_connections() -> Result<usize, String> {
+        let output = run_powershell_json(
+            "Get-NetTCPConnection -State Established | Where-Object { $_.LocalAddress -notmatch ':' -and $_.RemoteAddress -notmatch ':' } | Select-Object LocalAddress,LocalPort,RemoteAddress,RemotePort | ConvertTo-Json -Compress",
+        )?;
+        let targets = parse_tcp_session_snapshot(&output)?;
+        let mut reset = 0usize;
+        for target in targets {
+            let local = SocketAddr::new(
+                target
+                    .local_address
+                    .parse()
+                    .map_err(|e| format!("invalid local address {}: {e}", target.local_address))?,
+                target.local_port,
+            );
+            let remote = SocketAddr::new(
+                target.remote_address.parse().map_err(|e| {
+                    format!("invalid remote address {}: {e}", target.remote_address)
+                })?,
+                target.remote_port,
+            );
+            if let Err(err) = kill_tcp_connection(&SocketKillTarget { local, remote }) {
+                match err {
+                    // Some Windows builds report 317 for already-closed sockets;
+                    // it is noisy but does not prevent isolation.
+                    SocketKillError::OsError(317) => continue,
+                    SocketKillError::UnsupportedAddressFamily => continue,
+                    other => return Err(other.to_string()),
+                }
+            }
+            reset += 1;
+        }
+        Ok(reset)
+    }
     pub fn suspend_process(pid: u32) -> Result<(), String> {
         let snapshot = unsafe {
             CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0)
@@ -1226,7 +1580,7 @@ mod platform {
         Ok(())
     }
     fn flush_dns() -> Result<(), String> {
-        let status = Command::new("ipconfig")
+        let status = hidden_command("ipconfig")
             .arg("/flushdns")
             .status()
             .map_err(|e| format!("failed to spawn ipconfig: {e}"))?;
@@ -1294,7 +1648,7 @@ mod platform {
         }
     }
     pub fn add_block_rule(rule_name: &str, target: &str) -> Result<(), String> {
-        let status = Command::new("netsh")
+        let status = hidden_command("netsh")
             .args([
                 "advfirewall",
                 "firewall",
@@ -1316,7 +1670,7 @@ mod platform {
         }
     }
     pub fn add_block_all_rule(rule_name: &str, dir: &str) -> Result<(), String> {
-        let status = Command::new("netsh")
+        let status = hidden_command("netsh")
             .args([
                 "advfirewall",
                 "firewall",
@@ -1338,7 +1692,7 @@ mod platform {
         }
     }
     pub fn add_block_program_rule(rule_name: &str, path: &str, dir: &str) -> Result<(), String> {
-        let status = Command::new("netsh")
+        let status = hidden_command("netsh")
             .args([
                 "advfirewall",
                 "firewall",
@@ -1360,7 +1714,7 @@ mod platform {
         }
     }
     pub fn delete_rule(rule_name: &str) -> Result<(), String> {
-        let status = Command::new("netsh")
+        let status = hidden_command("netsh")
             .args([
                 "advfirewall",
                 "firewall",
@@ -1376,10 +1730,303 @@ mod platform {
             Err(format!("failed to delete firewall rule {rule_name}"))
         }
     }
+    fn run_powershell(script: &str) -> Result<String, String> {
+        let script = format!("$ErrorActionPreference = 'Stop'; {script}");
+        let output = hidden_command("powershell")
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                &script,
+            ])
+            .output()
+            .map_err(|e| format!("failed to spawn powershell: {e}"))?;
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+        } else {
+            Err(format!(
+                "powershell failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            ))
+        }
+    }
+    fn run_powershell_json(script: &str) -> Result<String, String> {
+        run_powershell(script)
+    }
+    fn snapshot_connected_wifi_profiles() -> BTreeMap<String, String> {
+        let output = hidden_command("netsh")
+            .args(["wlan", "show", "interfaces"])
+            .output();
+        let Ok(output) = output else {
+            return BTreeMap::new();
+        };
+        if !output.status.success() {
+            return BTreeMap::new();
+        }
+        parse_wifi_profile_map(&String::from_utf8_lossy(&output.stdout))
+    }
+    fn reconnect_wireless_adapter(name: &str, profile: Option<&str>) -> Result<(), String> {
+        // Give Windows a brief moment to bring the radio interface fully up.
+        std::thread::sleep(Duration::from_millis(900));
+        if let Some(profile) = profile {
+            let status = hidden_command("netsh")
+                .args([
+                    "wlan",
+                    "connect",
+                    &format!("name={profile}"),
+                    &format!("interface={name}"),
+                ])
+                .status()
+                .map_err(|e| format!("failed to spawn netsh wlan connect: {e}"))?;
+            if status.success() {
+                return Ok(());
+            }
+        }
+        for _ in 0..4 {
+            let status = hidden_command("netsh")
+                .args(["wlan", "reconnect", &format!("interface={name}")])
+                .status()
+                .map_err(|e| format!("failed to spawn netsh wlan reconnect: {e}"))?;
+            if status.success() {
+                return Ok(());
+            }
+            std::thread::sleep(Duration::from_millis(900));
+        }
+        Err(format!("netsh wlan reconnect failed for {name}"))
+    }
+    fn hidden_command<S: AsRef<OsStr>>(program: S) -> Command {
+        let mut cmd = Command::new(program);
+        cmd.creation_flags(CREATE_NO_WINDOW);
+        cmd
+    }
+    fn ps_quoted(text: &str) -> String {
+        format!("'{}'", text.replace('\'', "''"))
+    }
+    fn parse_firewall_snapshot(text: &str) -> Result<FirewallSnapshot, String> {
+        if text.trim().is_empty() {
+            return Ok(FirewallSnapshot { profiles: vec![] });
+        }
+        let value: serde_json::Value = serde_json::from_str(text)
+            .map_err(|e| format!("failed to parse firewall profile snapshot: {e}"))?;
+        let mut profiles = Vec::new();
+        let items = match value {
+            serde_json::Value::Array(items) => items,
+            serde_json::Value::Object(map) => vec![serde_json::Value::Object(map)],
+            serde_json::Value::Null => Vec::new(),
+            other => {
+                return Err(format!(
+                    "unexpected firewall profile snapshot shape: {other}"
+                ))
+            }
+        };
+        for item in items {
+            let Some(name) = item.get("Name").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let enabled = item
+                .get("Enabled")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let inbound_action = item
+                .get("DefaultInboundAction")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Block")
+                .to_string();
+            let outbound_action = item
+                .get("DefaultOutboundAction")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Block")
+                .to_string();
+            profiles.push(FirewallProfileState {
+                name: name.to_string(),
+                enabled,
+                inbound_action,
+                outbound_action,
+            });
+        }
+        profiles.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(FirewallSnapshot { profiles })
+    }
+    fn parse_tcp_session_snapshot(text: &str) -> Result<Vec<TcpSessionState>, String> {
+        if text.trim().is_empty() {
+            return Ok(vec![]);
+        }
+        let value: serde_json::Value = serde_json::from_str(text)
+            .map_err(|e| format!("failed to parse TCP session snapshot: {e}"))?;
+        let items = match value {
+            serde_json::Value::Array(items) => items,
+            serde_json::Value::Object(map) => vec![serde_json::Value::Object(map)],
+            serde_json::Value::Null => Vec::new(),
+            other => {
+                return Err(format!("unexpected TCP session snapshot shape: {other}"));
+            }
+        };
+        let mut sessions = Vec::new();
+        for item in items {
+            let local_address = item
+                .get("LocalAddress")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let remote_address = item
+                .get("RemoteAddress")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let local_port = item
+                .get("LocalPort")
+                .and_then(|v| v.as_u64())
+                .and_then(|v| u16::try_from(v).ok())
+                .unwrap_or(0);
+            let remote_port = item
+                .get("RemotePort")
+                .and_then(|v| v.as_u64())
+                .and_then(|v| u16::try_from(v).ok())
+                .unwrap_or(0);
+            if !local_address.trim().is_empty()
+                && !remote_address.trim().is_empty()
+                && local_port != 0
+                && remote_port != 0
+            {
+                sessions.push(TcpSessionState {
+                    local_address,
+                    local_port,
+                    remote_address,
+                    remote_port,
+                });
+            }
+        }
+        Ok(sessions)
+    }
+    fn parse_adapter_snapshot(
+        text: &str,
+        wifi_profiles: &BTreeMap<String, String>,
+    ) -> Result<Vec<NetworkAdapterState>, String> {
+        if text.trim().is_empty() {
+            return Ok(vec![]);
+        }
+        let value: serde_json::Value =
+            serde_json::from_str(text).map_err(|e| format!("failed to parse adapter list: {e}"))?;
+        let items = match value {
+            serde_json::Value::Array(items) => items,
+            serde_json::Value::Object(map) => vec![serde_json::Value::Object(map)],
+            serde_json::Value::Null => Vec::new(),
+            other => {
+                return Err(format!("unexpected adapter list shape: {other}"));
+            }
+        };
+        let mut adapters = Vec::new();
+        for item in items {
+            let Some(name) = item.get("Name").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let name = name.trim();
+            if name.is_empty() {
+                continue;
+            }
+            let medium = item
+                .get("NdisPhysicalMedium")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_ascii_lowercase();
+            let description = item
+                .get("InterfaceDescription")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_ascii_lowercase();
+            let is_wireless = medium.contains("802")
+                || medium.contains("wireless")
+                || description.contains("wi-fi")
+                || description.contains("wifi")
+                || description.contains("wireless")
+                || description.contains("wlan");
+            adapters.push(NetworkAdapterState {
+                name: name.to_string(),
+                is_wireless,
+                wifi_profile: wifi_profiles.get(name).cloned(),
+            });
+        }
+        Ok(adapters)
+    }
+    fn parse_wifi_profile_map(text: &str) -> BTreeMap<String, String> {
+        let mut out = BTreeMap::new();
+        let mut current_name: Option<String> = None;
+        let mut current_profile: Option<String> = None;
+        let mut current_ssid: Option<String> = None;
+        let mut connected = false;
+        let flush = |out: &mut BTreeMap<String, String>,
+                     name: &mut Option<String>,
+                     profile: &mut Option<String>,
+                     ssid: &mut Option<String>,
+                     connected: &mut bool| {
+            if *connected {
+                if let Some(iface) = name.as_ref().map(|s| s.trim()).filter(|s| !s.is_empty()) {
+                    if let Some(value) = profile
+                        .as_ref()
+                        .or(ssid.as_ref())
+                        .map(|s| s.trim())
+                        .filter(|s| !s.is_empty())
+                    {
+                        out.insert(iface.to_string(), value.to_string());
+                    }
+                }
+            }
+            *name = None;
+            *profile = None;
+            *ssid = None;
+            *connected = false;
+        };
+        for line in text.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let Some((key, value)) = trimmed.split_once(':') else {
+                continue;
+            };
+            let key = key.trim().to_ascii_lowercase();
+            let value = value.trim();
+            let is_name_key = key == "name" || key == "nombre";
+            if is_name_key {
+                flush(
+                    &mut out,
+                    &mut current_name,
+                    &mut current_profile,
+                    &mut current_ssid,
+                    &mut connected,
+                );
+                current_name = Some(value.to_string());
+                continue;
+            }
+            if key == "state" || key == "estado" {
+                let lower = value.to_ascii_lowercase();
+                connected = lower.starts_with("connected") || lower.starts_with("conectad");
+                continue;
+            }
+            if key == "profile" || key == "perfil" {
+                current_profile = Some(value.to_string());
+                continue;
+            }
+            if key == "ssid" {
+                current_ssid = Some(value.to_string());
+            }
+        }
+        flush(
+            &mut out,
+            &mut current_name,
+            &mut current_profile,
+            &mut current_ssid,
+            &mut connected,
+        );
+        out
+    }
 }
 #[cfg(not(windows))]
 mod platform {
     use super::*;
+    use std::process::Stdio;
     pub struct AutorunRevertResult {
         pub removed_additions: usize,
         pub restored_entries: usize,
@@ -1387,11 +2034,28 @@ mod platform {
     pub fn is_supported() -> bool {
         false
     }
-    pub fn is_elevated() -> bool {
-        false
+    pub fn supports_isolation() -> bool {
+        cfg!(target_os = "linux") || cfg!(target_os = "macos")
     }
-    pub fn process_exists(_pid: u32) -> bool {
-        false
+    pub fn is_elevated() -> bool {
+        match Command::new("id").arg("-u").output() {
+            Ok(output) if output.status.success() => {
+                String::from_utf8_lossy(&output.stdout).trim() == "0"
+            }
+            _ => false,
+        }
+    }
+    pub fn process_exists(pid: u32) -> bool {
+        if pid == 0 {
+            return false;
+        }
+        Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
     }
     pub fn snapshot_autoruns() -> Result<AutorunSnapshot, String> {
         Err("Autorun freezing is not implemented on this platform.".into())
@@ -1400,6 +2064,94 @@ mod platform {
         _baseline: &[AutorunEntry],
     ) -> Result<AutorunRevertResult, String> {
         Err("Autorun revert is not implemented on this platform.".into())
+    }
+    pub fn snapshot_firewall_profiles() -> Result<FirewallSnapshot, String> {
+        Ok(FirewallSnapshot { profiles: vec![] })
+    }
+    pub fn apply_firewall_isolation() -> Result<(), String> {
+        Err("firewall backend unavailable; falling back to emergency adapter cutoff".into())
+    }
+    pub fn restore_firewall_profiles(_snapshot: &FirewallSnapshot) -> Result<(), String> {
+        Ok(())
+    }
+    pub fn snapshot_active_adapters() -> Result<NetworkSnapshot, String> {
+        #[cfg(target_os = "linux")]
+        {
+            let output = command_stdout("ip", &["-o", "link", "show", "up"])?;
+            let mut adapters = Vec::new();
+            for line in output.lines() {
+                let mut parts = line.splitn(3, ':');
+                let _ = parts.next();
+                let Some(name) = parts.next().map(|p| p.trim()) else {
+                    continue;
+                };
+                if !name.is_empty() && name != "lo" {
+                    adapters.push(NetworkAdapterState {
+                        name: name.to_string(),
+                        is_wireless: false,
+                        wifi_profile: None,
+                    });
+                }
+            }
+            return Ok(NetworkSnapshot { adapters });
+        }
+        #[cfg(target_os = "macos")]
+        {
+            let output = command_stdout("ifconfig", &["-l"])?;
+            let mut adapters = Vec::new();
+            for name in output.split_whitespace() {
+                if name == "lo0" {
+                    continue;
+                }
+                let details = command_stdout("ifconfig", &[name])?;
+                if details.contains("status: active") {
+                    adapters.push(NetworkAdapterState {
+                        name: name.to_string(),
+                        is_wireless: false,
+                        wifi_profile: None,
+                    });
+                }
+            }
+            return Ok(NetworkSnapshot { adapters });
+        }
+        #[allow(unreachable_code)]
+        Err("Network adapter snapshots are not implemented on this platform.".into())
+    }
+    pub fn disable_active_adapters(snapshot: &NetworkSnapshot) -> Result<(), String> {
+        #[cfg(target_os = "linux")]
+        {
+            for adapter in &snapshot.adapters {
+                command_status("ip", &["link", "set", "dev", &adapter.name, "down"])?;
+            }
+            return Ok(());
+        }
+        #[cfg(target_os = "macos")]
+        {
+            for adapter in &snapshot.adapters {
+                command_status("ifconfig", &[&adapter.name, "down"])?;
+            }
+            return Ok(());
+        }
+        #[allow(unreachable_code)]
+        Err("Network adapter isolation is not implemented on this platform.".into())
+    }
+    pub fn enable_active_adapters(snapshot: &NetworkSnapshot) -> Result<(), String> {
+        #[cfg(target_os = "linux")]
+        {
+            for adapter in &snapshot.adapters {
+                command_status("ip", &["link", "set", "dev", &adapter.name, "up"])?;
+            }
+            return Ok(());
+        }
+        #[cfg(target_os = "macos")]
+        {
+            for adapter in &snapshot.adapters {
+                command_status("ifconfig", &[&adapter.name, "up"])?;
+            }
+            return Ok(());
+        }
+        #[allow(unreachable_code)]
+        Err("Network adapter restoration is not implemented on this platform.".into())
     }
     pub fn suspend_process(_pid: u32) -> Result<(), String> {
         Err("Process suspension is not implemented on this platform.".into())
@@ -1427,6 +2179,31 @@ mod platform {
     }
     pub fn delete_rule(_rule_name: &str) -> Result<(), String> {
         Ok(())
+    }
+    fn command_stdout(program: &str, args: &[&str]) -> Result<String, String> {
+        let output = Command::new(program)
+            .args(args)
+            .output()
+            .map_err(|e| format!("failed to spawn {program}: {e}"))?;
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        } else {
+            Err(format!(
+                "{program} failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            ))
+        }
+    }
+    fn command_status(program: &str, args: &[&str]) -> Result<(), String> {
+        let status = Command::new(program)
+            .args(args)
+            .status()
+            .map_err(|e| format!("failed to spawn {program}: {e}"))?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(format!("{program} failed with status {status}"))
+        }
     }
 }
 
@@ -1499,7 +2276,11 @@ mod tests {
             blocked_domains: vec![blocked_domain("bad.example")],
             suspended_processes: vec![],
             autorun_snapshot: None,
+            firewall_snapshot: None,
+            network_snapshot: None,
             isolated: false,
+            isolation_started_unix: None,
+            isolation_expires_unix: None,
         };
         let changed = reconcile_state(&mut state, 100, |_| false);
         assert!(!changed);
@@ -1516,7 +2297,11 @@ mod tests {
             blocked_domains: vec![],
             suspended_processes: vec![],
             autorun_snapshot: None,
+            firewall_snapshot: None,
+            network_snapshot: None,
             isolated: false,
+            isolation_started_unix: None,
+            isolation_expires_unix: None,
         };
         let changed = reconcile_state(&mut state, 100, |rule| {
             deleted.push(rule.to_string());

--- a/src/active_response.rs
+++ b/src/active_response.rs
@@ -33,150 +33,1580 @@ pub struct Status {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct State {
     blocked: Vec<BlockedTarget>,
-    #[serde(default)] blocked_processes: Vec<BlockedProcess>,
-    #[serde(default)] blocked_domains: Vec<BlockedDomain>,
-    #[serde(default)] suspended_processes: Vec<SuspendedProcess>,
-    #[serde(default)] autorun_snapshot: Option<AutorunSnapshot>,
+    #[serde(default)]
+    blocked_processes: Vec<BlockedProcess>,
+    #[serde(default)]
+    blocked_domains: Vec<BlockedDomain>,
+    #[serde(default)]
+    suspended_processes: Vec<SuspendedProcess>,
+    #[serde(default)]
+    autorun_snapshot: Option<AutorunSnapshot>,
     isolated: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct BlockedTarget { target: String, rule_name: String, expires_at_unix: Option<u64> }
+struct BlockedTarget {
+    target: String,
+    rule_name: String,
+    expires_at_unix: Option<u64>,
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct BlockedProcess { #[serde(default)] pid: u32, path: String, inbound_rule_name: String, outbound_rule_name: String, expires_at_unix: Option<u64> }
-#[derive(Debug, Clone, Serialize, Deserialize)] struct BlockedDomain { domain: String, marker: String }
-#[derive(Debug, Clone, Serialize, Deserialize)] struct SuspendedProcess { pid: u32, path: String, proc_name: String, suspended_at_unix: u64 }
-#[derive(Debug, Clone, Serialize, Deserialize)] struct AutorunSnapshot { captured_at_unix: u64, entries: Vec<AutorunEntry> }
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)] struct AutorunEntry { hive: String, key_path: String, value_name: String, value_data: String }
+struct BlockedProcess {
+    #[serde(default)]
+    pid: u32,
+    path: String,
+    inbound_rule_name: String,
+    outbound_rule_name: String,
+    expires_at_unix: Option<u64>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BlockedDomain {
+    domain: String,
+    marker: String,
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SuspendedProcess {
+    pid: u32,
+    path: String,
+    proc_name: String,
+    suspended_at_unix: u64,
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AutorunSnapshot {
+    captured_at_unix: u64,
+    entries: Vec<AutorunEntry>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct AutorunEntry {
+    hive: String,
+    key_path: String,
+    value_name: String,
+    value_data: String,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SocketKillError { UnsupportedStatus(String), InvalidLocalAddr(String), InvalidRemoteAddr(String), UnsupportedAddressFamily, UnsupportedProtocol, PlatformUnsupported, PermissionDenied, OsError(u32) }
-impl std::fmt::Display for SocketKillError { fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { match self { Self::UnsupportedStatus(status) => write!(f, "cannot kill a socket in {status} state"), Self::InvalidLocalAddr(addr) => write!(f, "invalid local address: {addr}"), Self::InvalidRemoteAddr(addr) => write!(f, "invalid remote address: {addr}"), Self::UnsupportedAddressFamily => write!(f, "live socket kill currently supports IPv4 TCP only on Windows"), Self::UnsupportedProtocol => write!(f, "socket kill currently supports TCP connections only"), Self::PlatformUnsupported => write!(f, "socket kill is currently only implemented on Windows"), Self::PermissionDenied => write!(f, "administrator privileges are required to kill a TCP connection"), Self::OsError(code) => write!(f, "Windows returned error code {code}"), } } }
+pub enum SocketKillError {
+    UnsupportedStatus(String),
+    InvalidLocalAddr(String),
+    InvalidRemoteAddr(String),
+    UnsupportedAddressFamily,
+    PlatformUnsupported,
+    PermissionDenied,
+    OsError(u32),
+}
+impl std::fmt::Display for SocketKillError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedStatus(status) => write!(f, "cannot kill a socket in {status} state"),
+            Self::InvalidLocalAddr(addr) => write!(f, "invalid local address: {addr}"),
+            Self::InvalidRemoteAddr(addr) => write!(f, "invalid remote address: {addr}"),
+            Self::UnsupportedAddressFamily => write!(
+                f,
+                "live socket kill currently supports IPv4 TCP only on Windows"
+            ),
+            Self::PlatformUnsupported => {
+                write!(f, "socket kill is currently only implemented on Windows")
+            }
+            Self::PermissionDenied => write!(
+                f,
+                "administrator privileges are required to kill a TCP connection"
+            ),
+            Self::OsError(code) => write!(f, "Windows returned error code {code}"),
+        }
+    }
+}
 impl std::error::Error for SocketKillError {}
-#[derive(Debug, Clone, PartialEq, Eq)] struct SocketKillTarget { local: SocketAddr, remote: SocketAddr }
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SocketKillTarget {
+    local: SocketAddr,
+    remote: SocketAddr,
+}
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DurationPreset { OneHour, OneDay, Permanent }
-impl DurationPreset { fn ttl(self) -> Option<Duration> { match self { Self::OneHour => Some(Duration::from_secs(60 * 60)), Self::OneDay => Some(Duration::from_secs(60 * 60 * 24)), Self::Permanent => None } } }
+pub enum DurationPreset {
+    OneHour,
+    OneDay,
+    Permanent,
+}
+impl DurationPreset {
+    fn ttl(self) -> Option<Duration> {
+        match self {
+            Self::OneHour => Some(Duration::from_secs(60 * 60)),
+            Self::OneDay => Some(Duration::from_secs(60 * 60 * 24)),
+            Self::Permanent => None,
+        }
+    }
+}
 
-pub fn status() -> Status { let state = load_state().unwrap_or_default(); Status { blocked_rules: state.blocked.len() + state.blocked_processes.len(), blocked_processes: state.blocked_processes.len(), blocked_domains: state.blocked_domains.len(), suspended_processes: state.suspended_processes.len(), frozen_autoruns: state.autorun_snapshot.is_some(), isolated: state.isolated } }
-pub fn has_frozen_autoruns() -> bool { load_state().ok().and_then(|s| s.autorun_snapshot).is_some() }
-pub fn can_modify_firewall() -> bool { platform::is_supported() && platform::is_elevated() }
-pub fn can_kill_connection(conn: &ConnInfo) -> bool { if !platform::is_supported() || !platform::is_elevated() { return false; } socket_kill_target(conn).is_ok() }
-pub fn can_suspend_process(pid: u32) -> bool { platform::is_supported() && platform::is_elevated() && pid != 0 }
-pub fn can_block_domain() -> bool { platform::is_supported() && platform::is_elevated() }
-pub fn can_apply_quarantine_profile(pid: u32, path: &str) -> bool { platform::is_supported() && platform::is_elevated() && (pid != 0 || !path.trim().is_empty()) }
+pub fn status() -> Status {
+    let state = load_state().unwrap_or_default();
+    Status {
+        blocked_rules: state.blocked.len() + state.blocked_processes.len(),
+        blocked_processes: state.blocked_processes.len(),
+        blocked_domains: state.blocked_domains.len(),
+        suspended_processes: state.suspended_processes.len(),
+        frozen_autoruns: state.autorun_snapshot.is_some(),
+        isolated: state.isolated,
+    }
+}
+pub fn has_frozen_autoruns() -> bool {
+    load_state().ok().and_then(|s| s.autorun_snapshot).is_some()
+}
+pub fn can_modify_firewall() -> bool {
+    platform::is_supported() && platform::is_elevated()
+}
+pub fn can_kill_connection(conn: &ConnInfo) -> bool {
+    if !platform::is_supported() || !platform::is_elevated() {
+        return false;
+    }
+    socket_kill_target(conn).is_ok()
+}
+pub fn can_suspend_process(pid: u32) -> bool {
+    platform::is_supported() && platform::is_elevated() && pid != 0
+}
+pub fn can_block_domain() -> bool {
+    platform::is_supported() && platform::is_elevated()
+}
+pub fn can_apply_quarantine_profile(pid: u32, path: &str) -> bool {
+    platform::is_supported() && platform::is_elevated() && (pid != 0 || !path.trim().is_empty())
+}
 
-pub fn freeze_autoruns() -> Result<String, String> { ensure_modifiable()?; let snapshot = platform::snapshot_autoruns()?; let mut state = load_state().unwrap_or_default(); let count = snapshot.entries.len(); state.autorun_snapshot = Some(snapshot); save_state(&state)?; audit::record("freeze_autoruns", "success", json!({ "entries": count })); Ok(format!("Captured autorun baseline with {count} entr{}.", if count == 1 { "y" } else { "ies" })) }
-pub fn revert_frozen_autoruns() -> Result<String, String> { ensure_modifiable()?; let mut state = load_state().unwrap_or_default(); let Some(snapshot) = state.autorun_snapshot.clone() else { return Err("No autorun baseline has been captured yet.".into()); }; let result = platform::revert_autorun_changes(&snapshot.entries)?; state.autorun_snapshot = None; save_state(&state)?; audit::record("revert_frozen_autoruns", "success", json!({ "removed_additions": result.removed_additions, "restored_entries": result.restored_entries })); Ok(format!("Reverted autorun changes: removed {} added entr{} and restored {} baseline entr{}.", result.removed_additions, if result.removed_additions == 1 { "y" } else { "ies" }, result.restored_entries, if result.restored_entries == 1 { "y" } else { "ies" })) }
-pub fn kill_connection(conn: &ConnInfo) -> Result<String, SocketKillError> { if !platform::is_supported() { return Err(SocketKillError::PlatformUnsupported); } if !platform::is_elevated() { return Err(SocketKillError::PermissionDenied); } let target = socket_kill_target(conn)?; platform::kill_tcp_connection(&target)?; let message = format!("Killed TCP connection {} -> {}.", target.local, target.remote); audit::record("kill_connection", "success", json!({ "local_addr": target.local.to_string(), "remote_addr": target.remote.to_string(), "pid": conn.pid, "proc_name": conn.proc_name })); Ok(message) }
-pub fn suspend_process(pid: u32, path: &str, proc_name: &str) -> Result<String, String> { ensure_modifiable()?; if pid == 0 { return Err("Cannot suspend PID 0.".into()); } platform::suspend_process(pid)?; let path = path.trim().to_string(); let proc_name = proc_name.trim().to_string(); let mut state = load_state().unwrap_or_default(); state.suspended_processes.retain(|entry| !suspended_process_matches(entry, pid, &path)); state.suspended_processes.push(SuspendedProcess { pid, path: path.clone(), proc_name: proc_name.clone(), suspended_at_unix: unix_now() }); save_state(&state)?; let message = if path.is_empty() { format!("Suspended PID {pid}.") } else { format!("Suspended PID {pid} ({path}).") }; audit::record("suspend_process", "success", json!({ "pid": pid, "path": path, "proc_name": proc_name })); Ok(message) }
-pub fn resume_process(pid: u32, path: &str) -> Result<String, String> { ensure_modifiable()?; if pid == 0 { return Err("Cannot resume PID 0.".into()); } platform::resume_process(pid)?; let path = path.trim().to_string(); let mut state = load_state().unwrap_or_default(); let before = state.suspended_processes.len(); state.suspended_processes.retain(|entry| !suspended_process_matches(entry, pid, &path)); let removed = before.saturating_sub(state.suspended_processes.len()); save_state(&state)?; let message = if path.is_empty() { format!("Resumed PID {pid}.") } else { format!("Resumed PID {pid} ({path}).") }; audit::record("resume_process", if removed > 0 { "success" } else { "noop" }, json!({ "pid": pid, "path": path, "removed_entries": removed })); Ok(message) }
-pub fn block_domain(domain: &str) -> Result<String, String> { ensure_modifiable()?; let domain = normalise_domain(domain)?; let marker = domain_marker(&domain); platform::add_domain_block(&domain, &marker)?; let mut state = load_state().unwrap_or_default(); state.blocked_domains.retain(|entry| entry.domain != domain); state.blocked_domains.push(BlockedDomain { domain: domain.clone(), marker: marker.clone() }); save_state(&state)?; audit::record("block_domain", "success", json!({ "domain": domain, "marker": marker })); Ok(format!("Blocked domain {domain} via the local hosts file.")) }
-pub fn unblock_domain(domain: &str) -> Result<String, String> { ensure_modifiable()?; let domain = normalise_domain(domain)?; let marker = domain_marker(&domain); platform::remove_domain_block(&domain, &marker)?; let mut state = load_state().unwrap_or_default(); let before = state.blocked_domains.len(); state.blocked_domains.retain(|entry| entry.domain != domain); let removed = before.saturating_sub(state.blocked_domains.len()); save_state(&state)?; audit::record("unblock_domain", if removed > 0 { "success" } else { "noop" }, json!({ "domain": domain, "marker": marker, "removed_entries": removed })); Ok(if removed > 0 { format!("Removed the hosts-file block for {domain}.") } else { format!("No hosts-file block found for {domain}.") }) }
+pub fn freeze_autoruns() -> Result<String, String> {
+    ensure_modifiable()?;
+    let snapshot = platform::snapshot_autoruns()?;
+    let mut state = load_state().unwrap_or_default();
+    let count = snapshot.entries.len();
+    state.autorun_snapshot = Some(snapshot);
+    save_state(&state)?;
+    audit::record("freeze_autoruns", "success", json!({ "entries": count }));
+    Ok(format!(
+        "Captured autorun baseline with {count} entr{}.",
+        if count == 1 { "y" } else { "ies" }
+    ))
+}
+pub fn revert_frozen_autoruns() -> Result<String, String> {
+    ensure_modifiable()?;
+    let mut state = load_state().unwrap_or_default();
+    let Some(snapshot) = state.autorun_snapshot.clone() else {
+        return Err("No autorun baseline has been captured yet.".into());
+    };
+    let result = platform::revert_autorun_changes(&snapshot.entries)?;
+    state.autorun_snapshot = None;
+    save_state(&state)?;
+    audit::record(
+        "revert_frozen_autoruns",
+        "success",
+        json!({ "removed_additions": result.removed_additions, "restored_entries": result.restored_entries }),
+    );
+    Ok(format!(
+        "Reverted autorun changes: removed {} added entr{} and restored {} baseline entr{}.",
+        result.removed_additions,
+        if result.removed_additions == 1 {
+            "y"
+        } else {
+            "ies"
+        },
+        result.restored_entries,
+        if result.restored_entries == 1 {
+            "y"
+        } else {
+            "ies"
+        }
+    ))
+}
+pub fn kill_connection(conn: &ConnInfo) -> Result<String, SocketKillError> {
+    if !platform::is_supported() {
+        return Err(SocketKillError::PlatformUnsupported);
+    }
+    if !platform::is_elevated() {
+        return Err(SocketKillError::PermissionDenied);
+    }
+    let target = socket_kill_target(conn)?;
+    platform::kill_tcp_connection(&target)?;
+    let message = format!(
+        "Killed TCP connection {} -> {}.",
+        target.local, target.remote
+    );
+    audit::record(
+        "kill_connection",
+        "success",
+        json!({ "local_addr": target.local.to_string(), "remote_addr": target.remote.to_string(), "pid": conn.pid, "proc_name": conn.proc_name }),
+    );
+    Ok(message)
+}
+pub fn suspend_process(pid: u32, path: &str, proc_name: &str) -> Result<String, String> {
+    ensure_modifiable()?;
+    if pid == 0 {
+        return Err("Cannot suspend PID 0.".into());
+    }
+    platform::suspend_process(pid)?;
+    let path = path.trim().to_string();
+    let proc_name = proc_name.trim().to_string();
+    let mut state = load_state().unwrap_or_default();
+    state
+        .suspended_processes
+        .retain(|entry| !suspended_process_matches(entry, pid, &path));
+    state.suspended_processes.push(SuspendedProcess {
+        pid,
+        path: path.clone(),
+        proc_name: proc_name.clone(),
+        suspended_at_unix: unix_now(),
+    });
+    save_state(&state)?;
+    let message = if path.is_empty() {
+        format!("Suspended PID {pid}.")
+    } else {
+        format!("Suspended PID {pid} ({path}).")
+    };
+    audit::record(
+        "suspend_process",
+        "success",
+        json!({ "pid": pid, "path": path, "proc_name": proc_name }),
+    );
+    Ok(message)
+}
+pub fn resume_process(pid: u32, path: &str) -> Result<String, String> {
+    ensure_modifiable()?;
+    if pid == 0 {
+        return Err("Cannot resume PID 0.".into());
+    }
+    platform::resume_process(pid)?;
+    let path = path.trim().to_string();
+    let mut state = load_state().unwrap_or_default();
+    let before = state.suspended_processes.len();
+    state
+        .suspended_processes
+        .retain(|entry| !suspended_process_matches(entry, pid, &path));
+    let removed = before.saturating_sub(state.suspended_processes.len());
+    save_state(&state)?;
+    let message = if path.is_empty() {
+        format!("Resumed PID {pid}.")
+    } else {
+        format!("Resumed PID {pid} ({path}).")
+    };
+    audit::record(
+        "resume_process",
+        if removed > 0 { "success" } else { "noop" },
+        json!({ "pid": pid, "path": path, "removed_entries": removed }),
+    );
+    Ok(message)
+}
+pub fn block_domain(domain: &str) -> Result<String, String> {
+    ensure_modifiable()?;
+    let domain = normalise_domain(domain)?;
+    let marker = domain_marker(&domain);
+    platform::add_domain_block(&domain, &marker)?;
+    let mut state = load_state().unwrap_or_default();
+    state.blocked_domains.retain(|entry| entry.domain != domain);
+    state.blocked_domains.push(BlockedDomain {
+        domain: domain.clone(),
+        marker: marker.clone(),
+    });
+    save_state(&state)?;
+    audit::record(
+        "block_domain",
+        "success",
+        json!({ "domain": domain, "marker": marker }),
+    );
+    Ok(format!("Blocked domain {domain} via the local hosts file."))
+}
+pub fn unblock_domain(domain: &str) -> Result<String, String> {
+    ensure_modifiable()?;
+    let domain = normalise_domain(domain)?;
+    let marker = domain_marker(&domain);
+    platform::remove_domain_block(&domain, &marker)?;
+    let mut state = load_state().unwrap_or_default();
+    let before = state.blocked_domains.len();
+    state.blocked_domains.retain(|entry| entry.domain != domain);
+    let removed = before.saturating_sub(state.blocked_domains.len());
+    save_state(&state)?;
+    audit::record(
+        "unblock_domain",
+        if removed > 0 { "success" } else { "noop" },
+        json!({ "domain": domain, "marker": marker, "removed_entries": removed }),
+    );
+    Ok(if removed > 0 {
+        format!("Removed the hosts-file block for {domain}.")
+    } else {
+        format!("No hosts-file block found for {domain}.")
+    })
+}
 
 pub fn apply_quarantine_profile(pid: u32, path: &str, proc_name: &str) -> Result<String, String> {
     ensure_modifiable()?;
-    if pid == 0 && path.trim().is_empty() { return Err("Quarantine profile requires a real PID or a known executable path.".into()); }
-    let mut applied = Vec::new(); let mut warnings = Vec::new();
-    match isolate_machine() { Ok(_) => applied.push("network isolated".to_string()), Err(err) => warnings.push(format!("network isolation failed: {err}")), }
-    if !path.trim().is_empty() { match block_process(pid, path, DurationPreset::Permanent) { Ok(_) => applied.push("process traffic blocked".to_string()), Err(err) => warnings.push(format!("process block failed: {err}")), } }
-    if pid != 0 { match suspend_process(pid, path, proc_name) { Ok(_) => applied.push("process suspended".to_string()), Err(err) => warnings.push(format!("process suspend failed: {err}")), } }
+    if pid == 0 && path.trim().is_empty() {
+        return Err("Quarantine profile requires a real PID or a known executable path.".into());
+    }
+    let mut applied = Vec::new();
+    let mut warnings = Vec::new();
+    match isolate_machine() {
+        Ok(_) => applied.push("network isolated".to_string()),
+        Err(err) => warnings.push(format!("network isolation failed: {err}")),
+    }
+    if !path.trim().is_empty() {
+        match block_process(pid, path, DurationPreset::Permanent) {
+            Ok(_) => applied.push("process traffic blocked".to_string()),
+            Err(err) => warnings.push(format!("process block failed: {err}")),
+        }
+    }
+    if pid != 0 {
+        match suspend_process(pid, path, proc_name) {
+            Ok(_) => applied.push("process suspended".to_string()),
+            Err(err) => warnings.push(format!("process suspend failed: {err}")),
+        }
+    }
     let (extended_applied, extended_warnings) = quarantine::apply();
     applied.extend(extended_applied);
     warnings.extend(extended_warnings);
-    if applied.is_empty() { return Err(if warnings.is_empty() { "Quarantine profile could not apply any containment step.".into() } else { warnings.join("; ") }); }
-    let message = if warnings.is_empty() { format!("Applied quarantine profile: {}.", applied.join(", ")) } else { format!("Applied quarantine profile: {}. Warnings: {}.", applied.join(", "), warnings.join("; ")) };
-    audit::record("quarantine_profile", if warnings.is_empty() { "success" } else { "partial" }, json!({ "pid": pid, "path": path, "proc_name": proc_name, "applied": applied, "warnings": warnings }));
+    if applied.is_empty() {
+        return Err(if warnings.is_empty() {
+            "Quarantine profile could not apply any containment step.".into()
+        } else {
+            warnings.join("; ")
+        });
+    }
+    let message = if warnings.is_empty() {
+        format!("Applied quarantine profile: {}.", applied.join(", "))
+    } else {
+        format!(
+            "Applied quarantine profile: {}. Warnings: {}.",
+            applied.join(", "),
+            warnings.join("; ")
+        )
+    };
+    audit::record(
+        "quarantine_profile",
+        if warnings.is_empty() {
+            "success"
+        } else {
+            "partial"
+        },
+        json!({ "pid": pid, "path": path, "proc_name": proc_name, "applied": applied, "warnings": warnings }),
+    );
     Ok(message)
 }
 
 pub fn clear_quarantine_profile(pid: u32, path: &str) -> Result<String, String> {
     ensure_modifiable()?;
-    let mut cleared = Vec::new(); let mut warnings = Vec::new();
-    match restore_machine() { Ok(_) => cleared.push("network restored".to_string()), Err(err) => warnings.push(format!("network restore failed: {err}")), }
-    if !path.trim().is_empty() { match unblock_process(pid, path) { Ok(_) => cleared.push("process block removed".to_string()), Err(err) => warnings.push(format!("process unblock failed: {err}")), } }
-    if pid != 0 { match resume_process(pid, path) { Ok(_) => cleared.push("process resumed".to_string()), Err(err) => warnings.push(format!("process resume failed: {err}")), } }
+    let mut cleared = Vec::new();
+    let mut warnings = Vec::new();
+    match restore_machine() {
+        Ok(_) => cleared.push("network restored".to_string()),
+        Err(err) => warnings.push(format!("network restore failed: {err}")),
+    }
+    if !path.trim().is_empty() {
+        match unblock_process(pid, path) {
+            Ok(_) => cleared.push("process block removed".to_string()),
+            Err(err) => warnings.push(format!("process unblock failed: {err}")),
+        }
+    }
+    if pid != 0 {
+        match resume_process(pid, path) {
+            Ok(_) => cleared.push("process resumed".to_string()),
+            Err(err) => warnings.push(format!("process resume failed: {err}")),
+        }
+    }
     let (extended_cleared, extended_warnings) = quarantine::clear();
     cleared.extend(extended_cleared);
     warnings.extend(extended_warnings);
-    if cleared.is_empty() { return Err(if warnings.is_empty() { "Quarantine clear did not change any containment step.".into() } else { warnings.join("; ") }); }
-    let message = if warnings.is_empty() { format!("Cleared quarantine profile: {}.", cleared.join(", ")) } else { format!("Cleared quarantine profile: {}. Warnings: {}.", cleared.join(", "), warnings.join("; ")) };
-    audit::record("clear_quarantine_profile", if warnings.is_empty() { "success" } else { "partial" }, json!({ "pid": pid, "path": path, "cleared": cleared, "warnings": warnings }));
+    if cleared.is_empty() {
+        return Err(if warnings.is_empty() {
+            "Quarantine clear did not change any containment step.".into()
+        } else {
+            warnings.join("; ")
+        });
+    }
+    let message = if warnings.is_empty() {
+        format!("Cleared quarantine profile: {}.", cleared.join(", "))
+    } else {
+        format!(
+            "Cleared quarantine profile: {}. Warnings: {}.",
+            cleared.join(", "),
+            warnings.join("; ")
+        )
+    };
+    audit::record(
+        "clear_quarantine_profile",
+        if warnings.is_empty() {
+            "success"
+        } else {
+            "partial"
+        },
+        json!({ "pid": pid, "path": path, "cleared": cleared, "warnings": warnings }),
+    );
     Ok(message)
 }
 
-pub fn reconcile() { if !platform::is_supported() || !platform::is_elevated() { return; } let Ok(mut state) = load_state() else { return; }; let now = unix_now(); let changed = reconcile_state(&mut state, now, |rule_name| platform::delete_rule(rule_name).is_ok()); if changed { let _ = save_state(&state); } }
-pub fn block_remote(target: &str, preset: DurationPreset) -> Result<String, String> { ensure_modifiable()?; let target = normalise_target(target)?; let rule_name = rule_name_for_target(&target); let expires_at_unix = preset.ttl().map(|ttl| unix_now().saturating_add(ttl.as_secs())); let _ = platform::delete_rule(&rule_name); platform::add_block_rule(&rule_name, &target)?; let mut state = load_state().unwrap_or_default(); state.blocked.retain(|rule| rule.target != target); state.blocked.push(BlockedTarget { target: target.clone(), rule_name: rule_name.clone(), expires_at_unix }); save_state(&state)?; let message = match preset { DurationPreset::OneHour => format!("Blocked {target} for 1 hour."), DurationPreset::OneDay => format!("Blocked {target} for 24 hours."), DurationPreset::Permanent => format!("Blocked {target} until removed.") }; audit::record("block_remote", "success", json!({ "target": target, "duration": format!("{:?}", preset), "rule_name": rule_name })); Ok(message) }
-pub fn unblock_remote(target: &str) -> Result<String, String> { ensure_modifiable()?; let target = normalise_target(target)?; let mut state = load_state().unwrap_or_default(); let mut removed = 0usize; let mut kept = Vec::with_capacity(state.blocked.len()); let mut delete_failed = false; for rule in state.blocked.drain(..) { if rule.target == target { if platform::delete_rule(&rule.rule_name).is_ok() { removed += 1; } else { delete_failed = true; kept.push(rule); } } else { kept.push(rule); } } state.blocked = kept; if delete_failed { return Err(format!("Could not remove the firewall rule for {target}; it was kept in state so Vigil can retry.")); } let message = if removed > 0 { save_state(&state)?; format!("Removed {removed} block rule(s) for {target}.") } else { format!("No active block rule found for {target}.") }; audit::record("unblock_remote", if removed > 0 { "success" } else { "noop" }, json!({ "target": target, "removed_rules": removed })); Ok(message) }
-pub fn block_process(pid: u32, path: &str, preset: DurationPreset) -> Result<String, String> { ensure_modifiable()?; let path = normalise_target(path)?; let rule_suffix = rule_suffix_for_process(&path); let outbound_rule_name = format!("{PROCESS_BLOCK_RULE_PREFIX} Out {rule_suffix}"); let inbound_rule_name = format!("{PROCESS_BLOCK_RULE_PREFIX} In {rule_suffix}"); let expires_at_unix = preset.ttl().map(|ttl| unix_now().saturating_add(ttl.as_secs())); let _ = platform::delete_rule(&outbound_rule_name); let _ = platform::delete_rule(&inbound_rule_name); platform::add_block_program_rule(&outbound_rule_name, &path, "out")?; if let Err(err) = platform::add_block_program_rule(&inbound_rule_name, &path, "in") { let _ = platform::delete_rule(&outbound_rule_name); return Err(err); } let mut state = load_state().unwrap_or_default(); state.blocked_processes.retain(|rule| !process_block_matches(rule, &path)); state.blocked_processes.push(BlockedProcess { pid, path: path.clone(), inbound_rule_name: inbound_rule_name.clone(), outbound_rule_name: outbound_rule_name.clone(), expires_at_unix }); save_state(&state)?; let message = match preset { DurationPreset::OneHour => format!("Blocked {path} for 1 hour."), DurationPreset::OneDay => format!("Blocked {path} for 24 hours."), DurationPreset::Permanent => format!("Blocked {path} until removed.") }; audit::record("block_process", "success", json!({ "pid": pid, "path": path, "duration": format!("{:?}", preset), "inbound_rule_name": inbound_rule_name, "outbound_rule_name": outbound_rule_name })); Ok(message) }
-pub fn unblock_process(pid: u32, path: &str) -> Result<String, String> { ensure_modifiable()?; let path = normalise_target(path)?; let mut state = load_state().unwrap_or_default(); let mut removed = 0usize; let mut kept = Vec::with_capacity(state.blocked_processes.len()); let mut delete_failed = false; for rule in state.blocked_processes.drain(..) { if process_block_matches(&rule, &path) { let inbound_deleted = platform::delete_rule(&rule.inbound_rule_name).is_ok(); let outbound_deleted = platform::delete_rule(&rule.outbound_rule_name).is_ok(); if inbound_deleted && outbound_deleted { removed += 1; } else { delete_failed = true; kept.push(rule); } } else { kept.push(rule); } } state.blocked_processes = kept; if delete_failed { return Err(format!("Could not remove the firewall rules for PID {pid} ({path}); they were kept in state so Vigil can retry.")); } let message = if removed > 0 { save_state(&state)?; format!("Removed {removed} process block(s) for PID {pid} ({path}).") } else { format!("No active process block found for PID {pid} ({path}).") }; audit::record("unblock_process", if removed > 0 { "success" } else { "noop" }, json!({ "pid": pid, "path": path, "removed_rules": removed })); Ok(message) }
-
-pub fn isolate_machine() -> Result<String, String> { ensure_modifiable()?; let _ = platform::delete_rule(ISOLATE_RULE_IN); let _ = platform::delete_rule(ISOLATE_RULE_OUT); platform::add_block_all_rule(ISOLATE_RULE_IN, "in")?; platform::add_block_all_rule(ISOLATE_RULE_OUT, "out")?; let mut state = load_state().unwrap_or_default(); state.isolated = true; save_state(&state)?; let cfg = crate::config::Config::load(); crate::break_glass::sync_watchdog(&cfg); audit::record("isolate_machine", "success", json!({ "inbound_rule_name": ISOLATE_RULE_IN, "outbound_rule_name": ISOLATE_RULE_OUT })); Ok("Network isolation enabled.".into()) }
-pub fn restore_machine() -> Result<String, String> { ensure_modifiable()?; let in_deleted = platform::delete_rule(ISOLATE_RULE_IN).is_ok(); let out_deleted = platform::delete_rule(ISOLATE_RULE_OUT).is_ok(); if !(in_deleted && out_deleted) { return Err("Could not remove all isolation firewall rules; the state was kept for retry.".into()); } let mut state = load_state().unwrap_or_default(); state.isolated = false; save_state(&state)?; let cfg = crate::config::Config::load(); crate::break_glass::sync_watchdog(&cfg); audit::record("restore_machine", "success", json!({})); Ok("Network isolation removed.".into()) }
-
-pub fn is_blocked(target: &str) -> bool { let Ok(target) = normalise_target(target) else { return false; }; load_state().ok().map(|state| state.blocked.iter().any(|r| r.target == target)).unwrap_or(false) }
-pub fn is_domain_blocked(domain: &str) -> bool { let Ok(domain) = normalise_domain(domain) else { return false; }; load_state().ok().map(|state| state.blocked_domains.iter().any(|entry| entry.domain == domain)).unwrap_or(false) }
-pub fn remote_block_remaining(target: &str) -> Option<Duration> { let target = normalise_target(target).ok()?; let now = unix_now(); load_state().ok().and_then(|state| state.blocked.into_iter().find(|r| r.target == target).and_then(|rule| rule.expires_at_unix)).and_then(|expires_at_unix| expires_at_unix.checked_sub(now)).map(Duration::from_secs) }
-pub fn is_process_blocked(_pid: u32, path: &str) -> bool { let Ok(path) = normalise_target(path) else { return false; }; load_state().ok().map(|state| state.blocked_processes.iter().any(|r| process_block_matches(r, &path))).unwrap_or(false) }
-pub fn process_block_remaining(_pid: u32, path: &str) -> Option<Duration> { let path = normalise_target(path).ok()?; let now = unix_now(); load_state().ok().and_then(|state| state.blocked_processes.into_iter().find(|r| process_block_matches(r, &path)).and_then(|rule| rule.expires_at_unix)).and_then(|expires_at_unix| expires_at_unix.checked_sub(now)).map(Duration::from_secs) }
-pub fn is_process_suspended(pid: u32, path: &str) -> bool { load_state().ok().map(|state| state.suspended_processes.iter().any(|entry| suspended_process_matches(entry, pid, path))).unwrap_or(false) }
-
-pub fn extract_remote_target(remote_addr: &str) -> Option<String> { if let Ok(addr) = socket_addr_from_text(remote_addr) { return Some(addr.ip().to_string()); } let trimmed = remote_addr.trim(); let (host, port) = trimmed.rsplit_once(':')?; if host.is_empty() || !port.chars().all(|c| c.is_ascii_digit()) { return None; } let host = host.strip_prefix('[').and_then(|h| h.strip_suffix(']')).unwrap_or(host); if host.parse::<IpAddr>().is_ok() { Some(host.to_string()) } else { None } }
-pub fn extract_domain_target(conn: &ConnInfo) -> Option<String> { conn.hostname.as_deref().and_then(extract_domain_from_hostname) }
-pub fn extract_domain_from_hostname(hostname: &str) -> Option<String> { let host = hostname.trim().trim_end_matches('.').to_ascii_lowercase(); if host.is_empty() || host.parse::<IpAddr>().is_ok() || !host.contains('.') { return None; } if host.chars().all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-') { Some(host) } else { None } }
-
-fn ensure_modifiable() -> Result<(), String> { if !platform::is_supported() { return Err("Active response is currently only implemented on Windows.".into()); } if !platform::is_elevated() { return Err("Administrator privileges are required for active response.".into()); } Ok(()) }
-fn socket_kill_target(conn: &ConnInfo) -> Result<SocketKillTarget, SocketKillError> { if !conn.status.eq_ignore_ascii_case("ESTABLISHED") && !conn.status.eq_ignore_ascii_case("SYN_SENT") && !conn.status.eq_ignore_ascii_case("SYN_RECEIVED") && !conn.status.eq_ignore_ascii_case("FIN_WAIT_1") && !conn.status.eq_ignore_ascii_case("FIN_WAIT_2") && !conn.status.eq_ignore_ascii_case("CLOSE_WAIT") && !conn.status.eq_ignore_ascii_case("CLOSING") && !conn.status.eq_ignore_ascii_case("LAST_ACK") && !conn.status.eq_ignore_ascii_case("TIME_WAIT") { return Err(SocketKillError::UnsupportedStatus(conn.status.clone())); } let local = socket_addr_from_text(&conn.local_addr).map_err(|_| SocketKillError::InvalidLocalAddr(conn.local_addr.clone()))?; let remote = socket_addr_from_text(&conn.remote_addr).map_err(|_| SocketKillError::InvalidRemoteAddr(conn.remote_addr.clone()))?; match (local.ip(), remote.ip()) { (IpAddr::V4(_), IpAddr::V4(_)) => Ok(SocketKillTarget { local, remote }), _ => Err(SocketKillError::UnsupportedAddressFamily) } }
-fn socket_addr_from_text(text: &str) -> Result<SocketAddr, std::net::AddrParseError> { text.trim().parse::<SocketAddr>() }
-fn normalise_target(target: &str) -> Result<String, String> { let target = target.trim(); if target.is_empty() { Err("Target cannot be empty.".into()) } else { Ok(target.to_string()) } }
-fn normalise_domain(domain: &str) -> Result<String, String> { extract_domain_from_hostname(domain).ok_or_else(|| "Domain is empty or invalid.".into()) }
-fn process_block_matches(rule: &BlockedProcess, path: &str) -> bool { rule.path == path }
-fn suspended_process_matches(entry: &SuspendedProcess, pid: u32, path: &str) -> bool { entry.pid == pid && (path.is_empty() || entry.path == path) }
-fn domain_marker(domain: &str) -> String { format!("{DOMAIN_MARKER_PREFIX}:{}", sanitise_rule_suffix(domain)) }
-fn rule_name_for_target(target: &str) -> String { format!("{BLOCK_RULE_PREFIX} {}", sanitise_rule_suffix(target)) }
-fn rule_suffix_for_process(path: &str) -> String { let base = std::path::Path::new(path).file_name().and_then(|s| s.to_str()).unwrap_or("process"); format!("{}-{:016x}", sanitise_rule_suffix(base), stable_hash(path)) }
-fn sanitise_rule_suffix(text: &str) -> String { text.chars().map(|c| if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' { c } else { '_' }).collect() }
-fn stable_hash(text: &str) -> u64 { let mut hash = 0xcbf29ce484222325u64; for b in text.as_bytes() { hash ^= u64::from(*b); hash = hash.wrapping_mul(0x100000001b3); } hash }
-fn state_path() -> PathBuf { crate::config::data_dir().join(STATE_FILE) }
-fn load_state() -> Result<State, String> { let path = state_path(); if !path.exists() { return Ok(State::default()); } let text = std::fs::read_to_string(&path).map_err(|e| format!("failed to read {}: {e}", path.display()))?; serde_json::from_str(&text).map_err(|e| format!("failed to parse {}: {e}", path.display())) }
-fn save_state(state: &State) -> Result<(), String> { let path = state_path(); if let Some(parent)=path.parent(){ std::fs::create_dir_all(parent).map_err(|e| format!("failed to create {}: {e}", parent.display()))?; } let json=serde_json::to_string_pretty(state).map_err(|e| format!("failed to serialise active-response state: {e}"))?; std::fs::write(&path, json).map_err(|e| format!("failed to write {}: {e}", path.display())) }
-fn reconcile_state<F>(state: &mut State, now: u64, mut delete_rule: F) -> bool where F: FnMut(&str) -> bool { let mut changed = false; state.blocked.retain(|rule| { let expired = rule.expires_at_unix.is_some_and(|ts| ts <= now); if expired { if delete_rule(&rule.rule_name) { changed = true; false } else { true } } else { true } }); state.blocked_processes.retain(|rule| { let expired = rule.expires_at_unix.is_some_and(|ts| ts <= now); if expired { let inbound_deleted = delete_rule(&rule.inbound_rule_name); let outbound_deleted = delete_rule(&rule.outbound_rule_name); if inbound_deleted && outbound_deleted { changed = true; false } else { true } } else { true } }); state.suspended_processes.retain(|entry| { if platform::process_exists(entry.pid) { true } else { changed = true; false } }); changed }
-fn unix_now() -> u64 { SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0) }
-
-#[cfg(windows)] mod platform {
-    use super::*; use std::collections::BTreeMap; use std::fs; use windows::Win32::Foundation::{CloseHandle, HANDLE, ERROR_ACCESS_DENIED, INVALID_HANDLE_VALUE, NO_ERROR}; use windows::Win32::NetworkManagement::IpHelper::{SetTcpEntry, MIB_TCP_STATE_DELETE_TCB, MIB_TCPROW}; use windows::Win32::Security::{GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY}; use windows::Win32::System::Diagnostics::ToolHelp::{CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD, THREADENTRY32}; use windows::Win32::System::SystemInformation::GetSystemWindowsDirectoryW; use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcess, OpenProcessToken, OpenThread, ResumeThread, SuspendThread, PROCESS_QUERY_LIMITED_INFORMATION, THREAD_SUSPEND_RESUME}; use winreg::enums::{HKEY, HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE}; use winreg::RegKey;
-    pub struct AutorunRevertResult { pub removed_additions: usize, pub restored_entries: usize }
-    const RUN_KEYS: [(&str, HKEY, &str); 4] = [("HKCU", HKEY_CURRENT_USER, r"Software\Microsoft\Windows\CurrentVersion\Run"), ("HKLM", HKEY_LOCAL_MACHINE, r"Software\Microsoft\Windows\CurrentVersion\Run"), ("HKCU", HKEY_CURRENT_USER, r"Software\Microsoft\Windows\CurrentVersion\RunOnce"), ("HKLM", HKEY_LOCAL_MACHINE, r"Software\Microsoft\Windows\CurrentVersion\RunOnce")];
-    pub fn is_supported() -> bool { true }
-    pub fn is_elevated() -> bool { unsafe { let mut token = HANDLE::default(); if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token).is_err() { return false; } let mut elevation = TOKEN_ELEVATION::default(); let mut bytes = 0u32; let ok = GetTokenInformation(token, TokenElevation, Some((&mut elevation as *mut TOKEN_ELEVATION).cast()), std::mem::size_of::<TOKEN_ELEVATION>() as u32, &mut bytes).is_ok(); let _ = CloseHandle(token); ok && elevation.TokenIsElevated != 0 } }
-    pub fn process_exists(pid: u32) -> bool { unsafe { match OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) { Ok(handle) => { let _ = CloseHandle(handle); true } Err(_) => false } } }
-    pub fn snapshot_autoruns() -> Result<AutorunSnapshot, String> { let mut entries=Vec::new(); for (label,hive,key_path) in RUN_KEYS { let root=RegKey::predef(hive); let key=match root.open_subkey(key_path){Ok(k)=>k,Err(_)=>continue}; for item in key.enum_values(){ let Ok((name,_value))=item else {continue}; let value_data=key.get_value::<String,_>(&name).unwrap_or_default(); entries.push(AutorunEntry{hive:label.to_string(), key_path:key_path.to_string(), value_name:name, value_data}); } } entries.sort_by(|a,b| (&a.hive,&a.key_path,&a.value_name).cmp(&(&b.hive,&b.key_path,&b.value_name))); Ok(AutorunSnapshot{captured_at_unix:unix_now(), entries}) }
-    pub fn revert_autorun_changes(baseline:&[AutorunEntry])->Result<AutorunRevertResult,String>{ let current=snapshot_autoruns()?; let mut baseline_map:BTreeMap<(String,String,String),String>=BTreeMap::new(); for entry in baseline { baseline_map.insert((entry.hive.clone(), entry.key_path.clone(), entry.value_name.clone()), entry.value_data.clone()); } let mut current_map:BTreeMap<(String,String,String),String>=BTreeMap::new(); for entry in &current.entries { current_map.insert((entry.hive.clone(), entry.key_path.clone(), entry.value_name.clone()), entry.value_data.clone()); } let mut removed_additions=0usize; let mut restored_entries=0usize; for (label,hive,key_path) in RUN_KEYS { let root=RegKey::predef(hive); let key=match root.create_subkey(key_path){ Ok((k,_))=>k, Err(e)=>return Err(format!("failed to open autorun key {}\\{}: {e}", label,key_path))}; for ((entry_hive,entry_path,value_name), current_value) in current_map.iter(){ if entry_hive != label || entry_path != key_path { continue; } let lookup=(entry_hive.clone(), entry_path.clone(), value_name.clone()); if !baseline_map.contains_key(&lookup){ key.delete_value(value_name).map_err(|e| format!("failed to delete autorun value {}\\{}\\{}: {e}", label,key_path,value_name))?; removed_additions += 1; } else if baseline_map.get(&lookup) != Some(current_value) { let baseline_value=baseline_map.get(&lookup).cloned().unwrap_or_default(); key.set_value(value_name, &baseline_value).map_err(|e| format!("failed to restore autorun value {}\\{}\\{}: {e}", label,key_path,value_name))?; restored_entries += 1; } } for ((entry_hive,entry_path,value_name), baseline_value) in baseline_map.iter(){ if entry_hive != label || entry_path != key_path { continue; } let lookup=(entry_hive.clone(), entry_path.clone(), value_name.clone()); if !current_map.contains_key(&lookup){ key.set_value(value_name, baseline_value).map_err(|e| format!("failed to restore missing autorun value {}\\{}\\{}: {e}", label,key_path,value_name))?; restored_entries += 1; } } } Ok(AutorunRevertResult{removed_additions, restored_entries}) }
-    pub fn suspend_process(pid:u32)->Result<(),String>{ let snapshot=unsafe{ CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD,0).map_err(|e| format!("failed to snapshot threads for PID {pid}: {e}"))? }; if snapshot==INVALID_HANDLE_VALUE{ return Err(format!("failed to snapshot threads for PID {pid}")); } let mut entry=THREADENTRY32{ dwSize: std::mem::size_of::<THREADENTRY32>() as u32, ..Default::default() }; let mut success_count=0usize; let first=unsafe{ Thread32First(snapshot,&mut entry).as_bool() }; if first { loop { if entry.th32OwnerProcessID==pid { unsafe { if let Ok(thread)=OpenThread(THREAD_SUSPEND_RESUME,false,entry.th32ThreadID){ let result=SuspendThread(thread); let _=CloseHandle(thread); if result != u32::MAX { success_count += 1; } } } } if !unsafe{ Thread32Next(snapshot,&mut entry).as_bool() } { break; } } } let _=unsafe{ CloseHandle(snapshot) }; if success_count==0{ Err(format!("no suspendable threads were found for PID {pid}")) } else { Ok(()) } }
-    pub fn resume_process(pid:u32)->Result<(),String>{ let snapshot=unsafe{ CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD,0).map_err(|e| format!("failed to snapshot threads for PID {pid}: {e}"))? }; if snapshot==INVALID_HANDLE_VALUE{ return Err(format!("failed to snapshot threads for PID {pid}")); } let mut entry=THREADENTRY32{ dwSize: std::mem::size_of::<THREADENTRY32>() as u32, ..Default::default() }; let mut success_count=0usize; let first=unsafe{ Thread32First(snapshot,&mut entry).as_bool() }; if first { loop { if entry.th32OwnerProcessID==pid { unsafe { if let Ok(thread)=OpenThread(THREAD_SUSPEND_RESUME,false,entry.th32ThreadID){ let result=ResumeThread(thread); let _=CloseHandle(thread); if result != u32::MAX { success_count += 1; } } } } if !unsafe{ Thread32Next(snapshot,&mut entry).as_bool() } { break; } } } let _=unsafe{ CloseHandle(snapshot) }; if success_count==0{ Err(format!("no resumable threads were found for PID {pid}")) } else { Ok(()) } }
-    pub fn add_domain_block(domain:&str, marker:&str)->Result<(),String>{ let path=hosts_path()?; let existing=fs::read_to_string(&path).map_err(|e| format!("failed to read {}: {e}", path.display()))?; if existing.contains(marker){ return Ok(()); } let addition=format!("\r\n{marker}\r\n127.0.0.1 {domain}\r\n::1 {domain}\r\n"); fs::write(&path, format!("{existing}{addition}")).map_err(|e| format!("failed to update {}: {e}", path.display()))?; let _=flush_dns(); Ok(()) }
-    pub fn remove_domain_block(domain:&str, marker:&str)->Result<(),String>{ let path=hosts_path()?; let existing=fs::read_to_string(&path).map_err(|e| format!("failed to read {}: {e}", path.display()))?; let target_v4=format!("127.0.0.1 {domain}"); let target_v6=format!("::1 {domain}"); let mut lines=Vec::new(); let mut skipping=false; for line in existing.lines(){ let trimmed=line.trim(); if trimmed==marker{ skipping=true; continue; } if skipping && (trimmed==target_v4 || trimmed==target_v6){ continue; } if skipping && !trimmed.is_empty(){ skipping=false; } if !skipping || trimmed.is_empty(){ lines.push(line); } } fs::write(&path, lines.join("\r\n")).map_err(|e| format!("failed to update {}: {e}", path.display()))?; let _=flush_dns(); Ok(()) }
-    fn flush_dns()->Result<(),String>{ let status=Command::new("ipconfig").arg("/flushdns").status().map_err(|e| format!("failed to spawn ipconfig: {e}"))?; if status.success(){ Ok(()) } else { Err("ipconfig /flushdns failed".into()) } }
-    fn hosts_path()->Result<PathBuf,String>{ let windows_dir=windows_directory().ok_or_else(|| "failed to resolve the Windows directory".to_string())?; Ok(windows_dir.join("System32").join("drivers").join("etc").join("hosts")) }
-    fn windows_directory()->Option<PathBuf>{ let mut buffer=vec![0u16;260]; unsafe{ let len=GetSystemWindowsDirectoryW(Some(&mut buffer)); if len==0 { return None; } let len=len as usize; if len >= buffer.len(){ buffer.resize(len+1,0); let retry_len=GetSystemWindowsDirectoryW(Some(&mut buffer)); if retry_len==0{ return None; } return Some(PathBuf::from(String::from_utf16_lossy(&buffer[..retry_len as usize]))); } Some(PathBuf::from(String::from_utf16_lossy(&buffer[..len]))) } }
-    pub fn kill_tcp_connection(target:&SocketKillTarget)->Result<(),SocketKillError>{ let local=match target.local{ SocketAddr::V4(local)=>local, SocketAddr::V6(_)=>return Err(SocketKillError::UnsupportedAddressFamily) }; let remote=match target.remote{ SocketAddr::V4(remote)=>remote, SocketAddr::V6(_)=>return Err(SocketKillError::UnsupportedAddressFamily) }; let row=MIB_TCPROW{ dwState:MIB_TCP_STATE_DELETE_TCB, dwLocalAddr:u32::from_be_bytes(local.ip().octets()), dwLocalPort:u32::from(local.port().to_be()), dwRemoteAddr:u32::from_be_bytes(remote.ip().octets()), dwRemotePort:u32::from(remote.port().to_be()) }; let status=unsafe{ SetTcpEntry(&row) }; if status==NO_ERROR { Ok(()) } else if status==ERROR_ACCESS_DENIED.0 { Err(SocketKillError::PermissionDenied) } else { Err(SocketKillError::OsError(status)) } }
-    pub fn add_block_rule(rule_name:&str, target:&str)->Result<(),String>{ let status=Command::new("netsh").args(["advfirewall","firewall","add","rule",&format!("name={rule_name}"),"dir=out","action=block",&format!("remoteip={target}"),"profile=any","enable=yes"]).status().map_err(|e| format!("failed to spawn netsh: {e}"))?; if status.success(){ Ok(()) } else { Err(format!("failed to add firewall rule for {target}")) } }
-    pub fn add_block_all_rule(rule_name:&str, dir:&str)->Result<(),String>{ let status=Command::new("netsh").args(["advfirewall","firewall","add","rule",&format!("name={rule_name}"),&format!("dir={dir}"),"action=block","remoteip=any","profile=any","enable=yes"]).status().map_err(|e| format!("failed to spawn netsh: {e}"))?; if status.success(){ Ok(()) } else { Err(format!("failed to add isolation rule {rule_name}")) } }
-    pub fn add_block_program_rule(rule_name:&str, path:&str, dir:&str)->Result<(),String>{ let status=Command::new("netsh").args(["advfirewall","firewall","add","rule",&format!("name={rule_name}"),&format!("dir={dir}"),"action=block",&format!("program={path}"),"profile=any","enable=yes"]).status().map_err(|e| format!("failed to spawn netsh: {e}"))?; if status.success(){ Ok(()) } else { Err(format!("failed to add process firewall rule {rule_name}")) } }
-    pub fn delete_rule(rule_name:&str)->Result<(),String>{ let status=Command::new("netsh").args(["advfirewall","firewall","delete","rule",&format!("name={rule_name}")]).status().map_err(|e| format!("failed to spawn netsh: {e}"))?; if status.success(){ Ok(()) } else { Err(format!("failed to delete firewall rule {rule_name}")) } }
+pub fn reconcile() {
+    if !platform::is_supported() || !platform::is_elevated() {
+        return;
+    }
+    let Ok(mut state) = load_state() else {
+        return;
+    };
+    let now = unix_now();
+    let changed = reconcile_state(&mut state, now, |rule_name| {
+        platform::delete_rule(rule_name).is_ok()
+    });
+    if changed {
+        let _ = save_state(&state);
+    }
 }
-#[cfg(not(windows))] mod platform { use super::*; pub struct AutorunRevertResult { pub removed_additions: usize, pub restored_entries: usize } pub fn is_supported()->bool{false} pub fn is_elevated()->bool{false} pub fn process_exists(_pid:u32)->bool{false} pub fn snapshot_autoruns()->Result<AutorunSnapshot,String>{Err("Autorun freezing is not implemented on this platform.".into())} pub fn revert_autorun_changes(_baseline:&[AutorunEntry])->Result<AutorunRevertResult,String>{Err("Autorun revert is not implemented on this platform.".into())} pub fn suspend_process(_pid:u32)->Result<(),String>{Err("Process suspension is not implemented on this platform.".into())} pub fn resume_process(_pid:u32)->Result<(),String>{Err("Process resume is not implemented on this platform.".into())} pub fn add_domain_block(_domain:&str,_marker:&str)->Result<(),String>{Err("Domain blocking is not implemented on this platform.".into())} pub fn remove_domain_block(_domain:&str,_marker:&str)->Result<(),String>{Err("Domain blocking is not implemented on this platform.".into())} pub fn kill_tcp_connection(_target:&SocketKillTarget)->Result<(),SocketKillError>{Err(SocketKillError::PlatformUnsupported)} pub fn add_block_rule(_rule_name:&str,_target:&str)->Result<(),String>{Err("Active response is not implemented on this platform.".into())} pub fn add_block_all_rule(_rule_name:&str,_dir:&str)->Result<(),String>{Err("Active response is not implemented on this platform.".into())} pub fn add_block_program_rule(_rule_name:&str,_path:&str,_dir:&str)->Result<(),String>{Err("Active response is not implemented on this platform.".into())} pub fn delete_rule(_rule_name:&str)->Result<(),String>{Ok(())} }
+pub fn block_remote(target: &str, preset: DurationPreset) -> Result<String, String> {
+    ensure_modifiable()?;
+    let target = normalise_target(target)?;
+    let rule_name = rule_name_for_target(&target);
+    let expires_at_unix = preset
+        .ttl()
+        .map(|ttl| unix_now().saturating_add(ttl.as_secs()));
+    let _ = platform::delete_rule(&rule_name);
+    platform::add_block_rule(&rule_name, &target)?;
+    let mut state = load_state().unwrap_or_default();
+    state.blocked.retain(|rule| rule.target != target);
+    state.blocked.push(BlockedTarget {
+        target: target.clone(),
+        rule_name: rule_name.clone(),
+        expires_at_unix,
+    });
+    save_state(&state)?;
+    let message = match preset {
+        DurationPreset::OneHour => format!("Blocked {target} for 1 hour."),
+        DurationPreset::OneDay => format!("Blocked {target} for 24 hours."),
+        DurationPreset::Permanent => format!("Blocked {target} until removed."),
+    };
+    audit::record(
+        "block_remote",
+        "success",
+        json!({ "target": target, "duration": format!("{:?}", preset), "rule_name": rule_name }),
+    );
+    Ok(message)
+}
+pub fn unblock_remote(target: &str) -> Result<String, String> {
+    ensure_modifiable()?;
+    let target = normalise_target(target)?;
+    let mut state = load_state().unwrap_or_default();
+    let mut removed = 0usize;
+    let mut kept = Vec::with_capacity(state.blocked.len());
+    let mut delete_failed = false;
+    for rule in state.blocked.drain(..) {
+        if rule.target == target {
+            if platform::delete_rule(&rule.rule_name).is_ok() {
+                removed += 1;
+            } else {
+                delete_failed = true;
+                kept.push(rule);
+            }
+        } else {
+            kept.push(rule);
+        }
+    }
+    state.blocked = kept;
+    if delete_failed {
+        return Err(format!("Could not remove the firewall rule for {target}; it was kept in state so Vigil can retry."));
+    }
+    let message = if removed > 0 {
+        save_state(&state)?;
+        format!("Removed {removed} block rule(s) for {target}.")
+    } else {
+        format!("No active block rule found for {target}.")
+    };
+    audit::record(
+        "unblock_remote",
+        if removed > 0 { "success" } else { "noop" },
+        json!({ "target": target, "removed_rules": removed }),
+    );
+    Ok(message)
+}
+pub fn block_process(pid: u32, path: &str, preset: DurationPreset) -> Result<String, String> {
+    ensure_modifiable()?;
+    let path = normalise_target(path)?;
+    let rule_suffix = rule_suffix_for_process(&path);
+    let outbound_rule_name = format!("{PROCESS_BLOCK_RULE_PREFIX} Out {rule_suffix}");
+    let inbound_rule_name = format!("{PROCESS_BLOCK_RULE_PREFIX} In {rule_suffix}");
+    let expires_at_unix = preset
+        .ttl()
+        .map(|ttl| unix_now().saturating_add(ttl.as_secs()));
+    let _ = platform::delete_rule(&outbound_rule_name);
+    let _ = platform::delete_rule(&inbound_rule_name);
+    platform::add_block_program_rule(&outbound_rule_name, &path, "out")?;
+    if let Err(err) = platform::add_block_program_rule(&inbound_rule_name, &path, "in") {
+        let _ = platform::delete_rule(&outbound_rule_name);
+        return Err(err);
+    }
+    let mut state = load_state().unwrap_or_default();
+    state
+        .blocked_processes
+        .retain(|rule| !process_block_matches(rule, &path));
+    state.blocked_processes.push(BlockedProcess {
+        pid,
+        path: path.clone(),
+        inbound_rule_name: inbound_rule_name.clone(),
+        outbound_rule_name: outbound_rule_name.clone(),
+        expires_at_unix,
+    });
+    save_state(&state)?;
+    let message = match preset {
+        DurationPreset::OneHour => format!("Blocked {path} for 1 hour."),
+        DurationPreset::OneDay => format!("Blocked {path} for 24 hours."),
+        DurationPreset::Permanent => format!("Blocked {path} until removed."),
+    };
+    audit::record(
+        "block_process",
+        "success",
+        json!({ "pid": pid, "path": path, "duration": format!("{:?}", preset), "inbound_rule_name": inbound_rule_name, "outbound_rule_name": outbound_rule_name }),
+    );
+    Ok(message)
+}
+pub fn unblock_process(pid: u32, path: &str) -> Result<String, String> {
+    ensure_modifiable()?;
+    let path = normalise_target(path)?;
+    let mut state = load_state().unwrap_or_default();
+    let mut removed = 0usize;
+    let mut kept = Vec::with_capacity(state.blocked_processes.len());
+    let mut delete_failed = false;
+    for rule in state.blocked_processes.drain(..) {
+        if process_block_matches(&rule, &path) {
+            let inbound_deleted = platform::delete_rule(&rule.inbound_rule_name).is_ok();
+            let outbound_deleted = platform::delete_rule(&rule.outbound_rule_name).is_ok();
+            if inbound_deleted && outbound_deleted {
+                removed += 1;
+            } else {
+                delete_failed = true;
+                kept.push(rule);
+            }
+        } else {
+            kept.push(rule);
+        }
+    }
+    state.blocked_processes = kept;
+    if delete_failed {
+        return Err(format!("Could not remove the firewall rules for PID {pid} ({path}); they were kept in state so Vigil can retry."));
+    }
+    let message = if removed > 0 {
+        save_state(&state)?;
+        format!("Removed {removed} process block(s) for PID {pid} ({path}).")
+    } else {
+        format!("No active process block found for PID {pid} ({path}).")
+    };
+    audit::record(
+        "unblock_process",
+        if removed > 0 { "success" } else { "noop" },
+        json!({ "pid": pid, "path": path, "removed_rules": removed }),
+    );
+    Ok(message)
+}
 
-#[cfg(test)] mod tests { use super::*; fn blocked_target(target:&str, expires_at_unix:Option<u64>)->BlockedTarget{ BlockedTarget{ target:target.to_string(), rule_name:format!("rule-{target}"), expires_at_unix } } fn blocked_process(path:&str, expires_at_unix:Option<u64>)->BlockedProcess{ BlockedProcess{ pid:1234, path:path.to_string(), inbound_rule_name:format!("in-{path}"), outbound_rule_name:format!("out-{path}"), expires_at_unix } } fn blocked_domain(domain:&str)->BlockedDomain{ BlockedDomain{ domain:domain.to_string(), marker:domain_marker(domain) } } fn suspended_process(pid:u32, path:&str)->SuspendedProcess{ SuspendedProcess{ pid, path:path.to_string(), proc_name:"app.exe".into(), suspended_at_unix:10 } } fn conn(local:&str, remote:&str, status:&str)->ConnInfo{ ConnInfo{ timestamp:"12:00:00".into(), proc_name:"evil.exe".into(), pid:4242, proc_path:"C:/Temp/evil.exe".into(), proc_user:"user".into(), parent_name:"cmd.exe".into(), parent_pid:123, service_name:String::new(), publisher:String::new(), local_addr:local.into(), remote_addr:remote.into(), status:status.into(), score:9, reasons:vec!["test".into()], ancestor_chain:vec![("cmd.exe".into(),123)], pre_login:false, hostname:Some("c2.bad.example".into()), country:None, asn:None, asn_org:None, reputation_hit:None, recently_dropped:false, long_lived:false, dga_like:false } }
-#[test] fn reconcile_keeps_expired_entries_when_deletion_fails(){ let mut state=State{ blocked:vec![blocked_target("10.0.0.1",Some(10))], blocked_processes:vec![blocked_process("C:/app.exe",Some(10))], blocked_domains:vec![blocked_domain("bad.example")], suspended_processes:vec![suspended_process(1234,"C:/app.exe")], autorun_snapshot:None, isolated:false }; let changed=reconcile_state(&mut state,100, |_| false); assert!(!changed); assert_eq!(state.blocked.len(),1); assert_eq!(state.blocked_processes.len(),1); assert_eq!(state.blocked_domains.len(),1); }
-#[test] fn reconcile_removes_expired_entries_after_successful_deletion(){ let mut deleted=Vec::new(); let mut state=State{ blocked:vec![blocked_target("10.0.0.1",Some(10))], blocked_processes:vec![blocked_process("C:/app.exe",Some(10))], blocked_domains:vec![], suspended_processes:vec![], autorun_snapshot:None, isolated:false }; let changed=reconcile_state(&mut state,100, |rule| { deleted.push(rule.to_string()); true }); assert!(changed); assert!(state.blocked.is_empty()); assert!(state.blocked_processes.is_empty()); assert_eq!(deleted, vec!["rule-10.0.0.1".to_string(), "in-C:/app.exe".to_string(), "out-C:/app.exe".to_string()]); }
-#[test] fn process_blocks_match_by_path_only(){ let rule=BlockedProcess{ pid:1234, path:"C:/app.exe".into(), inbound_rule_name:"in".into(), outbound_rule_name:"out".into(), expires_at_unix:Some(200) }; assert!(process_block_matches(&rule,"C:/app.exe")); assert!(!process_block_matches(&rule,"C:/other.exe")); }
-#[test] fn suspended_processes_match_on_pid_and_optional_path(){ let entry=suspended_process(1234,"C:/app.exe"); assert!(suspended_process_matches(&entry,1234,"C:/app.exe")); assert!(suspended_process_matches(&entry,1234,"")); assert!(!suspended_process_matches(&entry,9999,"C:/app.exe")); }
-#[test] fn socket_kill_target_accepts_established_ipv4_connections(){ let parsed=socket_kill_target(&conn("192.168.1.10:50000","8.8.8.8:443","ESTABLISHED")).unwrap(); assert_eq!(parsed.local.to_string(),"192.168.1.10:50000"); assert_eq!(parsed.remote.to_string(),"8.8.8.8:443"); }
-#[test] fn socket_kill_target_rejects_listen_rows(){ let err=socket_kill_target(&conn("0.0.0.0:80","0.0.0.0:0","LISTEN")).unwrap_err(); assert!(matches!(err, SocketKillError::UnsupportedStatus(_))); }
-#[test] fn socket_kill_target_rejects_invalid_remote(){ let err=socket_kill_target(&conn("192.168.1.10:50000","not-an-endpoint","ESTABLISHED")).unwrap_err(); assert!(matches!(err, SocketKillError::InvalidRemoteAddr(_))); }
-#[test] fn socket_kill_target_rejects_ipv6_for_now(){ let err=socket_kill_target(&conn("[::1]:50000","[2606:4700:4700::1111]:443","ESTABLISHED")).unwrap_err(); assert!(matches!(err, SocketKillError::UnsupportedAddressFamily)); }
-#[test] fn extract_remote_target_supports_ipv4_and_ipv6(){ assert_eq!(extract_remote_target("8.8.8.8:443").as_deref(), Some("8.8.8.8")); assert_eq!(extract_remote_target("[2606:4700:4700::1111]:443").as_deref(), Some("2606:4700:4700::1111")); assert_eq!(extract_remote_target("2606:4700:4700::1111:443").as_deref(), Some("2606:4700:4700::1111")); }
-#[test] fn extract_domain_target_uses_hostname(){ let sample=conn("192.168.1.10:50000","8.8.8.8:443","ESTABLISHED"); assert_eq!(extract_domain_target(&sample).as_deref(), Some("c2.bad.example")); assert_eq!(extract_domain_from_hostname("8.8.8.8"), None); } }
+pub fn isolate_machine() -> Result<String, String> {
+    ensure_modifiable()?;
+    let _ = platform::delete_rule(ISOLATE_RULE_IN);
+    let _ = platform::delete_rule(ISOLATE_RULE_OUT);
+    platform::add_block_all_rule(ISOLATE_RULE_IN, "in")?;
+    platform::add_block_all_rule(ISOLATE_RULE_OUT, "out")?;
+    let mut state = load_state().unwrap_or_default();
+    state.isolated = true;
+    save_state(&state)?;
+    let cfg = crate::config::Config::load();
+    crate::break_glass::sync_watchdog(&cfg);
+    audit::record(
+        "isolate_machine",
+        "success",
+        json!({ "inbound_rule_name": ISOLATE_RULE_IN, "outbound_rule_name": ISOLATE_RULE_OUT }),
+    );
+    Ok("Network isolation enabled.".into())
+}
+pub fn restore_machine() -> Result<String, String> {
+    ensure_modifiable()?;
+    let in_deleted = platform::delete_rule(ISOLATE_RULE_IN).is_ok();
+    let out_deleted = platform::delete_rule(ISOLATE_RULE_OUT).is_ok();
+    if !(in_deleted && out_deleted) {
+        return Err(
+            "Could not remove all isolation firewall rules; the state was kept for retry.".into(),
+        );
+    }
+    let mut state = load_state().unwrap_or_default();
+    state.isolated = false;
+    save_state(&state)?;
+    let cfg = crate::config::Config::load();
+    crate::break_glass::sync_watchdog(&cfg);
+    audit::record("restore_machine", "success", json!({}));
+    Ok("Network isolation removed.".into())
+}
+
+pub fn is_blocked(target: &str) -> bool {
+    let Ok(target) = normalise_target(target) else {
+        return false;
+    };
+    load_state()
+        .ok()
+        .map(|state| state.blocked.iter().any(|r| r.target == target))
+        .unwrap_or(false)
+}
+pub fn is_domain_blocked(domain: &str) -> bool {
+    let Ok(domain) = normalise_domain(domain) else {
+        return false;
+    };
+    load_state()
+        .ok()
+        .map(|state| {
+            state
+                .blocked_domains
+                .iter()
+                .any(|entry| entry.domain == domain)
+        })
+        .unwrap_or(false)
+}
+pub fn remote_block_remaining(target: &str) -> Option<Duration> {
+    let target = normalise_target(target).ok()?;
+    let now = unix_now();
+    load_state()
+        .ok()
+        .and_then(|state| {
+            state
+                .blocked
+                .into_iter()
+                .find(|r| r.target == target)
+                .and_then(|rule| rule.expires_at_unix)
+        })
+        .and_then(|expires_at_unix| expires_at_unix.checked_sub(now))
+        .map(Duration::from_secs)
+}
+pub fn is_process_blocked(_pid: u32, path: &str) -> bool {
+    let Ok(path) = normalise_target(path) else {
+        return false;
+    };
+    load_state()
+        .ok()
+        .map(|state| {
+            state
+                .blocked_processes
+                .iter()
+                .any(|r| process_block_matches(r, &path))
+        })
+        .unwrap_or(false)
+}
+pub fn process_block_remaining(_pid: u32, path: &str) -> Option<Duration> {
+    let path = normalise_target(path).ok()?;
+    let now = unix_now();
+    load_state()
+        .ok()
+        .and_then(|state| {
+            state
+                .blocked_processes
+                .into_iter()
+                .find(|r| process_block_matches(r, &path))
+                .and_then(|rule| rule.expires_at_unix)
+        })
+        .and_then(|expires_at_unix| expires_at_unix.checked_sub(now))
+        .map(Duration::from_secs)
+}
+pub fn is_process_suspended(pid: u32, path: &str) -> bool {
+    load_state()
+        .ok()
+        .map(|state| {
+            state
+                .suspended_processes
+                .iter()
+                .any(|entry| suspended_process_matches(entry, pid, path))
+        })
+        .unwrap_or(false)
+}
+
+pub fn extract_remote_target(remote_addr: &str) -> Option<String> {
+    if let Ok(addr) = socket_addr_from_text(remote_addr) {
+        return Some(addr.ip().to_string());
+    }
+    let trimmed = remote_addr.trim();
+    let (host, port) = trimmed.rsplit_once(':')?;
+    if host.is_empty() || !port.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    let host = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+    if host.parse::<IpAddr>().is_ok() {
+        Some(host.to_string())
+    } else {
+        None
+    }
+}
+pub fn extract_domain_target(conn: &ConnInfo) -> Option<String> {
+    conn.hostname
+        .as_deref()
+        .and_then(extract_domain_from_hostname)
+}
+pub fn extract_domain_from_hostname(hostname: &str) -> Option<String> {
+    let host = hostname.trim().trim_end_matches('.').to_ascii_lowercase();
+    if host.is_empty() || host.parse::<IpAddr>().is_ok() || !host.contains('.') {
+        return None;
+    }
+    if host
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-')
+    {
+        Some(host)
+    } else {
+        None
+    }
+}
+
+fn ensure_modifiable() -> Result<(), String> {
+    if !platform::is_supported() {
+        return Err("Active response is currently only implemented on Windows.".into());
+    }
+    if !platform::is_elevated() {
+        return Err("Administrator privileges are required for active response.".into());
+    }
+    Ok(())
+}
+fn socket_kill_target(conn: &ConnInfo) -> Result<SocketKillTarget, SocketKillError> {
+    if !conn.status.eq_ignore_ascii_case("ESTABLISHED")
+        && !conn.status.eq_ignore_ascii_case("SYN_SENT")
+        && !conn.status.eq_ignore_ascii_case("SYN_RECEIVED")
+        && !conn.status.eq_ignore_ascii_case("FIN_WAIT_1")
+        && !conn.status.eq_ignore_ascii_case("FIN_WAIT_2")
+        && !conn.status.eq_ignore_ascii_case("CLOSE_WAIT")
+        && !conn.status.eq_ignore_ascii_case("CLOSING")
+        && !conn.status.eq_ignore_ascii_case("LAST_ACK")
+        && !conn.status.eq_ignore_ascii_case("TIME_WAIT")
+    {
+        return Err(SocketKillError::UnsupportedStatus(conn.status.clone()));
+    }
+    let local = socket_addr_from_text(&conn.local_addr)
+        .map_err(|_| SocketKillError::InvalidLocalAddr(conn.local_addr.clone()))?;
+    let remote = socket_addr_from_text(&conn.remote_addr)
+        .map_err(|_| SocketKillError::InvalidRemoteAddr(conn.remote_addr.clone()))?;
+    match (local.ip(), remote.ip()) {
+        (IpAddr::V4(_), IpAddr::V4(_)) => Ok(SocketKillTarget { local, remote }),
+        _ => Err(SocketKillError::UnsupportedAddressFamily),
+    }
+}
+fn socket_addr_from_text(text: &str) -> Result<SocketAddr, std::net::AddrParseError> {
+    text.trim().parse::<SocketAddr>()
+}
+fn normalise_target(target: &str) -> Result<String, String> {
+    let target = target.trim();
+    if target.is_empty() {
+        Err("Target cannot be empty.".into())
+    } else {
+        Ok(target.to_string())
+    }
+}
+fn normalise_domain(domain: &str) -> Result<String, String> {
+    extract_domain_from_hostname(domain).ok_or_else(|| "Domain is empty or invalid.".into())
+}
+fn process_block_matches(rule: &BlockedProcess, path: &str) -> bool {
+    rule.path == path
+}
+fn suspended_process_matches(entry: &SuspendedProcess, pid: u32, path: &str) -> bool {
+    entry.pid == pid && (path.is_empty() || entry.path == path)
+}
+fn domain_marker(domain: &str) -> String {
+    format!("{DOMAIN_MARKER_PREFIX}:{}", sanitise_rule_suffix(domain))
+}
+fn rule_name_for_target(target: &str) -> String {
+    format!("{BLOCK_RULE_PREFIX} {}", sanitise_rule_suffix(target))
+}
+fn rule_suffix_for_process(path: &str) -> String {
+    let base = std::path::Path::new(path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("process");
+    format!("{}-{:016x}", sanitise_rule_suffix(base), stable_hash(path))
+}
+fn sanitise_rule_suffix(text: &str) -> String {
+    text.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+fn stable_hash(text: &str) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64;
+    for b in text.as_bytes() {
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+fn state_path() -> PathBuf {
+    crate::config::data_dir().join(STATE_FILE)
+}
+fn load_state() -> Result<State, String> {
+    let path = state_path();
+    if !path.exists() {
+        return Ok(State::default());
+    }
+    let text = std::fs::read_to_string(&path)
+        .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    serde_json::from_str(&text).map_err(|e| format!("failed to parse {}: {e}", path.display()))
+}
+fn save_state(state: &State) -> Result<(), String> {
+    let path = state_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
+    }
+    let json = serde_json::to_string_pretty(state)
+        .map_err(|e| format!("failed to serialise active-response state: {e}"))?;
+    std::fs::write(&path, json).map_err(|e| format!("failed to write {}: {e}", path.display()))
+}
+fn reconcile_state<F>(state: &mut State, now: u64, mut delete_rule: F) -> bool
+where
+    F: FnMut(&str) -> bool,
+{
+    let mut changed = false;
+    state.blocked.retain(|rule| {
+        let expired = rule.expires_at_unix.is_some_and(|ts| ts <= now);
+        if expired {
+            if delete_rule(&rule.rule_name) {
+                changed = true;
+                false
+            } else {
+                true
+            }
+        } else {
+            true
+        }
+    });
+    state.blocked_processes.retain(|rule| {
+        let expired = rule.expires_at_unix.is_some_and(|ts| ts <= now);
+        if expired {
+            let inbound_deleted = delete_rule(&rule.inbound_rule_name);
+            let outbound_deleted = delete_rule(&rule.outbound_rule_name);
+            if inbound_deleted && outbound_deleted {
+                changed = true;
+                false
+            } else {
+                true
+            }
+        } else {
+            true
+        }
+    });
+    state.suspended_processes.retain(|entry| {
+        if platform::process_exists(entry.pid) {
+            true
+        } else {
+            changed = true;
+            false
+        }
+    });
+    changed
+}
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(windows)]
+mod platform {
+    use super::*;
+    use std::collections::BTreeMap;
+    use std::fs;
+    use windows::Win32::Foundation::{
+        CloseHandle, ERROR_ACCESS_DENIED, HANDLE, INVALID_HANDLE_VALUE, NO_ERROR,
+    };
+    use windows::Win32::NetworkManagement::IpHelper::{
+        SetTcpEntry, MIB_TCPROW_LH, MIB_TCPROW_LH_0, MIB_TCP_STATE_DELETE_TCB,
+    };
+    use windows::Win32::Security::{
+        GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY,
+    };
+    use windows::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD, THREADENTRY32,
+    };
+    use windows::Win32::System::SystemInformation::GetSystemWindowsDirectoryW;
+    use windows::Win32::System::Threading::{
+        GetCurrentProcess, OpenProcess, OpenProcessToken, OpenThread, ResumeThread, SuspendThread,
+        PROCESS_QUERY_LIMITED_INFORMATION, THREAD_SUSPEND_RESUME,
+    };
+    use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE};
+    use winreg::{RegKey, HKEY};
+    pub struct AutorunRevertResult {
+        pub removed_additions: usize,
+        pub restored_entries: usize,
+    }
+    const RUN_KEYS: [(&str, HKEY, &str); 4] = [
+        (
+            "HKCU",
+            HKEY_CURRENT_USER,
+            r"Software\Microsoft\Windows\CurrentVersion\Run",
+        ),
+        (
+            "HKLM",
+            HKEY_LOCAL_MACHINE,
+            r"Software\Microsoft\Windows\CurrentVersion\Run",
+        ),
+        (
+            "HKCU",
+            HKEY_CURRENT_USER,
+            r"Software\Microsoft\Windows\CurrentVersion\RunOnce",
+        ),
+        (
+            "HKLM",
+            HKEY_LOCAL_MACHINE,
+            r"Software\Microsoft\Windows\CurrentVersion\RunOnce",
+        ),
+    ];
+    pub fn is_supported() -> bool {
+        true
+    }
+    pub fn is_elevated() -> bool {
+        unsafe {
+            let mut token = HANDLE::default();
+            if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token).is_err() {
+                return false;
+            }
+            let mut elevation = TOKEN_ELEVATION::default();
+            let mut bytes = 0u32;
+            let ok = GetTokenInformation(
+                token,
+                TokenElevation,
+                Some((&mut elevation as *mut TOKEN_ELEVATION).cast()),
+                std::mem::size_of::<TOKEN_ELEVATION>() as u32,
+                &mut bytes,
+            )
+            .is_ok();
+            let _ = CloseHandle(token);
+            ok && elevation.TokenIsElevated != 0
+        }
+    }
+    pub fn process_exists(pid: u32) -> bool {
+        unsafe {
+            match OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) {
+                Ok(handle) => {
+                    let _ = CloseHandle(handle);
+                    true
+                }
+                Err(_) => false,
+            }
+        }
+    }
+    pub fn snapshot_autoruns() -> Result<AutorunSnapshot, String> {
+        let mut entries = Vec::new();
+        for (label, hive, key_path) in RUN_KEYS {
+            let root = RegKey::predef(hive);
+            let key = match root.open_subkey(key_path) {
+                Ok(k) => k,
+                Err(_) => continue,
+            };
+            for item in key.enum_values() {
+                let Ok((name, _value)) = item else { continue };
+                let value_data = key.get_value::<String, _>(&name).unwrap_or_default();
+                entries.push(AutorunEntry {
+                    hive: label.to_string(),
+                    key_path: key_path.to_string(),
+                    value_name: name,
+                    value_data,
+                });
+            }
+        }
+        entries.sort_by(|a, b| {
+            (&a.hive, &a.key_path, &a.value_name).cmp(&(&b.hive, &b.key_path, &b.value_name))
+        });
+        Ok(AutorunSnapshot {
+            captured_at_unix: unix_now(),
+            entries,
+        })
+    }
+    pub fn revert_autorun_changes(
+        baseline: &[AutorunEntry],
+    ) -> Result<AutorunRevertResult, String> {
+        let current = snapshot_autoruns()?;
+        let mut baseline_map: BTreeMap<(String, String, String), String> = BTreeMap::new();
+        for entry in baseline {
+            baseline_map.insert(
+                (
+                    entry.hive.clone(),
+                    entry.key_path.clone(),
+                    entry.value_name.clone(),
+                ),
+                entry.value_data.clone(),
+            );
+        }
+        let mut current_map: BTreeMap<(String, String, String), String> = BTreeMap::new();
+        for entry in &current.entries {
+            current_map.insert(
+                (
+                    entry.hive.clone(),
+                    entry.key_path.clone(),
+                    entry.value_name.clone(),
+                ),
+                entry.value_data.clone(),
+            );
+        }
+        let mut removed_additions = 0usize;
+        let mut restored_entries = 0usize;
+        for (label, hive, key_path) in RUN_KEYS {
+            let root = RegKey::predef(hive);
+            let key = match root.create_subkey(key_path) {
+                Ok((k, _)) => k,
+                Err(e) => {
+                    return Err(format!(
+                        "failed to open autorun key {}\\{}: {e}",
+                        label, key_path
+                    ))
+                }
+            };
+            for ((entry_hive, entry_path, value_name), current_value) in current_map.iter() {
+                if entry_hive != label || entry_path != key_path {
+                    continue;
+                }
+                let lookup = (entry_hive.clone(), entry_path.clone(), value_name.clone());
+                if !baseline_map.contains_key(&lookup) {
+                    key.delete_value(value_name).map_err(|e| {
+                        format!(
+                            "failed to delete autorun value {}\\{}\\{}: {e}",
+                            label, key_path, value_name
+                        )
+                    })?;
+                    removed_additions += 1;
+                } else if baseline_map.get(&lookup) != Some(current_value) {
+                    let baseline_value = baseline_map.get(&lookup).cloned().unwrap_or_default();
+                    key.set_value(value_name, &baseline_value).map_err(|e| {
+                        format!(
+                            "failed to restore autorun value {}\\{}\\{}: {e}",
+                            label, key_path, value_name
+                        )
+                    })?;
+                    restored_entries += 1;
+                }
+            }
+            for ((entry_hive, entry_path, value_name), baseline_value) in baseline_map.iter() {
+                if entry_hive != label || entry_path != key_path {
+                    continue;
+                }
+                let lookup = (entry_hive.clone(), entry_path.clone(), value_name.clone());
+                if !current_map.contains_key(&lookup) {
+                    key.set_value(value_name, baseline_value).map_err(|e| {
+                        format!(
+                            "failed to restore missing autorun value {}\\{}\\{}: {e}",
+                            label, key_path, value_name
+                        )
+                    })?;
+                    restored_entries += 1;
+                }
+            }
+        }
+        Ok(AutorunRevertResult {
+            removed_additions,
+            restored_entries,
+        })
+    }
+    pub fn suspend_process(pid: u32) -> Result<(), String> {
+        let snapshot = unsafe {
+            CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0)
+                .map_err(|e| format!("failed to snapshot threads for PID {pid}: {e}"))?
+        };
+        if snapshot == INVALID_HANDLE_VALUE {
+            return Err(format!("failed to snapshot threads for PID {pid}"));
+        }
+        let mut entry = THREADENTRY32 {
+            dwSize: std::mem::size_of::<THREADENTRY32>() as u32,
+            ..Default::default()
+        };
+        let mut success_count = 0usize;
+        let first = unsafe { Thread32First(snapshot, &mut entry).is_ok() };
+        if first {
+            loop {
+                if entry.th32OwnerProcessID == pid {
+                    unsafe {
+                        if let Ok(thread) =
+                            OpenThread(THREAD_SUSPEND_RESUME, false, entry.th32ThreadID)
+                        {
+                            let result = SuspendThread(thread);
+                            let _ = CloseHandle(thread);
+                            if result != u32::MAX {
+                                success_count += 1;
+                            }
+                        }
+                    }
+                }
+                if unsafe { Thread32Next(snapshot, &mut entry).is_err() } {
+                    break;
+                }
+            }
+        }
+        let _ = unsafe { CloseHandle(snapshot) };
+        if success_count == 0 {
+            Err(format!("no suspendable threads were found for PID {pid}"))
+        } else {
+            Ok(())
+        }
+    }
+    pub fn resume_process(pid: u32) -> Result<(), String> {
+        let snapshot = unsafe {
+            CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0)
+                .map_err(|e| format!("failed to snapshot threads for PID {pid}: {e}"))?
+        };
+        if snapshot == INVALID_HANDLE_VALUE {
+            return Err(format!("failed to snapshot threads for PID {pid}"));
+        }
+        let mut entry = THREADENTRY32 {
+            dwSize: std::mem::size_of::<THREADENTRY32>() as u32,
+            ..Default::default()
+        };
+        let mut success_count = 0usize;
+        let first = unsafe { Thread32First(snapshot, &mut entry).is_ok() };
+        if first {
+            loop {
+                if entry.th32OwnerProcessID == pid {
+                    unsafe {
+                        if let Ok(thread) =
+                            OpenThread(THREAD_SUSPEND_RESUME, false, entry.th32ThreadID)
+                        {
+                            let result = ResumeThread(thread);
+                            let _ = CloseHandle(thread);
+                            if result != u32::MAX {
+                                success_count += 1;
+                            }
+                        }
+                    }
+                }
+                if unsafe { Thread32Next(snapshot, &mut entry).is_err() } {
+                    break;
+                }
+            }
+        }
+        let _ = unsafe { CloseHandle(snapshot) };
+        if success_count == 0 {
+            Err(format!("no resumable threads were found for PID {pid}"))
+        } else {
+            Ok(())
+        }
+    }
+    pub fn add_domain_block(domain: &str, marker: &str) -> Result<(), String> {
+        let path = hosts_path()?;
+        let existing = fs::read_to_string(&path)
+            .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+        if existing.contains(marker) {
+            return Ok(());
+        }
+        let addition = format!("\r\n{marker}\r\n127.0.0.1 {domain}\r\n::1 {domain}\r\n");
+        fs::write(&path, format!("{existing}{addition}"))
+            .map_err(|e| format!("failed to update {}: {e}", path.display()))?;
+        let _ = flush_dns();
+        Ok(())
+    }
+    pub fn remove_domain_block(domain: &str, marker: &str) -> Result<(), String> {
+        let path = hosts_path()?;
+        let existing = fs::read_to_string(&path)
+            .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+        let target_v4 = format!("127.0.0.1 {domain}");
+        let target_v6 = format!("::1 {domain}");
+        let mut lines = Vec::new();
+        let mut skipping = false;
+        for line in existing.lines() {
+            let trimmed = line.trim();
+            if trimmed == marker {
+                skipping = true;
+                continue;
+            }
+            if skipping && (trimmed == target_v4 || trimmed == target_v6) {
+                continue;
+            }
+            if skipping && !trimmed.is_empty() {
+                skipping = false;
+            }
+            if !skipping || trimmed.is_empty() {
+                lines.push(line);
+            }
+        }
+        fs::write(&path, lines.join("\r\n"))
+            .map_err(|e| format!("failed to update {}: {e}", path.display()))?;
+        let _ = flush_dns();
+        Ok(())
+    }
+    fn flush_dns() -> Result<(), String> {
+        let status = Command::new("ipconfig")
+            .arg("/flushdns")
+            .status()
+            .map_err(|e| format!("failed to spawn ipconfig: {e}"))?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err("ipconfig /flushdns failed".into())
+        }
+    }
+    fn hosts_path() -> Result<PathBuf, String> {
+        let windows_dir = windows_directory()
+            .ok_or_else(|| "failed to resolve the Windows directory".to_string())?;
+        Ok(windows_dir
+            .join("System32")
+            .join("drivers")
+            .join("etc")
+            .join("hosts"))
+    }
+    fn windows_directory() -> Option<PathBuf> {
+        let mut buffer = vec![0u16; 260];
+        unsafe {
+            let len = GetSystemWindowsDirectoryW(Some(&mut buffer));
+            if len == 0 {
+                return None;
+            }
+            let len = len as usize;
+            if len >= buffer.len() {
+                buffer.resize(len + 1, 0);
+                let retry_len = GetSystemWindowsDirectoryW(Some(&mut buffer));
+                if retry_len == 0 {
+                    return None;
+                }
+                return Some(PathBuf::from(String::from_utf16_lossy(
+                    &buffer[..retry_len as usize],
+                )));
+            }
+            Some(PathBuf::from(String::from_utf16_lossy(&buffer[..len])))
+        }
+    }
+    pub fn kill_tcp_connection(target: &SocketKillTarget) -> Result<(), SocketKillError> {
+        let local = match target.local {
+            SocketAddr::V4(local) => local,
+            SocketAddr::V6(_) => return Err(SocketKillError::UnsupportedAddressFamily),
+        };
+        let remote = match target.remote {
+            SocketAddr::V4(remote) => remote,
+            SocketAddr::V6(_) => return Err(SocketKillError::UnsupportedAddressFamily),
+        };
+        let row = MIB_TCPROW_LH {
+            Anonymous: MIB_TCPROW_LH_0 {
+                State: MIB_TCP_STATE_DELETE_TCB,
+            },
+            dwLocalAddr: u32::from_be_bytes(local.ip().octets()),
+            dwLocalPort: u32::from(local.port().to_be()),
+            dwRemoteAddr: u32::from_be_bytes(remote.ip().octets()),
+            dwRemotePort: u32::from(remote.port().to_be()),
+        };
+        let status = unsafe { SetTcpEntry(&row) };
+        if status == NO_ERROR.0 {
+            Ok(())
+        } else if status == ERROR_ACCESS_DENIED.0 {
+            Err(SocketKillError::PermissionDenied)
+        } else {
+            Err(SocketKillError::OsError(status))
+        }
+    }
+    pub fn add_block_rule(rule_name: &str, target: &str) -> Result<(), String> {
+        let status = Command::new("netsh")
+            .args([
+                "advfirewall",
+                "firewall",
+                "add",
+                "rule",
+                &format!("name={rule_name}"),
+                "dir=out",
+                "action=block",
+                &format!("remoteip={target}"),
+                "profile=any",
+                "enable=yes",
+            ])
+            .status()
+            .map_err(|e| format!("failed to spawn netsh: {e}"))?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(format!("failed to add firewall rule for {target}"))
+        }
+    }
+    pub fn add_block_all_rule(rule_name: &str, dir: &str) -> Result<(), String> {
+        let status = Command::new("netsh")
+            .args([
+                "advfirewall",
+                "firewall",
+                "add",
+                "rule",
+                &format!("name={rule_name}"),
+                &format!("dir={dir}"),
+                "action=block",
+                "remoteip=any",
+                "profile=any",
+                "enable=yes",
+            ])
+            .status()
+            .map_err(|e| format!("failed to spawn netsh: {e}"))?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(format!("failed to add isolation rule {rule_name}"))
+        }
+    }
+    pub fn add_block_program_rule(rule_name: &str, path: &str, dir: &str) -> Result<(), String> {
+        let status = Command::new("netsh")
+            .args([
+                "advfirewall",
+                "firewall",
+                "add",
+                "rule",
+                &format!("name={rule_name}"),
+                &format!("dir={dir}"),
+                "action=block",
+                &format!("program={path}"),
+                "profile=any",
+                "enable=yes",
+            ])
+            .status()
+            .map_err(|e| format!("failed to spawn netsh: {e}"))?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(format!("failed to add process firewall rule {rule_name}"))
+        }
+    }
+    pub fn delete_rule(rule_name: &str) -> Result<(), String> {
+        let status = Command::new("netsh")
+            .args([
+                "advfirewall",
+                "firewall",
+                "delete",
+                "rule",
+                &format!("name={rule_name}"),
+            ])
+            .status()
+            .map_err(|e| format!("failed to spawn netsh: {e}"))?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(format!("failed to delete firewall rule {rule_name}"))
+        }
+    }
+}
+#[cfg(not(windows))]
+mod platform {
+    use super::*;
+    pub struct AutorunRevertResult {
+        pub removed_additions: usize,
+        pub restored_entries: usize,
+    }
+    pub fn is_supported() -> bool {
+        false
+    }
+    pub fn is_elevated() -> bool {
+        false
+    }
+    pub fn process_exists(_pid: u32) -> bool {
+        false
+    }
+    pub fn snapshot_autoruns() -> Result<AutorunSnapshot, String> {
+        Err("Autorun freezing is not implemented on this platform.".into())
+    }
+    pub fn revert_autorun_changes(
+        _baseline: &[AutorunEntry],
+    ) -> Result<AutorunRevertResult, String> {
+        Err("Autorun revert is not implemented on this platform.".into())
+    }
+    pub fn suspend_process(_pid: u32) -> Result<(), String> {
+        Err("Process suspension is not implemented on this platform.".into())
+    }
+    pub fn resume_process(_pid: u32) -> Result<(), String> {
+        Err("Process resume is not implemented on this platform.".into())
+    }
+    pub fn add_domain_block(_domain: &str, _marker: &str) -> Result<(), String> {
+        Err("Domain blocking is not implemented on this platform.".into())
+    }
+    pub fn remove_domain_block(_domain: &str, _marker: &str) -> Result<(), String> {
+        Err("Domain blocking is not implemented on this platform.".into())
+    }
+    pub fn kill_tcp_connection(_target: &SocketKillTarget) -> Result<(), SocketKillError> {
+        Err(SocketKillError::PlatformUnsupported)
+    }
+    pub fn add_block_rule(_rule_name: &str, _target: &str) -> Result<(), String> {
+        Err("Active response is not implemented on this platform.".into())
+    }
+    pub fn add_block_all_rule(_rule_name: &str, _dir: &str) -> Result<(), String> {
+        Err("Active response is not implemented on this platform.".into())
+    }
+    pub fn add_block_program_rule(_rule_name: &str, _path: &str, _dir: &str) -> Result<(), String> {
+        Err("Active response is not implemented on this platform.".into())
+    }
+    pub fn delete_rule(_rule_name: &str) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn blocked_target(target: &str, expires_at_unix: Option<u64>) -> BlockedTarget {
+        BlockedTarget {
+            target: target.to_string(),
+            rule_name: format!("rule-{target}"),
+            expires_at_unix,
+        }
+    }
+    fn blocked_process(path: &str, expires_at_unix: Option<u64>) -> BlockedProcess {
+        BlockedProcess {
+            pid: 1234,
+            path: path.to_string(),
+            inbound_rule_name: format!("in-{path}"),
+            outbound_rule_name: format!("out-{path}"),
+            expires_at_unix,
+        }
+    }
+    fn blocked_domain(domain: &str) -> BlockedDomain {
+        BlockedDomain {
+            domain: domain.to_string(),
+            marker: domain_marker(domain),
+        }
+    }
+    fn suspended_process(pid: u32, path: &str) -> SuspendedProcess {
+        SuspendedProcess {
+            pid,
+            path: path.to_string(),
+            proc_name: "app.exe".into(),
+            suspended_at_unix: 10,
+        }
+    }
+    fn conn(local: &str, remote: &str, status: &str) -> ConnInfo {
+        ConnInfo {
+            timestamp: "12:00:00".into(),
+            proc_name: "evil.exe".into(),
+            pid: 4242,
+            proc_path: "C:/Temp/evil.exe".into(),
+            proc_user: "user".into(),
+            parent_name: "cmd.exe".into(),
+            parent_pid: 123,
+            service_name: String::new(),
+            publisher: String::new(),
+            local_addr: local.into(),
+            remote_addr: remote.into(),
+            status: status.into(),
+            score: 9,
+            reasons: vec!["test".into()],
+            ancestor_chain: vec![("cmd.exe".into(), 123)],
+            pre_login: false,
+            hostname: Some("c2.bad.example".into()),
+            country: None,
+            asn: None,
+            asn_org: None,
+            reputation_hit: None,
+            recently_dropped: false,
+            long_lived: false,
+            dga_like: false,
+        }
+    }
+    #[test]
+    fn reconcile_keeps_expired_entries_when_deletion_fails() {
+        let mut state = State {
+            blocked: vec![blocked_target("10.0.0.1", Some(10))],
+            blocked_processes: vec![blocked_process("C:/app.exe", Some(10))],
+            blocked_domains: vec![blocked_domain("bad.example")],
+            suspended_processes: vec![],
+            autorun_snapshot: None,
+            isolated: false,
+        };
+        let changed = reconcile_state(&mut state, 100, |_| false);
+        assert!(!changed);
+        assert_eq!(state.blocked.len(), 1);
+        assert_eq!(state.blocked_processes.len(), 1);
+        assert_eq!(state.blocked_domains.len(), 1);
+    }
+    #[test]
+    fn reconcile_removes_expired_entries_after_successful_deletion() {
+        let mut deleted = Vec::new();
+        let mut state = State {
+            blocked: vec![blocked_target("10.0.0.1", Some(10))],
+            blocked_processes: vec![blocked_process("C:/app.exe", Some(10))],
+            blocked_domains: vec![],
+            suspended_processes: vec![],
+            autorun_snapshot: None,
+            isolated: false,
+        };
+        let changed = reconcile_state(&mut state, 100, |rule| {
+            deleted.push(rule.to_string());
+            true
+        });
+        assert!(changed);
+        assert!(state.blocked.is_empty());
+        assert!(state.blocked_processes.is_empty());
+        assert_eq!(
+            deleted,
+            vec![
+                "rule-10.0.0.1".to_string(),
+                "in-C:/app.exe".to_string(),
+                "out-C:/app.exe".to_string()
+            ]
+        );
+    }
+    #[test]
+    fn process_blocks_match_by_path_only() {
+        let rule = BlockedProcess {
+            pid: 1234,
+            path: "C:/app.exe".into(),
+            inbound_rule_name: "in".into(),
+            outbound_rule_name: "out".into(),
+            expires_at_unix: Some(200),
+        };
+        assert!(process_block_matches(&rule, "C:/app.exe"));
+        assert!(!process_block_matches(&rule, "C:/other.exe"));
+    }
+    #[test]
+    fn suspended_processes_match_on_pid_and_optional_path() {
+        let entry = suspended_process(1234, "C:/app.exe");
+        assert!(suspended_process_matches(&entry, 1234, "C:/app.exe"));
+        assert!(suspended_process_matches(&entry, 1234, ""));
+        assert!(!suspended_process_matches(&entry, 9999, "C:/app.exe"));
+    }
+    #[test]
+    fn socket_kill_target_accepts_established_ipv4_connections() {
+        let parsed =
+            socket_kill_target(&conn("192.168.1.10:50000", "8.8.8.8:443", "ESTABLISHED")).unwrap();
+        assert_eq!(parsed.local.to_string(), "192.168.1.10:50000");
+        assert_eq!(parsed.remote.to_string(), "8.8.8.8:443");
+    }
+    #[test]
+    fn socket_kill_target_rejects_listen_rows() {
+        let err = socket_kill_target(&conn("0.0.0.0:80", "0.0.0.0:0", "LISTEN")).unwrap_err();
+        assert!(matches!(err, SocketKillError::UnsupportedStatus(_)));
+    }
+    #[test]
+    fn socket_kill_target_rejects_invalid_remote() {
+        let err = socket_kill_target(&conn(
+            "192.168.1.10:50000",
+            "not-an-endpoint",
+            "ESTABLISHED",
+        ))
+        .unwrap_err();
+        assert!(matches!(err, SocketKillError::InvalidRemoteAddr(_)));
+    }
+    #[test]
+    fn socket_kill_target_rejects_ipv6_for_now() {
+        let err = socket_kill_target(&conn(
+            "[::1]:50000",
+            "[2606:4700:4700::1111]:443",
+            "ESTABLISHED",
+        ))
+        .unwrap_err();
+        assert!(matches!(err, SocketKillError::UnsupportedAddressFamily));
+    }
+    #[test]
+    fn extract_remote_target_supports_ipv4_and_ipv6() {
+        assert_eq!(
+            extract_remote_target("8.8.8.8:443").as_deref(),
+            Some("8.8.8.8")
+        );
+        assert_eq!(
+            extract_remote_target("[2606:4700:4700::1111]:443").as_deref(),
+            Some("2606:4700:4700::1111")
+        );
+        assert_eq!(
+            extract_remote_target("2606:4700:4700::1111:443").as_deref(),
+            Some("2606:4700:4700::1111")
+        );
+    }
+    #[test]
+    fn extract_domain_target_uses_hostname() {
+        let sample = conn("192.168.1.10:50000", "8.8.8.8:443", "ESTABLISHED");
+        assert_eq!(
+            extract_domain_target(&sample).as_deref(),
+            Some("c2.bad.example")
+        );
+        assert_eq!(extract_domain_from_hostname("8.8.8.8"), None);
+    }
+}

--- a/src/auto_response.rs
+++ b/src/auto_response.rs
@@ -10,7 +10,11 @@
 //! - allowlist-only mode can optionally force-block newly observed traffic from
 //!   processes outside the trusted list / operator allowlist.
 
-use crate::{active_response, audit, config::{normalise_name, Config}, types::ConnInfo};
+use crate::{
+    active_response, audit,
+    config::{normalise_name, Config},
+    types::ConnInfo,
+};
 use serde_json::json;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
@@ -22,86 +26,179 @@ pub struct EngineState {
 }
 
 #[derive(Debug, Clone, Copy)]
-struct OffenceState { count: u8, last_seen: Instant }
+struct OffenceState {
+    count: u8,
+    last_seen: Instant,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PlannedAction {
     KillConnection,
-    BlockRemote { target: String, preset: active_response::DurationPreset },
-    BlockProcess { pid: u32, path: String, preset: active_response::DurationPreset },
+    BlockRemote {
+        target: String,
+        preset: active_response::DurationPreset,
+    },
+    BlockProcess {
+        pid: u32,
+        path: String,
+        preset: active_response::DurationPreset,
+    },
 }
 
 pub fn maybe_apply(conn: &ConnInfo, cfg: &Config, state: &mut EngineState) -> Option<String> {
     let action = plan(conn, cfg, state)?;
     let cooldown = Duration::from_secs(cfg.auto_response_cooldown_secs.max(1));
-    if !state.try_acquire(cooldown_key(&action, conn), cooldown) { return None; }
+    if !state.try_acquire(cooldown_key(&action, conn), cooldown) {
+        return None;
+    }
     let summary = describe_action(&action, conn);
 
-    let dry_run = cfg.auto_response_dry_run || (cfg.allowlist_mode_enabled && cfg.allowlist_mode_dry_run && is_allowlist_enforcement(&action, conn, cfg));
+    let dry_run = cfg.auto_response_dry_run
+        || (cfg.allowlist_mode_enabled
+            && cfg.allowlist_mode_dry_run
+            && is_allowlist_enforcement(&action, conn, cfg));
     if dry_run {
-        audit::record("auto_response", "dry_run", json!({"summary": summary, "pid": conn.pid, "proc_name": conn.proc_name, "local_addr": conn.local_addr, "remote_addr": conn.remote_addr, "score": conn.score }));
+        audit::record(
+            "auto_response",
+            "dry_run",
+            json!({"summary": summary, "pid": conn.pid, "proc_name": conn.proc_name, "local_addr": conn.local_addr, "remote_addr": conn.remote_addr, "score": conn.score }),
+        );
         return Some(format!("Auto-response dry run: {summary}."));
     }
 
     let result = execute(&action, conn);
     match &result {
-        Ok(message) => { audit::record("auto_response", "success", json!({"summary": summary, "message": message, "pid": conn.pid, "proc_name": conn.proc_name, "local_addr": conn.local_addr, "remote_addr": conn.remote_addr, "score": conn.score })); Some(format!("Auto-response: {message}")) }
-        Err(err) => { audit::record("auto_response", "failure", json!({"summary": summary, "error": err, "pid": conn.pid, "proc_name": conn.proc_name, "local_addr": conn.local_addr, "remote_addr": conn.remote_addr, "score": conn.score })); Some(format!("Auto-response failed: {summary} ({err})")) }
+        Ok(message) => {
+            audit::record(
+                "auto_response",
+                "success",
+                json!({"summary": summary, "message": message, "pid": conn.pid, "proc_name": conn.proc_name, "local_addr": conn.local_addr, "remote_addr": conn.remote_addr, "score": conn.score }),
+            );
+            Some(format!("Auto-response: {message}"))
+        }
+        Err(err) => {
+            audit::record(
+                "auto_response",
+                "failure",
+                json!({"summary": summary, "error": err, "pid": conn.pid, "proc_name": conn.proc_name, "local_addr": conn.local_addr, "remote_addr": conn.remote_addr, "score": conn.score }),
+            );
+            Some(format!("Auto-response failed: {summary} ({err})"))
+        }
     }
 }
 
 pub fn plan(conn: &ConnInfo, cfg: &Config, state: &mut EngineState) -> Option<PlannedAction> {
-    if cfg.allowlist_mode_enabled && !is_allowlisted_process(conn, cfg) && !conn.proc_path.trim().is_empty() {
-        return Some(PlannedAction::BlockProcess { pid: conn.pid, path: conn.proc_path.clone(), preset: active_response::DurationPreset::Permanent });
+    if cfg.allowlist_mode_enabled
+        && !is_allowlisted_process(conn, cfg)
+        && !conn.proc_path.trim().is_empty()
+    {
+        return Some(PlannedAction::BlockProcess {
+            pid: conn.pid,
+            path: conn.proc_path.clone(),
+            preset: active_response::DurationPreset::Permanent,
+        });
     }
-    if !cfg.auto_response_enabled || conn.score < cfg.auto_response_min_score || is_trusted_process(conn, cfg) { return None; }
+    if !cfg.auto_response_enabled
+        || conn.score < cfg.auto_response_min_score
+        || is_trusted_process(conn, cfg)
+    {
+        return None;
+    }
 
     let signal_strength = signal_strength(conn);
-    if signal_strength < 2 { return None; }
+    if signal_strength < 2 {
+        return None;
+    }
     let offence_level = state.record_offence(conn, offence_window(cfg));
 
-    if cfg.auto_block_process && offence_level >= 3 && signal_strength >= 3 && !conn.proc_path.trim().is_empty() {
-        return Some(PlannedAction::BlockProcess { pid: conn.pid, path: conn.proc_path.clone(), preset: active_response::DurationPreset::OneHour });
+    if cfg.auto_block_process
+        && offence_level >= 3
+        && signal_strength >= 3
+        && !conn.proc_path.trim().is_empty()
+    {
+        return Some(PlannedAction::BlockProcess {
+            pid: conn.pid,
+            path: conn.proc_path.clone(),
+            preset: active_response::DurationPreset::OneHour,
+        });
     }
     if cfg.auto_block_remote && offence_level >= 2 {
-        if let Some(target) = active_response::extract_remote_target(&conn.remote_addr) { return Some(PlannedAction::BlockRemote { target, preset: active_response::DurationPreset::OneHour }); }
+        if let Some(target) = active_response::extract_remote_target(&conn.remote_addr) {
+            return Some(PlannedAction::BlockRemote {
+                target,
+                preset: active_response::DurationPreset::OneHour,
+            });
+        }
     }
-    if cfg.auto_kill_connection && active_response::can_kill_connection(conn) { return Some(PlannedAction::KillConnection); }
+    if cfg.auto_kill_connection && active_response::can_kill_connection(conn) {
+        return Some(PlannedAction::KillConnection);
+    }
     if cfg.auto_block_remote {
-        if let Some(target) = active_response::extract_remote_target(&conn.remote_addr) { return Some(PlannedAction::BlockRemote { target, preset: active_response::DurationPreset::OneHour }); }
+        if let Some(target) = active_response::extract_remote_target(&conn.remote_addr) {
+            return Some(PlannedAction::BlockRemote {
+                target,
+                preset: active_response::DurationPreset::OneHour,
+            });
+        }
     }
     if cfg.auto_block_process && signal_strength >= 3 && !conn.proc_path.trim().is_empty() {
-        return Some(PlannedAction::BlockProcess { pid: conn.pid, path: conn.proc_path.clone(), preset: active_response::DurationPreset::OneHour });
+        return Some(PlannedAction::BlockProcess {
+            pid: conn.pid,
+            path: conn.proc_path.clone(),
+            preset: active_response::DurationPreset::OneHour,
+        });
     }
     None
 }
 
 fn execute(action: &PlannedAction, conn: &ConnInfo) -> Result<String, String> {
     match action {
-        PlannedAction::KillConnection => active_response::kill_connection(conn).map_err(|err| err.to_string()),
-        PlannedAction::BlockRemote { target, preset } => active_response::block_remote(target, *preset),
-        PlannedAction::BlockProcess { pid, path, preset } => active_response::block_process(*pid, path, *preset),
+        PlannedAction::KillConnection => {
+            active_response::kill_connection(conn).map_err(|err| err.to_string())
+        }
+        PlannedAction::BlockRemote { target, preset } => {
+            active_response::block_remote(target, *preset)
+        }
+        PlannedAction::BlockProcess { pid, path, preset } => {
+            active_response::block_process(*pid, path, *preset)
+        }
     }
 }
 
 fn describe_action(action: &PlannedAction, conn: &ConnInfo) -> String {
     match action {
-        PlannedAction::KillConnection => format!("kill connection {} -> {}", conn.local_addr, conn.remote_addr),
-        PlannedAction::BlockRemote { target, preset } => format!("block remote {target} for {}", describe_preset(*preset)),
-        PlannedAction::BlockProcess { path, preset, .. } => format!("block process traffic for {path} for {}", describe_preset(*preset)),
+        PlannedAction::KillConnection => format!(
+            "kill connection {} -> {}",
+            conn.local_addr, conn.remote_addr
+        ),
+        PlannedAction::BlockRemote { target, preset } => {
+            format!("block remote {target} for {}", describe_preset(*preset))
+        }
+        PlannedAction::BlockProcess { path, preset, .. } => format!(
+            "block process traffic for {path} for {}",
+            describe_preset(*preset)
+        ),
     }
 }
 
 fn describe_preset(preset: active_response::DurationPreset) -> &'static str {
-    match preset { active_response::DurationPreset::OneHour => "1 hour", active_response::DurationPreset::OneDay => "24 hours", active_response::DurationPreset::Permanent => "an unlimited duration" }
+    match preset {
+        active_response::DurationPreset::OneHour => "1 hour",
+        active_response::DurationPreset::OneDay => "24 hours",
+        active_response::DurationPreset::Permanent => "an unlimited duration",
+    }
 }
 
 fn is_trusted_process(conn: &ConnInfo, cfg: &Config) -> bool {
     let key = normalise_name(&conn.proc_name);
-    cfg.trusted_processes.iter().any(|trusted| trusted.eq_ignore_ascii_case(&key))
+    cfg.trusted_processes
+        .iter()
+        .any(|trusted| trusted.eq_ignore_ascii_case(&key))
 }
 fn is_allowlisted_process(conn: &ConnInfo, cfg: &Config) -> bool {
-    if is_trusted_process(conn, cfg) { return true; }
+    if is_trusted_process(conn, cfg) {
+        return true;
+    }
     let key = normalise_name(&conn.proc_name);
     cfg.allowlist_processes.iter().any(|entry| {
         let entry_norm = normalise_name(entry);
@@ -109,32 +206,111 @@ fn is_allowlisted_process(conn: &ConnInfo, cfg: &Config) -> bool {
     }) || conn.publisher.to_ascii_lowercase().contains("microsoft")
 }
 fn is_allowlist_enforcement(action: &PlannedAction, conn: &ConnInfo, cfg: &Config) -> bool {
-    cfg.allowlist_mode_enabled && !is_allowlisted_process(conn, cfg) && matches!(action, PlannedAction::BlockProcess { preset: active_response::DurationPreset::Permanent, .. })
+    cfg.allowlist_mode_enabled
+        && !is_allowlisted_process(conn, cfg)
+        && matches!(
+            action,
+            PlannedAction::BlockProcess {
+                preset: active_response::DurationPreset::Permanent,
+                ..
+            }
+        )
 }
 
 fn signal_strength(conn: &ConnInfo) -> u8 {
-    let mut strength = 0u8; let mut has_primary_signal = false;
-    if conn.reputation_hit.is_some() { strength += 2; has_primary_signal = true; }
-    if conn.recently_dropped { strength += 1; has_primary_signal = true; }
-    if conn.dga_like { strength += 1; has_primary_signal = true; }
-    if conn.pre_login { strength += 1; }
-    if conn.publisher.trim().is_empty() { strength += 1; }
-    if conn.reasons.iter().any(|reason| reason.to_ascii_lowercase().contains("beacon")) { strength += 1; has_primary_signal = true; }
-    if conn.reasons.iter().any(|reason| reason.to_ascii_lowercase().contains("malware port")) { strength += 1; }
-    if has_primary_signal { strength } else { 0 }
+    let mut strength = 0u8;
+    let mut has_primary_signal = false;
+    if conn.reputation_hit.is_some() {
+        strength += 2;
+        has_primary_signal = true;
+    }
+    if conn.recently_dropped {
+        strength += 1;
+        has_primary_signal = true;
+    }
+    if conn.dga_like {
+        strength += 1;
+        has_primary_signal = true;
+    }
+    if conn.pre_login {
+        strength += 1;
+    }
+    if conn.publisher.trim().is_empty() {
+        strength += 1;
+    }
+    if conn
+        .reasons
+        .iter()
+        .any(|reason| reason.to_ascii_lowercase().contains("beacon"))
+    {
+        strength += 1;
+        has_primary_signal = true;
+    }
+    if conn
+        .reasons
+        .iter()
+        .any(|reason| reason.to_ascii_lowercase().contains("malware port"))
+    {
+        strength += 1;
+    }
+    if has_primary_signal {
+        strength
+    } else {
+        0
+    }
 }
 
 fn cooldown_key(action: &PlannedAction, conn: &ConnInfo) -> String {
     match action {
-        PlannedAction::KillConnection => format!("kill-connection:{}:{}", conn.local_addr, conn.remote_addr),
+        PlannedAction::KillConnection => {
+            format!("kill-connection:{}:{}", conn.local_addr, conn.remote_addr)
+        }
         PlannedAction::BlockRemote { target, .. } => format!("block-remote:{target}"),
         PlannedAction::BlockProcess { path, .. } => format!("block-process:{path}"),
     }
 }
-fn offence_key(conn: &ConnInfo) -> String { let remote = active_response::extract_remote_target(&conn.remote_addr).unwrap_or_else(|| conn.remote_addr.clone()); format!("{}:{}:{}", conn.pid, normalise_name(&conn.proc_name), remote) }
-fn offence_window(cfg: &Config) -> Duration { Duration::from_secs(cfg.auto_response_cooldown_secs.max(30).saturating_mul(3)) }
+fn offence_key(conn: &ConnInfo) -> String {
+    let remote = active_response::extract_remote_target(&conn.remote_addr)
+        .unwrap_or_else(|| conn.remote_addr.clone());
+    format!(
+        "{}:{}:{}",
+        conn.pid,
+        normalise_name(&conn.proc_name),
+        remote
+    )
+}
+fn offence_window(cfg: &Config) -> Duration {
+    Duration::from_secs(cfg.auto_response_cooldown_secs.max(30).saturating_mul(3))
+}
 
 impl EngineState {
-    fn try_acquire(&mut self, key: String, cooldown: Duration) -> bool { let now = Instant::now(); self.cooldowns.retain(|_, at| now.duration_since(*at) < cooldown.saturating_mul(2)); if let Some(previous) = self.cooldowns.get(&key) { if now.duration_since(*previous) < cooldown { return false; } } self.cooldowns.insert(key, now); true }
-    fn record_offence(&mut self, conn: &ConnInfo, offence_window: Duration) -> u8 { let now = Instant::now(); self.offences.retain(|_, state| now.duration_since(state.last_seen) < offence_window.saturating_mul(2)); let key = offence_key(conn); let entry = self.offences.entry(key).or_insert(OffenceState { count: 0, last_seen: now }); if now.duration_since(entry.last_seen) > offence_window { entry.count = 0; } entry.count = entry.count.saturating_add(1); entry.last_seen = now; entry.count }
+    fn try_acquire(&mut self, key: String, cooldown: Duration) -> bool {
+        let now = Instant::now();
+        self.cooldowns
+            .retain(|_, at| now.duration_since(*at) < cooldown.saturating_mul(2));
+        if let Some(previous) = self.cooldowns.get(&key) {
+            if now.duration_since(*previous) < cooldown {
+                return false;
+            }
+        }
+        self.cooldowns.insert(key, now);
+        true
+    }
+    fn record_offence(&mut self, conn: &ConnInfo, offence_window: Duration) -> u8 {
+        let now = Instant::now();
+        self.offences.retain(|_, state| {
+            now.duration_since(state.last_seen) < offence_window.saturating_mul(2)
+        });
+        let key = offence_key(conn);
+        let entry = self.offences.entry(key).or_insert(OffenceState {
+            count: 0,
+            last_seen: now,
+        });
+        if now.duration_since(entry.last_seen) > offence_window {
+            entry.count = 0;
+        }
+        entry.count = entry.count.saturating_add(1);
+        entry.last_seen = now;
+        entry.count
+    }
 }

--- a/src/break_glass.rs
+++ b/src/break_glass.rs
@@ -28,8 +28,8 @@ pub fn start_heartbeat_loop(cfg: Arc<RwLock<Config>>) {
         .name("vigil-break-glass-heartbeat".into())
         .spawn(move || loop {
             let snapshot = cfg.read().map(|c| c.clone()).unwrap_or_default();
-            sync_watchdog(&snapshot);
-            if snapshot.break_glass_enabled && active_response::status().isolated {
+            let _ = sync_watchdog(&snapshot);
+            if active_response::status().isolated {
                 let _ = touch_heartbeat();
             }
             std::thread::sleep(std::time::Duration::from_secs(
@@ -39,23 +39,17 @@ pub fn start_heartbeat_loop(cfg: Arc<RwLock<Config>>) {
         .ok();
 }
 
-pub fn sync_watchdog(cfg: &Config) {
-    if !cfg.break_glass_enabled {
-        let _ = disarm();
-        return;
-    }
+pub fn sync_watchdog(cfg: &Config) -> Result<(), String> {
+    // Isolation always requires a crash-recovery path, even if the user disabled
+    // recurring break-glass while the system is in a normal state.
     if active_response::status().isolated {
-        let _ = arm(cfg);
+        arm(cfg)
     } else {
-        let _ = disarm();
+        disarm()
     }
 }
 
 pub fn recover_if_stale() -> i32 {
-    let cfg = crate::config::Config::load();
-    if !cfg.break_glass_enabled {
-        return 0;
-    }
     let Some(state) = load_state().ok().flatten() else {
         return 0;
     };
@@ -109,13 +103,21 @@ fn arm(cfg: &Config) -> Result<(), String> {
     }
     platform::create_recovery_task(TASK_NAME)?;
     let deadline_unix = now.saturating_add(cfg.break_glass_timeout_mins.clamp(1, 240) * 60);
-    save_state(&RecoveryState {
+    let state = RecoveryState {
         armed_at_unix: now,
         deadline_unix,
         heartbeat_max_age_secs: cfg.break_glass_heartbeat_secs.clamp(5, 300) * 2,
         task_name: TASK_NAME.to_string(),
-    })?;
-    touch_heartbeat()?;
+    };
+    if let Err(err) = save_state(&state) {
+        let _ = platform::delete_recovery_task(TASK_NAME);
+        return Err(err);
+    }
+    if let Err(err) = touch_heartbeat() {
+        let _ = platform::delete_recovery_task(TASK_NAME);
+        let _ = std::fs::remove_file(state_path());
+        return Err(err);
+    }
     audit::record(
         "break_glass_arm",
         "success",
@@ -191,9 +193,12 @@ fn save_state(state: &RecoveryState) -> Result<(), String> {
 #[cfg(windows)]
 mod platform {
     use chrono::{Duration as ChronoDuration, Local};
+    use std::ffi::OsStr;
+    use std::os::windows::process::CommandExt;
     use std::path::PathBuf;
     use std::process::Command;
     use windows::Win32::System::SystemInformation::GetSystemWindowsDirectoryW;
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
 
     pub fn task_exists(name: &str) -> bool {
         schtasks()
@@ -240,7 +245,12 @@ mod platform {
             .unwrap_or_else(|| PathBuf::from(r"C:\Windows"))
             .join("System32")
             .join("schtasks.exe");
-        Command::new(path)
+        hidden_command(path)
+    }
+    fn hidden_command<S: AsRef<OsStr>>(program: S) -> Command {
+        let mut cmd = Command::new(program);
+        cmd.creation_flags(CREATE_NO_WINDOW);
+        cmd
     }
     fn windows_directory() -> Option<PathBuf> {
         let mut buffer = vec![0u16; 260];
@@ -267,13 +277,169 @@ mod platform {
 
 #[cfg(not(windows))]
 mod platform {
+    #[cfg(target_os = "linux")]
+    mod imp {
+        use std::io::Write;
+        use std::process::{Command, Stdio};
+
+        const CRON_MARKER: &str = "# Vigil Break Glass Recovery";
+
+        pub fn task_exists() -> bool {
+            read_crontab()
+                .map(|content| content.lines().any(|line| line.contains(CRON_MARKER)))
+                .unwrap_or(false)
+        }
+        pub fn create_recovery_task() -> Result<(), String> {
+            let mut lines: Vec<String> = read_crontab()?
+                .lines()
+                .filter(|line| !line.contains(CRON_MARKER))
+                .map(|line| line.to_string())
+                .collect();
+            lines.push(recovery_cron_line()?);
+            write_crontab(&lines.join("\n"))
+        }
+        pub fn delete_recovery_task() -> Result<(), String> {
+            let lines: Vec<String> = read_crontab()?
+                .lines()
+                .filter(|line| !line.contains(CRON_MARKER))
+                .map(|line| line.to_string())
+                .collect();
+            write_crontab(&lines.join("\n"))
+        }
+        fn recovery_cron_line() -> Result<String, String> {
+            let exe = std::env::current_exe()
+                .map_err(|e| format!("failed to resolve current exe: {e}"))?;
+            let exe = exe.display().to_string().replace('"', "\\\"");
+            Ok(format!(
+                "* * * * * \"{exe}\" --break-glass-recover {CRON_MARKER}"
+            ))
+        }
+        fn read_crontab() -> Result<String, String> {
+            let output = Command::new("crontab")
+                .arg("-l")
+                .output()
+                .map_err(|e| format!("failed to spawn crontab -l: {e}"))?;
+            if output.status.success() {
+                Ok(String::from_utf8_lossy(&output.stdout).to_string())
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
+                if stderr.contains("no crontab") {
+                    Ok(String::new())
+                } else {
+                    Err(format!("crontab -l failed: {stderr}"))
+                }
+            }
+        }
+        fn write_crontab(content: &str) -> Result<(), String> {
+            let mut child = Command::new("crontab")
+                .arg("-")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::null())
+                .stderr(Stdio::piped())
+                .spawn()
+                .map_err(|e| format!("failed to spawn crontab -: {e}"))?;
+            if let Some(stdin) = child.stdin.as_mut() {
+                if !content.trim().is_empty() {
+                    stdin
+                        .write_all(content.as_bytes())
+                        .map_err(|e| format!("failed to write crontab content: {e}"))?;
+                }
+                stdin
+                    .write_all(b"\n")
+                    .map_err(|e| format!("failed to finalise crontab content: {e}"))?;
+            }
+            let output = child
+                .wait_with_output()
+                .map_err(|e| format!("failed to wait for crontab -: {e}"))?;
+            if output.status.success() {
+                Ok(())
+            } else {
+                Err(format!(
+                    "crontab - failed: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ))
+            }
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    mod imp {
+        use std::path::PathBuf;
+        use std::process::Command;
+
+        const PLIST_LABEL: &str = "com.vigil.break-glass-recovery";
+
+        pub fn task_exists() -> bool {
+            plist_path().exists()
+        }
+        pub fn create_recovery_task() -> Result<(), String> {
+            let exe = std::env::current_exe()
+                .map_err(|e| format!("failed to resolve current exe: {e}"))?;
+            let plist = format!(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n  <key>Label</key>\n  <string>{PLIST_LABEL}</string>\n  <key>ProgramArguments</key>\n  <array>\n    <string>{}</string>\n    <string>--break-glass-recover</string>\n  </array>\n  <key>RunAtLoad</key>\n  <true/>\n  <key>StartInterval</key>\n  <integer>60</integer>\n</dict>\n</plist>\n",
+                xml_escape(&exe.display().to_string())
+            );
+            std::fs::write(plist_path(), plist)
+                .map_err(|e| format!("failed to write launchd plist: {e}"))?;
+            let _ = Command::new("launchctl")
+                .args(["bootout", "system", plist_path().to_string_lossy().as_ref()])
+                .status();
+            let status = Command::new("launchctl")
+                .args([
+                    "bootstrap",
+                    "system",
+                    plist_path().to_string_lossy().as_ref(),
+                ])
+                .status()
+                .map_err(|e| format!("failed to spawn launchctl bootstrap: {e}"))?;
+            if status.success() {
+                Ok(())
+            } else {
+                Err(format!("launchctl bootstrap failed with status {status}"))
+            }
+        }
+        pub fn delete_recovery_task() -> Result<(), String> {
+            let _ = Command::new("launchctl")
+                .args(["bootout", "system", plist_path().to_string_lossy().as_ref()])
+                .status();
+            if plist_path().exists() {
+                std::fs::remove_file(plist_path())
+                    .map_err(|e| format!("failed to remove launchd plist: {e}"))?;
+            }
+            Ok(())
+        }
+        fn plist_path() -> PathBuf {
+            PathBuf::from(format!("/Library/LaunchDaemons/{PLIST_LABEL}.plist"))
+        }
+        fn xml_escape(text: &str) -> String {
+            text.replace('&', "&amp;")
+                .replace('<', "&lt;")
+                .replace('>', "&gt;")
+                .replace('"', "&quot;")
+                .replace('\'', "&apos;")
+        }
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    mod imp {
+        pub fn task_exists() -> bool {
+            false
+        }
+        pub fn create_recovery_task() -> Result<(), String> {
+            Err("break-glass recovery is not implemented on this platform".into())
+        }
+        pub fn delete_recovery_task() -> Result<(), String> {
+            Ok(())
+        }
+    }
+
     pub fn task_exists(_name: &str) -> bool {
-        false
+        imp::task_exists()
     }
     pub fn create_recovery_task(_name: &str) -> Result<(), String> {
-        Err("break-glass recovery is not implemented on this platform".into())
+        imp::create_recovery_task()
     }
     pub fn delete_recovery_task(_name: &str) -> Result<(), String> {
-        Ok(())
+        imp::delete_recovery_task()
     }
 }

--- a/src/break_glass.rs
+++ b/src/break_glass.rs
@@ -32,7 +32,9 @@ pub fn start_heartbeat_loop(cfg: Arc<RwLock<Config>>) {
             if snapshot.break_glass_enabled && active_response::status().isolated {
                 let _ = touch_heartbeat();
             }
-            std::thread::sleep(std::time::Duration::from_secs(snapshot.break_glass_heartbeat_secs.clamp(5, 300)));
+            std::thread::sleep(std::time::Duration::from_secs(
+                snapshot.break_glass_heartbeat_secs.clamp(5, 300),
+            ));
         })
         .ok();
 }
@@ -54,7 +56,9 @@ pub fn recover_if_stale() -> i32 {
     if !cfg.break_glass_enabled {
         return 0;
     }
-    let Some(state) = load_state().ok().flatten() else { return 0; };
+    let Some(state) = load_state().ok().flatten() else {
+        return 0;
+    };
     if !active_response::status().isolated {
         let _ = disarm();
         return 0;
@@ -69,20 +73,28 @@ pub fn recover_if_stale() -> i32 {
     }
     match active_response::restore_machine() {
         Ok(message) => {
-            audit::record("break_glass_recovery", "success", json!({
-                "message": message,
-                "heartbeat_age_secs": heartbeat_age,
-                "deadline_unix": state.deadline_unix,
-            }));
+            audit::record(
+                "break_glass_recovery",
+                "success",
+                json!({
+                    "message": message,
+                    "heartbeat_age_secs": heartbeat_age,
+                    "deadline_unix": state.deadline_unix,
+                }),
+            );
             let _ = disarm();
             0
         }
         Err(err) => {
-            audit::record("break_glass_recovery", "error", json!({
-                "error": err,
-                "heartbeat_age_secs": heartbeat_age,
-                "deadline_unix": state.deadline_unix,
-            }));
+            audit::record(
+                "break_glass_recovery",
+                "error",
+                json!({
+                    "error": err,
+                    "heartbeat_age_secs": heartbeat_age,
+                    "deadline_unix": state.deadline_unix,
+                }),
+            );
             1
         }
     }
@@ -104,11 +116,15 @@ fn arm(cfg: &Config) -> Result<(), String> {
         task_name: TASK_NAME.to_string(),
     })?;
     touch_heartbeat()?;
-    audit::record("break_glass_arm", "success", json!({
-        "deadline_unix": deadline_unix,
-        "heartbeat_secs": cfg.break_glass_heartbeat_secs,
-        "task_name": TASK_NAME,
-    }));
+    audit::record(
+        "break_glass_arm",
+        "success",
+        json!({
+            "deadline_unix": deadline_unix,
+            "heartbeat_secs": cfg.break_glass_heartbeat_secs,
+            "task_name": TASK_NAME,
+        }),
+    );
     Ok(())
 }
 
@@ -122,9 +138,11 @@ pub fn disarm() -> Result<(), String> {
 fn touch_heartbeat() -> Result<(), String> {
     let path = heartbeat_path();
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
     }
-    std::fs::write(&path, unix_now().to_string()).map_err(|e| format!("failed to write {}: {e}", path.display()))
+    std::fs::write(&path, unix_now().to_string())
+        .map_err(|e| format!("failed to write {}: {e}", path.display()))
 }
 
 fn heartbeat_age_secs() -> Option<u64> {
@@ -135,63 +153,112 @@ fn heartbeat_age_secs() -> Option<u64> {
     Some(age.as_secs())
 }
 
-fn state_path() -> PathBuf { crate::config::data_dir().join(STATE_FILE) }
-fn heartbeat_path() -> PathBuf { crate::config::data_dir().join(HEARTBEAT_FILE) }
-fn unix_now() -> u64 { std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0) }
+fn state_path() -> PathBuf {
+    crate::config::data_dir().join(STATE_FILE)
+}
+fn heartbeat_path() -> PathBuf {
+    crate::config::data_dir().join(HEARTBEAT_FILE)
+}
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
 
 fn load_state() -> Result<Option<RecoveryState>, String> {
     let path = state_path();
-    if !path.exists() { return Ok(None); }
-    let text = std::fs::read_to_string(&path).map_err(|e| format!("failed to read {}: {e}", path.display()))?;
-    serde_json::from_str(&text).map(Some).map_err(|e| format!("failed to parse {}: {e}", path.display()))
+    if !path.exists() {
+        return Ok(None);
+    }
+    let text = std::fs::read_to_string(&path)
+        .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    serde_json::from_str(&text)
+        .map(Some)
+        .map_err(|e| format!("failed to parse {}: {e}", path.display()))
 }
 fn save_state(state: &RecoveryState) -> Result<(), String> {
     let path = state_path();
-    if let Some(parent) = path.parent() { std::fs::create_dir_all(parent).map_err(|e| format!("failed to create {}: {e}", parent.display()))?; }
-    let json = serde_json::to_string_pretty(state).map_err(|e| format!("failed to serialise break-glass state: {e}"))?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
+    }
+    let json = serde_json::to_string_pretty(state)
+        .map_err(|e| format!("failed to serialise break-glass state: {e}"))?;
     std::fs::write(&path, json).map_err(|e| format!("failed to write {}: {e}", path.display()))
 }
 
 #[cfg(windows)]
 mod platform {
-    use super::*;
     use chrono::{Duration as ChronoDuration, Local};
     use std::path::PathBuf;
     use std::process::Command;
     use windows::Win32::System::SystemInformation::GetSystemWindowsDirectoryW;
 
     pub fn task_exists(name: &str) -> bool {
-        schtasks().arg("/Query").arg("/TN").arg(name).status().map(|s| s.success()).unwrap_or(false)
+        schtasks()
+            .arg("/Query")
+            .arg("/TN")
+            .arg(name)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
     }
     pub fn create_recovery_task(name: &str) -> Result<(), String> {
-        let exe = std::env::current_exe().map_err(|e| format!("failed to resolve current exe: {e}"))?;
+        let exe =
+            std::env::current_exe().map_err(|e| format!("failed to resolve current exe: {e}"))?;
         let command = format!("\"{}\" --break-glass-recover", exe.display());
-        let start = (Local::now() + ChronoDuration::minutes(1)).format("%H:%M").to_string();
+        let start = (Local::now() + ChronoDuration::minutes(1))
+            .format("%H:%M")
+            .to_string();
         let status = schtasks()
-            .args(["/Create", "/F", "/SC", "MINUTE", "/MO", "1", "/TN", name, "/TR", &command, "/ST", &start, "/RU", "SYSTEM", "/RL", "HIGHEST"])
+            .args([
+                "/Create", "/F", "/SC", "MINUTE", "/MO", "1", "/TN", name, "/TR", &command, "/ST",
+                &start, "/RU", "SYSTEM", "/RL", "HIGHEST",
+            ])
             .status()
             .map_err(|e| format!("failed to spawn schtasks.exe: {e}"))?;
-        if status.success() { Ok(()) } else { Err(format!("schtasks /Create failed with status {status}")) }
+        if status.success() {
+            Ok(())
+        } else {
+            Err(format!("schtasks /Create failed with status {status}"))
+        }
     }
     pub fn delete_recovery_task(name: &str) -> Result<(), String> {
-        let status = schtasks().args(["/Delete", "/F", "/TN", name]).status().map_err(|e| format!("failed to spawn schtasks.exe: {e}"))?;
-        if status.success() { Ok(()) } else { Err(format!("schtasks /Delete failed with status {status}")) }
+        let status = schtasks()
+            .args(["/Delete", "/F", "/TN", name])
+            .status()
+            .map_err(|e| format!("failed to spawn schtasks.exe: {e}"))?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(format!("schtasks /Delete failed with status {status}"))
+        }
     }
     fn schtasks() -> Command {
-        let path = windows_directory().unwrap_or_else(|| PathBuf::from(r"C:\Windows")).join("System32").join("schtasks.exe");
+        let path = windows_directory()
+            .unwrap_or_else(|| PathBuf::from(r"C:\Windows"))
+            .join("System32")
+            .join("schtasks.exe");
         Command::new(path)
     }
     fn windows_directory() -> Option<PathBuf> {
         let mut buffer = vec![0u16; 260];
         unsafe {
             let len = GetSystemWindowsDirectoryW(Some(&mut buffer));
-            if len == 0 { return None; }
+            if len == 0 {
+                return None;
+            }
             let len = len as usize;
             if len >= buffer.len() {
                 buffer.resize(len + 1, 0);
                 let retry_len = GetSystemWindowsDirectoryW(Some(&mut buffer));
-                if retry_len == 0 { return None; }
-                return Some(PathBuf::from(String::from_utf16_lossy(&buffer[..retry_len as usize])));
+                if retry_len == 0 {
+                    return None;
+                }
+                return Some(PathBuf::from(String::from_utf16_lossy(
+                    &buffer[..retry_len as usize],
+                )));
             }
             Some(PathBuf::from(String::from_utf16_lossy(&buffer[..len])))
         }
@@ -200,7 +267,13 @@ mod platform {
 
 #[cfg(not(windows))]
 mod platform {
-    pub fn task_exists(_name: &str) -> bool { false }
-    pub fn create_recovery_task(_name: &str) -> Result<(), String> { Err("break-glass recovery is not implemented on this platform".into()) }
-    pub fn delete_recovery_task(_name: &str) -> Result<(), String> { Ok(()) }
+    pub fn task_exists(_name: &str) -> bool {
+        false
+    }
+    pub fn create_recovery_task(_name: &str) -> Result<(), String> {
+        Err("break-glass recovery is not implemented on this platform".into())
+    }
+    pub fn delete_recovery_task(_name: &str) -> Result<(), String> {
+        Ok(())
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,80 +22,163 @@ pub struct Config {
     pub suspicious_path_fragments: Vec<String>,
     pub lolbins: Vec<String>,
 
-    #[serde(default)] pub geoip_city_db: String,
-    #[serde(default)] pub geoip_asn_db: String,
-    #[serde(default)] pub allowed_countries: Vec<String>,
-    #[serde(default)] pub blocklist_paths: Vec<String>,
-    #[serde(default = "default_true")] pub fswatch_enabled: bool,
-    #[serde(default = "default_fswatch_window")] pub fswatch_window_secs: u64,
-    #[serde(default = "default_long_lived_threshold")] pub long_lived_secs: u64,
-    #[serde(default)] pub reverse_dns_enabled: bool,
-    #[serde(default = "default_dga_threshold")] pub dga_entropy_threshold: f32,
+    #[serde(default)]
+    pub geoip_city_db: String,
+    #[serde(default)]
+    pub geoip_asn_db: String,
+    #[serde(default)]
+    pub allowed_countries: Vec<String>,
+    #[serde(default)]
+    pub blocklist_paths: Vec<String>,
+    #[serde(default = "default_true")]
+    pub fswatch_enabled: bool,
+    #[serde(default = "default_fswatch_window")]
+    pub fswatch_window_secs: u64,
+    #[serde(default = "default_long_lived_threshold")]
+    pub long_lived_secs: u64,
+    #[serde(default)]
+    pub reverse_dns_enabled: bool,
+    #[serde(default = "default_dga_threshold")]
+    pub dga_entropy_threshold: f32,
 
-    #[serde(default)] pub auto_response_enabled: bool,
-    #[serde(default)] pub auto_response_dry_run: bool,
-    #[serde(default)] pub auto_kill_connection: bool,
-    #[serde(default)] pub auto_block_remote: bool,
-    #[serde(default)] pub auto_block_process: bool,
-    #[serde(default)] pub auto_isolate_machine: bool,
-    #[serde(default = "default_auto_response_min_score")] pub auto_response_min_score: u8,
-    #[serde(default = "default_auto_response_cooldown_secs")] pub auto_response_cooldown_secs: u64,
+    #[serde(default)]
+    pub auto_response_enabled: bool,
+    #[serde(default)]
+    pub auto_response_dry_run: bool,
+    #[serde(default)]
+    pub auto_kill_connection: bool,
+    #[serde(default)]
+    pub auto_block_remote: bool,
+    #[serde(default)]
+    pub auto_block_process: bool,
+    #[serde(default)]
+    pub auto_isolate_machine: bool,
+    #[serde(default = "default_auto_response_min_score")]
+    pub auto_response_min_score: u8,
+    #[serde(default = "default_auto_response_cooldown_secs")]
+    pub auto_response_cooldown_secs: u64,
 
-    #[serde(default)] pub allowlist_mode_enabled: bool,
-    #[serde(default)] pub allowlist_mode_dry_run: bool,
-    #[serde(default)] pub allowlist_processes: Vec<String>,
+    #[serde(default)]
+    pub allowlist_mode_enabled: bool,
+    #[serde(default)]
+    pub allowlist_mode_dry_run: bool,
+    #[serde(default)]
+    pub allowlist_processes: Vec<String>,
 
-    #[serde(default)] pub response_rules_enabled: bool,
-    #[serde(default = "default_true")] pub response_rules_dry_run: bool,
-    #[serde(default)] pub response_rules_path: String,
+    #[serde(default)]
+    pub response_rules_enabled: bool,
+    #[serde(default = "default_true")]
+    pub response_rules_dry_run: bool,
+    #[serde(default)]
+    pub response_rules_path: String,
 
-    #[serde(default)] pub scheduled_lockdown_enabled: bool,
-    #[serde(default = "default_scheduled_lockdown_start_hour")] pub scheduled_lockdown_start_hour: u8,
-    #[serde(default = "default_scheduled_lockdown_start_minute")] pub scheduled_lockdown_start_minute: u8,
-    #[serde(default = "default_scheduled_lockdown_end_hour")] pub scheduled_lockdown_end_hour: u8,
-    #[serde(default = "default_scheduled_lockdown_end_minute")] pub scheduled_lockdown_end_minute: u8,
+    #[serde(default)]
+    pub scheduled_lockdown_enabled: bool,
+    #[serde(default = "default_scheduled_lockdown_start_hour")]
+    pub scheduled_lockdown_start_hour: u8,
+    #[serde(default = "default_scheduled_lockdown_start_minute")]
+    pub scheduled_lockdown_start_minute: u8,
+    #[serde(default = "default_scheduled_lockdown_end_hour")]
+    pub scheduled_lockdown_end_hour: u8,
+    #[serde(default = "default_scheduled_lockdown_end_minute")]
+    pub scheduled_lockdown_end_minute: u8,
 
-    #[serde(default)] pub process_dump_on_alert: bool,
-    #[serde(default = "default_process_dump_min_score")] pub process_dump_min_score: u8,
-    #[serde(default = "default_process_dump_cooldown_secs")] pub process_dump_cooldown_secs: u64,
-    #[serde(default)] pub process_dump_dir: String,
+    #[serde(default)]
+    pub process_dump_on_alert: bool,
+    #[serde(default = "default_process_dump_min_score")]
+    pub process_dump_min_score: u8,
+    #[serde(default = "default_process_dump_cooldown_secs")]
+    pub process_dump_cooldown_secs: u64,
+    #[serde(default)]
+    pub process_dump_dir: String,
 
-    #[serde(default)] pub pcap_on_alert: bool,
-    #[serde(default = "default_pcap_min_score")] pub pcap_min_score: u8,
-    #[serde(default = "default_pcap_duration_secs")] pub pcap_duration_secs: u64,
-    #[serde(default = "default_pcap_cooldown_secs")] pub pcap_cooldown_secs: u64,
-    #[serde(default = "default_pcap_packet_size_bytes")] pub pcap_packet_size_bytes: u32,
-    #[serde(default)] pub pcap_dir: String,
+    #[serde(default)]
+    pub pcap_on_alert: bool,
+    #[serde(default = "default_pcap_min_score")]
+    pub pcap_min_score: u8,
+    #[serde(default = "default_pcap_duration_secs")]
+    pub pcap_duration_secs: u64,
+    #[serde(default = "default_pcap_cooldown_secs")]
+    pub pcap_cooldown_secs: u64,
+    #[serde(default = "default_pcap_packet_size_bytes")]
+    pub pcap_packet_size_bytes: u32,
+    #[serde(default)]
+    pub pcap_dir: String,
 
-    #[serde(default)] pub honeypot_decoys_enabled: bool,
-    #[serde(default)] pub honeypot_auto_isolate: bool,
-    #[serde(default = "default_honeypot_poll_secs")] pub honeypot_poll_secs: u64,
-    #[serde(default)] pub honeypot_decoy_names: Vec<String>,
+    #[serde(default)]
+    pub honeypot_decoys_enabled: bool,
+    #[serde(default)]
+    pub honeypot_auto_isolate: bool,
+    #[serde(default = "default_honeypot_poll_secs")]
+    pub honeypot_poll_secs: u64,
+    #[serde(default)]
+    pub honeypot_decoy_names: Vec<String>,
 
-    #[serde(default = "default_true")] pub break_glass_enabled: bool,
-    #[serde(default = "default_break_glass_timeout_mins")] pub break_glass_timeout_mins: u64,
-    #[serde(default = "default_break_glass_heartbeat_secs")] pub break_glass_heartbeat_secs: u64,
+    #[serde(default = "default_true")]
+    pub break_glass_enabled: bool,
+    #[serde(default = "default_break_glass_timeout_mins")]
+    pub break_glass_timeout_mins: u64,
+    #[serde(default = "default_break_glass_heartbeat_secs")]
+    pub break_glass_heartbeat_secs: u64,
 }
 
-fn default_true() -> bool { true }
-fn default_fswatch_window() -> u64 { 600 }
-fn default_long_lived_threshold() -> u64 { 3600 }
-fn default_dga_threshold() -> f32 { 3.2 }
-fn default_auto_response_min_score() -> u8 { 10 }
-fn default_auto_response_cooldown_secs() -> u64 { 300 }
-fn default_scheduled_lockdown_start_hour() -> u8 { 23 }
-fn default_scheduled_lockdown_start_minute() -> u8 { 0 }
-fn default_scheduled_lockdown_end_hour() -> u8 { 6 }
-fn default_scheduled_lockdown_end_minute() -> u8 { 0 }
-fn default_process_dump_min_score() -> u8 { 12 }
-fn default_process_dump_cooldown_secs() -> u64 { 600 }
-fn default_pcap_min_score() -> u8 { 12 }
-fn default_pcap_duration_secs() -> u64 { 15 }
-fn default_pcap_cooldown_secs() -> u64 { 300 }
-fn default_pcap_packet_size_bytes() -> u32 { 0 }
-fn default_honeypot_poll_secs() -> u64 { 10 }
-fn default_break_glass_timeout_mins() -> u64 { 10 }
-fn default_break_glass_heartbeat_secs() -> u64 { 30 }
+fn default_true() -> bool {
+    true
+}
+fn default_fswatch_window() -> u64 {
+    600
+}
+fn default_long_lived_threshold() -> u64 {
+    3600
+}
+fn default_dga_threshold() -> f32 {
+    3.2
+}
+fn default_auto_response_min_score() -> u8 {
+    10
+}
+fn default_auto_response_cooldown_secs() -> u64 {
+    300
+}
+fn default_scheduled_lockdown_start_hour() -> u8 {
+    23
+}
+fn default_scheduled_lockdown_start_minute() -> u8 {
+    0
+}
+fn default_scheduled_lockdown_end_hour() -> u8 {
+    6
+}
+fn default_scheduled_lockdown_end_minute() -> u8 {
+    0
+}
+fn default_process_dump_min_score() -> u8 {
+    12
+}
+fn default_process_dump_cooldown_secs() -> u64 {
+    600
+}
+fn default_pcap_min_score() -> u8 {
+    12
+}
+fn default_pcap_duration_secs() -> u64 {
+    15
+}
+fn default_pcap_cooldown_secs() -> u64 {
+    300
+}
+fn default_pcap_packet_size_bytes() -> u32 {
+    0
+}
+fn default_honeypot_poll_secs() -> u64 {
+    10
+}
+fn default_break_glass_timeout_mins() -> u64 {
+    10
+}
+fn default_break_glass_heartbeat_secs() -> u64 {
+    30
+}
 
 impl Default for Config {
     fn default() -> Self {
@@ -106,30 +189,173 @@ impl Default for Config {
             autostart: false,
             first_run_done: false,
             trusted_processes: vec![
-                "svchost","lsass","services","system","smss","csrss","wininit","winlogon","explorer","runtimebroker","searchhost","startmenuexperiencehost","shellhost","sihost","ctfmon","textinputhost","shellexperiencehost","widgetservice","widgetboard","crossdeviceservice","crossdeviceresume","phoneexperiencehost","castsrv",
-                "chrome","msedge","firefox","opera","brave","vivaldi","msedgewebview2","cefsharp.browsersubprocess",
-                "onedrive","systemsettings","microsoftstartfeedprovider",
-                "avgsvc","avgui","avgbidsagent","avgdriverupdsvc","avgtuneupssvc","vpnsvc","tuneupssvc","avgwscreporter","avgantitrack","antitrackSvc","securevpn","su_worker","avgtoolssvc","wa_3rd_party_host_64","avlaunch",
-                "claude","node","python","python3",
-                "spotify","steam","epicgameslauncher","ealauncher","eadesktop","eabackgroundservice",
-                "whatsapp","whatsapp.root","zoom","slack","discord","telegram",
-                "ollama","ollama_llama_server",
-                "nvdisplay.containerlocalsystem","nvbroadcast.containerlocalsystem",
-                "rtkaudiouniversalservice","intelgraphicssoftwareservice","waasmedicsvc","wsaifabricsvc",
-            ].iter().map(|s| s.to_string()).collect(),
-            common_ports: vec![80, 443, 8080, 8443, 53, 853, 22, 21, 25, 587, 465, 993, 995, 110, 143, 5222, 5228, 3478, 3479, 7500, 27275],
-            malware_ports: vec![4444, 1337, 31337, 6666, 6667, 6668, 6669, 9999, 1234, 54321, 12345, 23, 5900, 5901, 4899, 8888],
-            suspicious_path_fragments: [r"\Temp\", r"\AppData\Local\Temp\", r"\AppData\Roaming\", r"\Downloads\", r"\Public\", "/tmp/", "/var/tmp/"].into_iter().map(|s| s.to_string()).collect(),
-            lolbins: vec!["cmd","powershell","pwsh","wscript","cscript","mshta","regsvr32","rundll32","certutil","bitsadmin","wmic","msiexec","installutil","regasm","regsvcs","forfiles"].iter().map(|s| s.to_string()).collect(),
-            geoip_city_db: String::new(), geoip_asn_db: String::new(), allowed_countries: Vec::new(), blocklist_paths: Vec::new(), fswatch_enabled: true, fswatch_window_secs: 600, long_lived_secs: 3600, reverse_dns_enabled: false, dga_entropy_threshold: 3.2,
-            auto_response_enabled: false, auto_response_dry_run: true, auto_kill_connection: false, auto_block_remote: false, auto_block_process: false, auto_isolate_machine: false, auto_response_min_score: 10, auto_response_cooldown_secs: 300,
-            allowlist_mode_enabled: false, allowlist_mode_dry_run: true, allowlist_processes: Vec::new(),
-            response_rules_enabled: false, response_rules_dry_run: true, response_rules_path: String::new(),
-            scheduled_lockdown_enabled: false, scheduled_lockdown_start_hour: 23, scheduled_lockdown_start_minute: 0, scheduled_lockdown_end_hour: 6, scheduled_lockdown_end_minute: 0,
-            process_dump_on_alert: false, process_dump_min_score: 12, process_dump_cooldown_secs: 600, process_dump_dir: String::new(),
-            pcap_on_alert: false, pcap_min_score: 12, pcap_duration_secs: 15, pcap_cooldown_secs: 300, pcap_packet_size_bytes: 0, pcap_dir: String::new(),
-            honeypot_decoys_enabled: false, honeypot_auto_isolate: false, honeypot_poll_secs: 10, honeypot_decoy_names: vec!["Quarterly Payroll 2026.xlsx".into(), "Passwords-Do-Not-Open.txt".into(), "AWS-Root-Keys.txt".into()],
-            break_glass_enabled: true, break_glass_timeout_mins: 10, break_glass_heartbeat_secs: 30,
+                "svchost",
+                "lsass",
+                "services",
+                "system",
+                "smss",
+                "csrss",
+                "wininit",
+                "winlogon",
+                "explorer",
+                "runtimebroker",
+                "searchhost",
+                "startmenuexperiencehost",
+                "shellhost",
+                "sihost",
+                "ctfmon",
+                "textinputhost",
+                "shellexperiencehost",
+                "widgetservice",
+                "widgetboard",
+                "crossdeviceservice",
+                "crossdeviceresume",
+                "phoneexperiencehost",
+                "castsrv",
+                "chrome",
+                "msedge",
+                "firefox",
+                "opera",
+                "brave",
+                "vivaldi",
+                "msedgewebview2",
+                "cefsharp.browsersubprocess",
+                "onedrive",
+                "systemsettings",
+                "microsoftstartfeedprovider",
+                "avgsvc",
+                "avgui",
+                "avgbidsagent",
+                "avgdriverupdsvc",
+                "avgtuneupssvc",
+                "vpnsvc",
+                "tuneupssvc",
+                "avgwscreporter",
+                "avgantitrack",
+                "antitrackSvc",
+                "securevpn",
+                "su_worker",
+                "avgtoolssvc",
+                "wa_3rd_party_host_64",
+                "avlaunch",
+                "claude",
+                "node",
+                "python",
+                "python3",
+                "spotify",
+                "steam",
+                "epicgameslauncher",
+                "ealauncher",
+                "eadesktop",
+                "eabackgroundservice",
+                "whatsapp",
+                "whatsapp.root",
+                "zoom",
+                "slack",
+                "discord",
+                "telegram",
+                "ollama",
+                "ollama_llama_server",
+                "nvdisplay.containerlocalsystem",
+                "nvbroadcast.containerlocalsystem",
+                "rtkaudiouniversalservice",
+                "intelgraphicssoftwareservice",
+                "waasmedicsvc",
+                "wsaifabricsvc",
+            ]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+            common_ports: vec![
+                80, 443, 8080, 8443, 53, 853, 22, 21, 25, 587, 465, 993, 995, 110, 143, 5222, 5228,
+                3478, 3479, 7500, 27275,
+            ],
+            malware_ports: vec![
+                4444, 1337, 31337, 6666, 6667, 6668, 6669, 9999, 1234, 54321, 12345, 23, 5900,
+                5901, 4899, 8888,
+            ],
+            suspicious_path_fragments: [
+                r"\Temp\",
+                r"\AppData\Local\Temp\",
+                r"\AppData\Roaming\",
+                r"\Downloads\",
+                r"\Public\",
+                "/tmp/",
+                "/var/tmp/",
+            ]
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect(),
+            lolbins: vec![
+                "cmd",
+                "powershell",
+                "pwsh",
+                "wscript",
+                "cscript",
+                "mshta",
+                "regsvr32",
+                "rundll32",
+                "certutil",
+                "bitsadmin",
+                "wmic",
+                "msiexec",
+                "installutil",
+                "regasm",
+                "regsvcs",
+                "forfiles",
+            ]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+            geoip_city_db: String::new(),
+            geoip_asn_db: String::new(),
+            allowed_countries: Vec::new(),
+            blocklist_paths: Vec::new(),
+            fswatch_enabled: true,
+            fswatch_window_secs: 600,
+            long_lived_secs: 3600,
+            reverse_dns_enabled: false,
+            dga_entropy_threshold: 3.2,
+            auto_response_enabled: false,
+            auto_response_dry_run: true,
+            auto_kill_connection: false,
+            auto_block_remote: false,
+            auto_block_process: false,
+            auto_isolate_machine: false,
+            auto_response_min_score: 10,
+            auto_response_cooldown_secs: 300,
+            allowlist_mode_enabled: false,
+            allowlist_mode_dry_run: true,
+            allowlist_processes: Vec::new(),
+            response_rules_enabled: false,
+            response_rules_dry_run: true,
+            response_rules_path: String::new(),
+            scheduled_lockdown_enabled: false,
+            scheduled_lockdown_start_hour: 23,
+            scheduled_lockdown_start_minute: 0,
+            scheduled_lockdown_end_hour: 6,
+            scheduled_lockdown_end_minute: 0,
+            process_dump_on_alert: false,
+            process_dump_min_score: 12,
+            process_dump_cooldown_secs: 600,
+            process_dump_dir: String::new(),
+            pcap_on_alert: false,
+            pcap_min_score: 12,
+            pcap_duration_secs: 15,
+            pcap_cooldown_secs: 300,
+            pcap_packet_size_bytes: 0,
+            pcap_dir: String::new(),
+            honeypot_decoys_enabled: false,
+            honeypot_auto_isolate: false,
+            honeypot_poll_secs: 10,
+            honeypot_decoy_names: vec![
+                "Quarterly Payroll 2026.xlsx".into(),
+                "Passwords-Do-Not-Open.txt".into(),
+                "AWS-Root-Keys.txt".into(),
+            ],
+            break_glass_enabled: true,
+            break_glass_timeout_mins: 10,
+            break_glass_heartbeat_secs: 30,
         }
     }
 }
@@ -137,45 +363,148 @@ impl Default for Config {
 pub fn data_dir() -> PathBuf {
     #[cfg(target_os = "windows")]
     {
-        if let Some(dir) = std::env::var_os("LOCALAPPDATA") { return PathBuf::from(dir).join("Vigil"); }
-        if let Some(dir) = std::env::var_os("APPDATA") { return PathBuf::from(dir).join("Vigil"); }
+        if let Some(dir) = std::env::var_os("LOCALAPPDATA") {
+            return PathBuf::from(dir).join("Vigil");
+        }
+        if let Some(dir) = std::env::var_os("APPDATA") {
+            return PathBuf::from(dir).join("Vigil");
+        }
     }
     #[cfg(target_os = "macos")]
     {
-        if let Some(home) = std::env::var_os("HOME") { return PathBuf::from(home).join("Library").join("Application Support").join("Vigil"); }
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home)
+                .join("Library")
+                .join("Application Support")
+                .join("Vigil");
+        }
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") { return PathBuf::from(xdg).join("vigil"); }
-        if let Some(home) = std::env::var_os("HOME") { return PathBuf::from(home).join(".config").join("vigil"); }
+        if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+            return PathBuf::from(xdg).join("vigil");
+        }
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home).join(".config").join("vigil");
+        }
     }
-    std::env::current_exe().ok().and_then(|p| p.parent().map(|d| d.join("vigil-data"))).unwrap_or_else(|| PathBuf::from("vigil-data"))
+    std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.join("vigil-data")))
+        .unwrap_or_else(|| PathBuf::from("vigil-data"))
 }
 
-pub fn config_path() -> PathBuf { data_dir().join("vigil.json") }
+pub fn config_path() -> PathBuf {
+    data_dir().join("vigil.json")
+}
 
 impl Config {
     pub fn load() -> Self {
-        let path = config_path(); if !path.exists() { return Self::default(); }
-        std::fs::read_to_string(&path).ok().and_then(|s| serde_json::from_str::<Config>(&s).ok()).unwrap_or_default()
+        let path = config_path();
+        if !path.exists() {
+            return Self::default();
+        }
+        std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|s| serde_json::from_str::<Config>(&s).ok())
+            .unwrap_or_default()
     }
     pub fn save(&self) {
-        let path = config_path(); if let Some(parent)=path.parent(){ if let Err(e)=std::fs::create_dir_all(parent){ tracing::warn!("failed to create config directory: {e}"); return; } }
-        match serde_json::to_string_pretty(self) { Ok(json)=>{ if let Err(e)=std::fs::write(&path, json){ tracing::warn!("failed to save config: {e}"); } } Err(e)=>tracing::warn!("failed to serialise config: {e}"), }
+        let path = config_path();
+        if let Some(parent) = path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                tracing::warn!("failed to create config directory: {e}");
+                return;
+            }
+        }
+        match serde_json::to_string_pretty(self) {
+            Ok(json) => {
+                if let Err(e) = std::fs::write(&path, json) {
+                    tracing::warn!("failed to save config: {e}");
+                }
+            }
+            Err(e) => tracing::warn!("failed to serialise config: {e}"),
+        }
     }
-    #[allow(dead_code)] pub fn get_trusted(&self) -> &[String] { &self.trusted_processes }
-    pub fn add_trusted(&mut self, name: &str) -> bool { let key = normalise_name(name); if key.is_empty(){return false;} if self.trusted_processes.iter().any(|t| t.eq_ignore_ascii_case(&key)){return false;} self.trusted_processes.push(key); true }
-    #[allow(dead_code)] pub fn remove_trusted(&mut self, name: &str) -> bool { let before=self.trusted_processes.len(); self.trusted_processes.retain(|t| !t.eq_ignore_ascii_case(name)); self.trusted_processes.len() < before }
+    #[allow(dead_code)]
+    pub fn get_trusted(&self) -> &[String] {
+        &self.trusted_processes
+    }
+    pub fn add_trusted(&mut self, name: &str) -> bool {
+        let key = normalise_name(name);
+        if key.is_empty() {
+            return false;
+        }
+        if self
+            .trusted_processes
+            .iter()
+            .any(|t| t.eq_ignore_ascii_case(&key))
+        {
+            return false;
+        }
+        self.trusted_processes.push(key);
+        true
+    }
+    #[allow(dead_code)]
+    pub fn remove_trusted(&mut self, name: &str) -> bool {
+        let before = self.trusted_processes.len();
+        self.trusted_processes
+            .retain(|t| !t.eq_ignore_ascii_case(name));
+        self.trusted_processes.len() < before
+    }
 }
 
-pub fn normalise_name(name: &str) -> String { name.trim().to_lowercase().trim_end_matches(".exe").to_string() }
+pub fn normalise_name(name: &str) -> String {
+    name.trim()
+        .to_lowercase()
+        .trim_end_matches(".exe")
+        .to_string()
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[test] fn default_has_chrome_trusted() { let cfg = Config::default(); assert!(cfg.trusted_processes.contains(&"chrome".to_string())); }
-    #[test] fn add_trusted_normalises_name() { let mut cfg = Config::default(); assert!(cfg.add_trusted("MyApp.exe")); assert!(cfg.trusted_processes.contains(&"myapp".to_string())); }
-    #[test] fn add_trusted_no_duplicate() { let mut cfg = Config::default(); cfg.add_trusted("testapp"); assert!(!cfg.add_trusted("testapp")); assert_eq!(cfg.trusted_processes.iter().filter(|t| *t == "testapp").count(), 1); }
-    #[test] fn remove_trusted_works() { let mut cfg = Config::default(); cfg.add_trusted("removeme"); assert!(cfg.remove_trusted("removeme")); assert!(!cfg.trusted_processes.contains(&"removeme".to_string())); }
-    #[test] fn defaults_cover_phase_eleven_backlog() { let cfg = Config::default(); assert!(!cfg.allowlist_mode_enabled); assert!(cfg.allowlist_mode_dry_run); assert!(!cfg.response_rules_enabled); assert!(cfg.response_rules_dry_run); assert!(!cfg.honeypot_decoys_enabled); assert!(!cfg.honeypot_auto_isolate); assert_eq!(cfg.honeypot_poll_secs, 10); assert!(cfg.break_glass_enabled); }
+    #[test]
+    fn default_has_chrome_trusted() {
+        let cfg = Config::default();
+        assert!(cfg.trusted_processes.contains(&"chrome".to_string()));
+    }
+    #[test]
+    fn add_trusted_normalises_name() {
+        let mut cfg = Config::default();
+        assert!(cfg.add_trusted("MyApp.exe"));
+        assert!(cfg.trusted_processes.contains(&"myapp".to_string()));
+    }
+    #[test]
+    fn add_trusted_no_duplicate() {
+        let mut cfg = Config::default();
+        cfg.add_trusted("testapp");
+        assert!(!cfg.add_trusted("testapp"));
+        assert_eq!(
+            cfg.trusted_processes
+                .iter()
+                .filter(|t| *t == "testapp")
+                .count(),
+            1
+        );
+    }
+    #[test]
+    fn remove_trusted_works() {
+        let mut cfg = Config::default();
+        cfg.add_trusted("removeme");
+        assert!(cfg.remove_trusted("removeme"));
+        assert!(!cfg.trusted_processes.contains(&"removeme".to_string()));
+    }
+    #[test]
+    fn defaults_cover_phase_eleven_backlog() {
+        let cfg = Config::default();
+        assert!(!cfg.allowlist_mode_enabled);
+        assert!(cfg.allowlist_mode_dry_run);
+        assert!(!cfg.response_rules_enabled);
+        assert!(cfg.response_rules_dry_run);
+        assert!(!cfg.honeypot_decoys_enabled);
+        assert!(!cfg.honeypot_auto_isolate);
+        assert_eq!(cfg.honeypot_poll_secs, 10);
+        assert!(cfg.break_glass_enabled);
+    }
 }

--- a/src/forensics.rs
+++ b/src/forensics.rs
@@ -35,21 +35,29 @@ pub fn maybe_capture_process_dump(info: &ConnInfo, cfg: &Config) {
     match platform::capture_process_dump(info, cfg) {
         Ok(path) => {
             last.insert(info.pid, now);
-            audit::record("process_dump_on_alert", "success", json!({
-                "pid": info.pid,
-                "proc_name": info.proc_name,
-                "path": path.display().to_string(),
-                "score": info.score,
-            }));
+            audit::record(
+                "process_dump_on_alert",
+                "success",
+                json!({
+                    "pid": info.pid,
+                    "proc_name": info.proc_name,
+                    "path": path.display().to_string(),
+                    "score": info.score,
+                }),
+            );
             tracing::warn!(pid = info.pid, proc = %info.proc_name, dump = %path.display(), "captured process dump on alert");
         }
         Err(err) => {
-            audit::record("process_dump_on_alert", "error", json!({
-                "pid": info.pid,
-                "proc_name": info.proc_name,
-                "score": info.score,
-                "error": err,
-            }));
+            audit::record(
+                "process_dump_on_alert",
+                "error",
+                json!({
+                    "pid": info.pid,
+                    "proc_name": info.proc_name,
+                    "score": info.score,
+                    "error": err,
+                }),
+            );
             tracing::warn!(pid = info.pid, proc = %info.proc_name, %err, "failed to capture process dump on alert");
         }
     }
@@ -66,17 +74,29 @@ fn dump_root(cfg: &Config) -> PathBuf {
     if !cfg.process_dump_dir.trim().is_empty() {
         PathBuf::from(cfg.process_dump_dir.trim())
     } else {
-        crate::config::data_dir().join("artifacts").join("process-dumps")
+        crate::config::data_dir()
+            .join("artifacts")
+            .join("process-dumps")
     }
 }
 
 fn safe_name(text: &str) -> String {
     let cleaned: String = text
         .chars()
-        .map(|c| if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' { c } else { '_' })
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
         .collect();
     let cleaned = cleaned.trim_matches('_');
-    if cleaned.is_empty() { "process".to_string() } else { cleaned.to_string() }
+    if cleaned.is_empty() {
+        "process".to_string()
+    } else {
+        cleaned.to_string()
+    }
 }
 
 #[cfg(windows)]
@@ -86,10 +106,17 @@ mod platform {
 
     pub fn capture_process_dump(info: &ConnInfo, cfg: &Config) -> Result<PathBuf, String> {
         let dir = dump_root(cfg);
-        std::fs::create_dir_all(&dir).map_err(|e| format!("failed to create {}: {e}", dir.display()))?;
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| format!("failed to create {}: {e}", dir.display()))?;
 
         let stamp = chrono::Local::now().format("%Y%m%d-%H%M%S").to_string();
-        let filename = format!("{}-pid{}-score{}-{}.dmp", stamp, info.pid, info.score, safe_name(&info.proc_name));
+        let filename = format!(
+            "{}-pid{}-score{}-{}.dmp",
+            stamp,
+            info.pid,
+            info.score,
+            safe_name(&info.proc_name)
+        );
         let out = dir.join(filename);
 
         let status = Command::new("rundll32.exe")
@@ -104,7 +131,10 @@ mod platform {
             return Err(format!("rundll32 MiniDump exited with status {status}"));
         }
         if !out.exists() {
-            return Err(format!("expected dump file {} was not created", out.display()));
+            return Err(format!(
+                "expected dump file {} was not created",
+                out.display()
+            ));
         }
         Ok(out)
     }

--- a/src/honeypot.rs
+++ b/src/honeypot.rs
@@ -4,7 +4,11 @@
 //! poll them for timestamp changes. Any touch triggers a synthetic high-score
 //! alert and can optionally auto-isolate the machine.
 
-use crate::{active_response, audit, config::Config, types::{ConnEvent, ConnInfo}};
+use crate::{
+    active_response, audit,
+    config::Config,
+    types::{ConnEvent, ConnInfo},
+};
 use chrono::Local;
 use serde_json::json;
 use std::path::{Path, PathBuf};
@@ -39,7 +43,11 @@ pub fn start(cfg: Arc<RwLock<Config>>, tx: broadcast::Sender<ConnEvent>, thresho
                         decoy.modified_unix = updated;
                         let info = synthetic_alert(&decoy.path, threshold.max(10));
                         let _ = tx.send(ConnEvent::Alert(info.clone()));
-                        audit::record("honeypot_decoy", "success", json!({"path": decoy.path.display().to_string(), "score": info.score}));
+                        audit::record(
+                            "honeypot_decoy",
+                            "success",
+                            json!({"path": decoy.path.display().to_string(), "score": info.score}),
+                        );
                         if current_cfg.honeypot_auto_isolate {
                             let _ = active_response::isolate_machine();
                         }
@@ -89,7 +97,10 @@ fn ensure_decoys(cfg: &Config) -> Vec<DecoyEntry> {
             if !path.exists() {
                 let _ = std::fs::write(&path, decoy_contents(name));
             }
-            out.push(DecoyEntry { modified_unix: modified_unix(&path).unwrap_or(0), path });
+            out.push(DecoyEntry {
+                modified_unix: modified_unix(&path).unwrap_or(0),
+                path,
+            });
         }
     }
     out
@@ -101,7 +112,10 @@ fn decoy_contents(name: &str) -> String {
 
 fn watched_dirs() -> Vec<PathBuf> {
     let mut out = Vec::new();
-    if let Some(home) = std::env::var_os("USERPROFILE").or_else(|| std::env::var_os("HOME")).map(PathBuf::from) {
+    if let Some(home) = std::env::var_os("USERPROFILE")
+        .or_else(|| std::env::var_os("HOME"))
+        .map(PathBuf::from)
+    {
         out.push(home.join("Desktop"));
         out.push(home.join("Documents"));
         out.push(home.join("Downloads"));
@@ -117,5 +131,8 @@ fn watched_dirs() -> Vec<PathBuf> {
 
 fn modified_unix(path: &Path) -> Option<u64> {
     let modified = std::fs::metadata(path).ok()?.modified().ok()?;
-    modified.duration_since(std::time::UNIX_EPOCH).ok().map(|d| d.as_secs())
+    modified
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,10 @@
 //! context.  We therefore build the tokio runtime manually on background
 //! threads, spawn all async tasks into it, then hand the main thread to eframe.
 
-#![cfg_attr(all(not(debug_assertions), target_os = "windows"), windows_subsystem = "windows")]
+#![cfg_attr(
+    all(not(debug_assertions), target_os = "windows"),
+    windows_subsystem = "windows"
+)]
 
 mod active_response;
 mod audit;
@@ -68,10 +71,15 @@ fn main() {
     #[cfg(windows)]
     {
         use windows::Win32::UI::Shell::SetCurrentProcessExplicitAppUserModelID;
-        unsafe { let _ = SetCurrentProcessExplicitAppUserModelID(windows::core::w!("Vigil.App.1")); }
+        unsafe {
+            let _ = SetCurrentProcessExplicitAppUserModelID(windows::core::w!("Vigil.App.1"));
+        }
     }
 
-    let rt = tokio::runtime::Builder::new_multi_thread().enable_all().build().expect("failed to build tokio runtime");
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime");
     let _guard = rt.enter();
 
     let cfg = Arc::new(RwLock::new(Config::load()));
@@ -79,10 +87,21 @@ fn main() {
         let c = cfg.read().unwrap();
         geoip::init(&c.geoip_city_db, &c.geoip_asn_db);
         blocklist::init(&c.blocklist_paths);
-        if c.fswatch_enabled { fswatch::start(); }
-        if c.reverse_dns_enabled { revdns::start(); }
+        if c.fswatch_enabled {
+            fswatch::start();
+        }
+        if c.reverse_dns_enabled {
+            revdns::start();
+        }
         let (n_lists, n_entries) = blocklist::stats();
-        tracing::info!("Phase 10: geoip={}, blocklists={} ({} entries), fswatch={}, revdns={}", geoip::is_loaded(), n_lists, n_entries, c.fswatch_enabled, c.reverse_dns_enabled);
+        tracing::info!(
+            "Phase 10: geoip={}, blocklists={} ({} entries), fswatch={}, revdns={}",
+            geoip::is_loaded(),
+            n_lists,
+            n_entries,
+            c.fswatch_enabled,
+            c.reverse_dns_enabled
+        );
     }
 
     active_response::reconcile();
@@ -91,7 +110,12 @@ fn main() {
     {
         let mut w = cfg.write().unwrap();
         if !w.first_run_done {
-            if autostart::enable() { w.autostart = true; tracing::info!("autostart enabled"); } else { tracing::warn!("could not enable autostart"); }
+            if autostart::enable() {
+                w.autostart = true;
+                tracing::info!("autostart enabled");
+            } else {
+                tracing::warn!("could not enable autostart");
+            }
             w.first_run_done = true;
             w.save();
         }
@@ -99,7 +123,9 @@ fn main() {
 
     {
         let c = cfg.read().unwrap();
-        if c.autostart && !autostart::enable() { tracing::warn!("could not refresh autostart"); }
+        if c.autostart && !autostart::enable() {
+            tracing::warn!("could not refresh autostart");
+        }
     }
 
     let mon = Monitor::new(cfg.clone());
@@ -108,19 +134,40 @@ fn main() {
 
     let show_window = Arc::new(AtomicBool::new(false));
     let show_window_tray = show_window.clone();
-    let pending_nav: Arc<std::sync::Mutex<Option<crate::types::ConnInfo>>> = Arc::new(std::sync::Mutex::new(None));
+    let pending_nav: Arc<std::sync::Mutex<Option<crate::types::ConnInfo>>> =
+        Arc::new(std::sync::Mutex::new(None));
     let pending_nav_tray = pending_nav.clone();
     let pending_nav_ui = pending_nav.clone();
     let (tray_tx, tray_rx) = std::sync::mpsc::sync_channel::<tray::TrayCmd>(64);
 
-    std::thread::Builder::new().name("vigil-tray".into()).spawn(move || tray::run(tray_rx, show_window_tray, log_dir, pending_nav_tray)).expect("failed to spawn tray thread");
+    std::thread::Builder::new()
+        .name("vigil-tray".into())
+        .spawn(move || tray::run(tray_rx, show_window_tray, log_dir, pending_nav_tray))
+        .expect("failed to spawn tray thread");
 
     let native_options = eframe::NativeOptions {
-        viewport: egui::ViewportBuilder::default().with_title("Vigil").with_inner_size([1080.0, 680.0]).with_min_inner_size([700.0, 440.0]),
+        viewport: egui::ViewportBuilder::default()
+            .with_title("Vigil")
+            .with_inner_size([1080.0, 680.0])
+            .with_min_inner_size([700.0, 440.0]),
         persist_window: true,
         ..Default::default()
     };
 
     let cfg_ui = cfg.clone();
-    eframe::run_native("Vigil", native_options, Box::new(move |cc| Ok(Box::new(ui::VigilApp::new(cc, cfg_ui, event_rx, tray_tx, show_window, pending_nav_ui))))).expect("eframe failed");
+    eframe::run_native(
+        "Vigil",
+        native_options,
+        Box::new(move |cc| {
+            Ok(Box::new(ui::VigilApp::new(
+                cc,
+                cfg_ui,
+                event_rx,
+                tray_tx,
+                show_window,
+                pending_nav_ui,
+            )))
+        }),
+    )
+    .expect("eframe failed");
 }

--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -44,30 +44,95 @@ use tokio::sync::{broadcast, mpsc};
 use tokio::time::{sleep, Duration};
 
 #[derive(PartialEq, Eq, Hash, Clone)]
-struct ConnKey { pid: u32, local_ip: String, local_port: u16, remote_ip: String, remote_port: u16 }
-impl From<&RawConn> for ConnKey { fn from(c: &RawConn) -> Self { Self { pid: c.pid, local_ip: c.local_ip.clone(), local_port: c.local_port, remote_ip: c.remote_ip.clone(), remote_port: c.remote_port } } }
-
-pub struct Monitor { config: Arc<RwLock<Config>>, tx: broadcast::Sender<ConnEvent>, _cmd_tx: mpsc::Sender<MonitorCmd> }
-impl Monitor {
-    pub fn new(config: Arc<RwLock<Config>>) -> Self { let (tx, _) = broadcast::channel(4096); let (cmd_tx, _) = mpsc::channel(32); Self { config, tx, _cmd_tx: cmd_tx } }
-    pub fn subscribe(&self) -> broadcast::Receiver<ConnEvent> { self.tx.subscribe() }
-    pub fn start(self) -> tokio::task::JoinHandle<()> {
-        let config = self.config.clone(); let tx = self.tx.clone(); let (etw_tx, etw_rx) = mpsc::unbounded_channel::<RawConn>(); let using_etw = etw::start(etw_tx); let etw_rx = if using_etw { Some(etw_rx) } else { None };
-        if using_etw { tracing::info!("ETW kernel session started — real-time TCP monitoring active"); } else { tracing::info!("ETW unavailable — falling back to polling"); }
-        let threshold = config.read().unwrap().alert_threshold;
-        registry::win::spawn(tx.clone(), threshold);
-        honeypot::start(config.clone(), tx.clone(), threshold);
-        tokio::task::spawn_blocking(move || { let rt = tokio::runtime::Handle::current(); rt.block_on(poll_loop(config, tx, etw_rx)) })
+struct ConnKey {
+    pid: u32,
+    local_ip: String,
+    local_port: u16,
+    remote_ip: String,
+    remote_port: u16,
+}
+impl From<&RawConn> for ConnKey {
+    fn from(c: &RawConn) -> Self {
+        Self {
+            pid: c.pid,
+            local_ip: c.local_ip.clone(),
+            local_port: c.local_port,
+            remote_ip: c.remote_ip.clone(),
+            remote_port: c.remote_port,
+        }
     }
 }
 
-async fn recv_etw(rx: &mut Option<mpsc::UnboundedReceiver<RawConn>>) -> Option<RawConn> { match rx.as_mut() { Some(r) => r.recv().await, None => std::future::pending().await } }
+pub struct Monitor {
+    config: Arc<RwLock<Config>>,
+    tx: broadcast::Sender<ConnEvent>,
+    _cmd_tx: mpsc::Sender<MonitorCmd>,
+}
+impl Monitor {
+    pub fn new(config: Arc<RwLock<Config>>) -> Self {
+        let (tx, _) = broadcast::channel(4096);
+        let (cmd_tx, _) = mpsc::channel(32);
+        Self {
+            config,
+            tx,
+            _cmd_tx: cmd_tx,
+        }
+    }
+    pub fn subscribe(&self) -> broadcast::Receiver<ConnEvent> {
+        self.tx.subscribe()
+    }
+    pub fn start(self) -> tokio::task::JoinHandle<()> {
+        let config = self.config.clone();
+        let tx = self.tx.clone();
+        let (etw_tx, etw_rx) = mpsc::unbounded_channel::<RawConn>();
+        let using_etw = etw::start(etw_tx);
+        let etw_rx = if using_etw { Some(etw_rx) } else { None };
+        if using_etw {
+            tracing::info!("ETW kernel session started — real-time TCP monitoring active");
+        } else {
+            tracing::info!("ETW unavailable — falling back to polling");
+        }
+        let threshold = config.read().unwrap().alert_threshold;
+        registry::win::spawn(tx.clone(), threshold);
+        honeypot::start(config.clone(), tx.clone(), threshold);
+        tokio::task::spawn_blocking(move || {
+            let rt = tokio::runtime::Handle::current();
+            rt.block_on(poll_loop(config, tx, etw_rx))
+        })
+    }
+}
 
-async fn poll_loop(config: Arc<RwLock<Config>>, tx: broadcast::Sender<ConnEvent>, mut etw_rx: Option<mpsc::UnboundedReceiver<RawConn>>) {
-    let using_etw = etw_rx.is_some(); let mut known: HashMap<ConnKey, ConnInfo> = HashMap::new(); let mut beacon = BeaconTracker::new(); let long_lived = std::sync::Arc::new(LongLivedTracker::new()); let mut svc_map = process::build_service_map();
+async fn recv_etw(rx: &mut Option<mpsc::UnboundedReceiver<RawConn>>) -> Option<RawConn> {
+    match rx.as_mut() {
+        Some(r) => r.recv().await,
+        None => std::future::pending().await,
+    }
+}
+
+async fn poll_loop(
+    config: Arc<RwLock<Config>>,
+    tx: broadcast::Sender<ConnEvent>,
+    mut etw_rx: Option<mpsc::UnboundedReceiver<RawConn>>,
+) {
+    let using_etw = etw_rx.is_some();
+    let mut known: HashMap<ConnKey, ConnInfo> = HashMap::new();
+    let mut beacon = BeaconTracker::new();
+    let long_lived = std::sync::Arc::new(LongLivedTracker::new());
+    let mut svc_map = process::build_service_map();
     loop {
-        let (interval, threshold, log_all) = { let cfg = config.read().unwrap(); (cfg.poll_interval_secs, cfg.alert_threshold, cfg.log_all_connections) };
-        let poll_secs = if using_etw { (interval * 6).clamp(30, 60) } else { interval.max(1) };
+        let (interval, threshold, log_all) = {
+            let cfg = config.read().unwrap();
+            (
+                cfg.poll_interval_secs,
+                cfg.alert_threshold,
+                cfg.log_all_connections,
+            )
+        };
+        let poll_secs = if using_etw {
+            (interval * 6).clamp(30, 60)
+        } else {
+            interval.max(1)
+        };
         tokio::select! {
             raw = recv_etw(&mut etw_rx) => {
                 match raw {
@@ -90,18 +155,124 @@ async fn poll_loop(config: Arc<RwLock<Config>>, tx: broadcast::Sender<ConnEvent>
 }
 
 #[allow(clippy::too_many_arguments)]
-fn process_conn(raw_conn: &RawConn, beaconing: bool, known: &mut HashMap<ConnKey, ConnInfo>, svc_map: &HashMap<u32, String>, config: &Arc<RwLock<Config>>, tx: &broadcast::Sender<ConnEvent>, threshold: u8, log_all: bool, long_lived: &LongLivedTracker) {
-    let proc = process::collect(raw_conn.pid, svc_map); let ancestors_norm: Vec<(String, u32)> = proc.ancestors.iter().map(|(n, pid)| (crate::config::normalise_name(n), *pid)).collect(); let pre_login = session::is_pre_login();
-    let (fs_window, long_threshold, rev_enabled, reputation_enabled, forensic_cfg) = { let cfg = config.read().unwrap(); (std::time::Duration::from_secs(cfg.fswatch_window_secs), std::time::Duration::from_secs(cfg.long_lived_secs), cfg.reverse_dns_enabled, !cfg.blocklist_paths.is_empty(), cfg.clone()) };
-    let reputation_hit: Option<String> = if reputation_enabled { blocklist::lookup(&raw_conn.remote_ip) } else { None };
-    let geo = if !raw_conn.remote_ip.is_empty() { geoip::lookup(&raw_conn.remote_ip) } else { crate::geoip::GeoInfo::default() };
-    let hostname: Option<String> = if rev_enabled && !raw_conn.remote_ip.is_empty() { revdns::lookup(&raw_conn.remote_ip).filter(|s| !s.is_empty()) } else { None };
-    let recently_dropped = !proc.path.is_empty() && fswatch::dropped_within(&proc.path, fs_window).is_some(); let ll_flag = !raw_conn.remote_ip.is_empty() && long_lived.is_long_lived(raw_conn.pid, &raw_conn.remote_ip, long_threshold);
-    let (s, reasons) = { let cfg = config.read().unwrap(); score(&ScoreInput { name: &proc.name_key, path: &proc.path, publisher: &proc.publisher, remote_ip: &raw_conn.remote_ip, remote_port: raw_conn.remote_port, status: &raw_conn.status, ancestors: &ancestors_norm, beaconing, pre_login, reputation_hit: reputation_hit.as_deref(), country: geo.country.as_deref(), hostname: hostname.as_deref(), recently_dropped, long_lived: ll_flag }, &cfg) };
-    let local_addr = format!("{}:{}", raw_conn.local_ip, raw_conn.local_port); let remote_addr = if raw_conn.remote_ip.is_empty() { "LISTEN".to_string() } else { format!("{}:{}", raw_conn.remote_ip, raw_conn.remote_port) };
-    let dga_like = { let cfg = config.read().unwrap(); hostname.as_deref().map(|h| crate::entropy::is_dga_like(h, cfg.dga_entropy_threshold)).unwrap_or(false) };
-    let info = ConnInfo { timestamp: Local::now().format("%H:%M:%S").to_string(), proc_name: proc.name.clone(), pid: raw_conn.pid, proc_path: proc.path.clone(), proc_user: proc.user.clone(), parent_name: proc.parent_name.clone(), parent_pid: proc.parent_pid, ancestor_chain: proc.ancestors.clone(), service_name: proc.service_name.clone(), publisher: proc.publisher.clone(), local_addr, remote_addr, status: raw_conn.status.clone(), score: s, reasons: reasons.clone(), pre_login, hostname, country: geo.country, asn: geo.asn, asn_org: geo.asn_org, reputation_hit, recently_dropped, long_lived: ll_flag, dga_like };
-    let key = ConnKey::from(raw_conn); known.insert(key, info.clone());
-    let event = if s >= threshold { forensics::maybe_capture_process_dump(&info, &forensic_cfg); pcap::maybe_capture_pcap(&info, &forensic_cfg); ConnEvent::Alert(info) } else if s > 0 || log_all { ConnEvent::New(info) } else { return; };
+fn process_conn(
+    raw_conn: &RawConn,
+    beaconing: bool,
+    known: &mut HashMap<ConnKey, ConnInfo>,
+    svc_map: &HashMap<u32, String>,
+    config: &Arc<RwLock<Config>>,
+    tx: &broadcast::Sender<ConnEvent>,
+    threshold: u8,
+    log_all: bool,
+    long_lived: &LongLivedTracker,
+) {
+    let proc = process::collect(raw_conn.pid, svc_map);
+    let ancestors_norm: Vec<(String, u32)> = proc
+        .ancestors
+        .iter()
+        .map(|(n, pid)| (crate::config::normalise_name(n), *pid))
+        .collect();
+    let pre_login = session::is_pre_login();
+    let (fs_window, long_threshold, rev_enabled, reputation_enabled, forensic_cfg) = {
+        let cfg = config.read().unwrap();
+        (
+            std::time::Duration::from_secs(cfg.fswatch_window_secs),
+            std::time::Duration::from_secs(cfg.long_lived_secs),
+            cfg.reverse_dns_enabled,
+            !cfg.blocklist_paths.is_empty(),
+            cfg.clone(),
+        )
+    };
+    let reputation_hit: Option<String> = if reputation_enabled {
+        blocklist::lookup(&raw_conn.remote_ip)
+    } else {
+        None
+    };
+    let geo = if !raw_conn.remote_ip.is_empty() {
+        geoip::lookup(&raw_conn.remote_ip)
+    } else {
+        crate::geoip::GeoInfo::default()
+    };
+    let hostname: Option<String> = if rev_enabled && !raw_conn.remote_ip.is_empty() {
+        revdns::lookup(&raw_conn.remote_ip).filter(|s| !s.is_empty())
+    } else {
+        None
+    };
+    let recently_dropped =
+        !proc.path.is_empty() && fswatch::dropped_within(&proc.path, fs_window).is_some();
+    let ll_flag = !raw_conn.remote_ip.is_empty()
+        && long_lived.is_long_lived(raw_conn.pid, &raw_conn.remote_ip, long_threshold);
+    let (s, reasons) = {
+        let cfg = config.read().unwrap();
+        score(
+            &ScoreInput {
+                name: &proc.name_key,
+                path: &proc.path,
+                publisher: &proc.publisher,
+                remote_ip: &raw_conn.remote_ip,
+                remote_port: raw_conn.remote_port,
+                status: &raw_conn.status,
+                ancestors: &ancestors_norm,
+                beaconing,
+                pre_login,
+                reputation_hit: reputation_hit.as_deref(),
+                country: geo.country.as_deref(),
+                hostname: hostname.as_deref(),
+                recently_dropped,
+                long_lived: ll_flag,
+            },
+            &cfg,
+        )
+    };
+    let local_addr = format!("{}:{}", raw_conn.local_ip, raw_conn.local_port);
+    let remote_addr = if raw_conn.remote_ip.is_empty() {
+        "LISTEN".to_string()
+    } else {
+        format!("{}:{}", raw_conn.remote_ip, raw_conn.remote_port)
+    };
+    let dga_like = {
+        let cfg = config.read().unwrap();
+        hostname
+            .as_deref()
+            .map(|h| crate::entropy::is_dga_like(h, cfg.dga_entropy_threshold))
+            .unwrap_or(false)
+    };
+    let info = ConnInfo {
+        timestamp: Local::now().format("%H:%M:%S").to_string(),
+        proc_name: proc.name.clone(),
+        pid: raw_conn.pid,
+        proc_path: proc.path.clone(),
+        proc_user: proc.user.clone(),
+        parent_name: proc.parent_name.clone(),
+        parent_pid: proc.parent_pid,
+        ancestor_chain: proc.ancestors.clone(),
+        service_name: proc.service_name.clone(),
+        publisher: proc.publisher.clone(),
+        local_addr,
+        remote_addr,
+        status: raw_conn.status.clone(),
+        score: s,
+        reasons: reasons.clone(),
+        pre_login,
+        hostname,
+        country: geo.country,
+        asn: geo.asn,
+        asn_org: geo.asn_org,
+        reputation_hit,
+        recently_dropped,
+        long_lived: ll_flag,
+        dga_like,
+    };
+    let key = ConnKey::from(raw_conn);
+    known.insert(key, info.clone());
+    let event = if s >= threshold {
+        forensics::maybe_capture_process_dump(&info, &forensic_cfg);
+        pcap::maybe_capture_pcap(&info, &forensic_cfg);
+        ConnEvent::Alert(info)
+    } else if s > 0 || log_all {
+        ConnEvent::New(info)
+    } else {
+        return;
+    };
     let _ = tx.send(event);
 }

--- a/src/pcap.rs
+++ b/src/pcap.rs
@@ -40,12 +40,16 @@ pub fn maybe_capture_pcap(info: &ConnInfo, cfg: &Config) {
         Err(_) => return,
     };
     if *active_guard {
-        audit::record("pcap_on_alert", "skipped", json!({
-            "pid": info.pid,
-            "proc_name": info.proc_name,
-            "reason": "capture already active",
-            "score": info.score,
-        }));
+        audit::record(
+            "pcap_on_alert",
+            "skipped",
+            json!({
+                "pid": info.pid,
+                "proc_name": info.proc_name,
+                "reason": "capture already active",
+                "score": info.score,
+            }),
+        );
         return;
     }
     *active_guard = true;
@@ -104,10 +108,20 @@ fn capture_root(cfg: &Config) -> PathBuf {
 fn safe_name(text: &str) -> String {
     let cleaned: String = text
         .chars()
-        .map(|c| if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' { c } else { '_' })
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
         .collect();
     let cleaned = cleaned.trim_matches('_');
-    if cleaned.is_empty() { "process".to_string() } else { cleaned.to_string() }
+    if cleaned.is_empty() {
+        "process".to_string()
+    } else {
+        cleaned.to_string()
+    }
 }
 
 #[cfg(windows)]
@@ -117,10 +131,17 @@ mod platform {
 
     pub fn capture_window(info: &ConnInfo, cfg: &Config) -> Result<PathBuf, String> {
         let dir = capture_root(cfg);
-        std::fs::create_dir_all(&dir).map_err(|e| format!("failed to create {}: {e}", dir.display()))?;
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| format!("failed to create {}: {e}", dir.display()))?;
 
         let stamp = chrono::Local::now().format("%Y%m%d-%H%M%S").to_string();
-        let stem = format!("{}-pid{}-score{}-{}", stamp, info.pid, info.score, safe_name(&info.proc_name));
+        let stem = format!(
+            "{}-pid{}-score{}-{}",
+            stamp,
+            info.pid,
+            info.score,
+            safe_name(&info.proc_name)
+        );
         let etl = dir.join(format!("{stem}.etl"));
         let pcapng = dir.join(format!("{stem}.pcapng"));
 
@@ -128,29 +149,20 @@ mod platform {
         let _ = Command::new("pktmon.exe").arg("reset").status();
 
         let start = Command::new("pktmon.exe")
-            .args([
-                "start",
-                "--capture",
-                "--file-name",
-            ])
+            .args(["start", "--capture", "--file-name"])
             .arg(&etl)
-            .args([
-                "--pkt-size",
-            ])
+            .args(["--pkt-size"])
             .arg(cfg.pcap_packet_size_bytes.to_string())
-            .args([
-                "--file-size",
-                "64",
-                "--log-mode",
-                "memory",
-            ])
+            .args(["--file-size", "64", "--log-mode", "memory"])
             .status()
             .map_err(|e| format!("failed to spawn pktmon start: {e}"))?;
         if !start.success() {
             return Err(format!("pktmon start exited with status {start}"));
         }
 
-        std::thread::sleep(std::time::Duration::from_secs(cfg.pcap_duration_secs.max(1)));
+        std::thread::sleep(std::time::Duration::from_secs(
+            cfg.pcap_duration_secs.max(1),
+        ));
 
         let stop = Command::new("pktmon.exe")
             .arg("stop")
@@ -171,7 +183,10 @@ mod platform {
             return Err(format!("pktmon etl2pcap exited with status {convert}"));
         }
         if !pcapng.exists() {
-            return Err(format!("expected pcap file {} was not created", pcapng.display()));
+            return Err(format!(
+                "expected pcap file {} was not created",
+                pcapng.display()
+            ));
         }
 
         let _ = Command::new("pktmon.exe").arg("reset").status();

--- a/src/quarantine.rs
+++ b/src/quarantine.rs
@@ -13,43 +13,216 @@ use std::path::PathBuf;
 const STATE_FILE: &str = "vigil-quarantine-state.json";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-struct State { usb_disabled: bool, paused_tasks: Vec<String> }
+struct State {
+    usb_disabled: bool,
+    paused_tasks: Vec<String>,
+}
 
 pub fn apply() -> (Vec<String>, Vec<String>) {
     #[cfg(windows)]
     {
-        let mut state = load_state().unwrap_or_default(); let mut applied = Vec::new(); let mut warnings = Vec::new();
-        match platform::disable_usb_storage() { Ok(changed) => { if changed { state.usb_disabled = true; applied.push("USB storage disabled".into()); } } Err(err) => warnings.push(format!("USB disable failed: {err}")), }
-        match platform::pause_scheduled_tasks() { Ok(tasks) => { if !tasks.is_empty() { state.paused_tasks = tasks.clone(); applied.push(format!("{} scheduled task(s) paused", tasks.len())); } } Err(err) => warnings.push(format!("scheduled-task pause failed: {err}")), }
-        let _ = save_state(&state); audit::record("quarantine_extended_apply", if warnings.is_empty() { "success" } else { "partial" }, json!({"applied": applied, "warnings": warnings, "paused_tasks": state.paused_tasks})); (applied, warnings)
+        let mut state = load_state().unwrap_or_default();
+        let mut applied = Vec::new();
+        let mut warnings = Vec::new();
+        match platform::disable_usb_storage() {
+            Ok(changed) => {
+                if changed {
+                    state.usb_disabled = true;
+                    applied.push("USB storage disabled".into());
+                }
+            }
+            Err(err) => warnings.push(format!("USB disable failed: {err}")),
+        }
+        match platform::pause_scheduled_tasks() {
+            Ok(tasks) => {
+                if !tasks.is_empty() {
+                    state.paused_tasks = tasks.clone();
+                    applied.push(format!("{} scheduled task(s) paused", tasks.len()));
+                }
+            }
+            Err(err) => warnings.push(format!("scheduled-task pause failed: {err}")),
+        }
+        let _ = save_state(&state);
+        audit::record(
+            "quarantine_extended_apply",
+            if warnings.is_empty() {
+                "success"
+            } else {
+                "partial"
+            },
+            json!({"applied": applied, "warnings": warnings, "paused_tasks": state.paused_tasks}),
+        );
+        (applied, warnings)
     }
     #[cfg(not(windows))]
-    { (Vec::new(), vec!["extended quarantine is not implemented on this platform".into()]) }
+    {
+        (
+            Vec::new(),
+            vec!["extended quarantine is not implemented on this platform".into()],
+        )
+    }
 }
 
 pub fn clear() -> (Vec<String>, Vec<String>) {
     #[cfg(windows)]
     {
-        let state = load_state().unwrap_or_default(); let mut cleared = Vec::new(); let mut warnings = Vec::new();
-        if state.usb_disabled { match platform::restore_usb_storage() { Ok(()) => cleared.push("USB storage restored".into()), Err(err) => warnings.push(format!("USB restore failed: {err}")), } }
-        if !state.paused_tasks.is_empty() { match platform::resume_scheduled_tasks(&state.paused_tasks) { Ok(restored) => { if restored > 0 { cleared.push(format!("{} scheduled task(s) resumed", restored)); } } Err(err) => warnings.push(format!("scheduled-task resume failed: {err}")), } }
-        let _ = std::fs::remove_file(state_path()); audit::record("quarantine_extended_clear", if warnings.is_empty() { "success" } else { "partial" }, json!({"cleared": cleared, "warnings": warnings })); (cleared, warnings)
+        let state = load_state().unwrap_or_default();
+        let mut cleared = Vec::new();
+        let mut warnings = Vec::new();
+        if state.usb_disabled {
+            match platform::restore_usb_storage() {
+                Ok(()) => cleared.push("USB storage restored".into()),
+                Err(err) => warnings.push(format!("USB restore failed: {err}")),
+            }
+        }
+        if !state.paused_tasks.is_empty() {
+            match platform::resume_scheduled_tasks(&state.paused_tasks) {
+                Ok(restored) => {
+                    if restored > 0 {
+                        cleared.push(format!("{} scheduled task(s) resumed", restored));
+                    }
+                }
+                Err(err) => warnings.push(format!("scheduled-task resume failed: {err}")),
+            }
+        }
+        let _ = std::fs::remove_file(state_path());
+        audit::record(
+            "quarantine_extended_clear",
+            if warnings.is_empty() {
+                "success"
+            } else {
+                "partial"
+            },
+            json!({"cleared": cleared, "warnings": warnings }),
+        );
+        (cleared, warnings)
     }
     #[cfg(not(windows))]
-    { (Vec::new(), vec!["extended quarantine clear is not implemented on this platform".into()]) }
+    {
+        (
+            Vec::new(),
+            vec!["extended quarantine clear is not implemented on this platform".into()],
+        )
+    }
 }
 
-fn state_path() -> PathBuf { crate::config::data_dir().join(STATE_FILE) }
-fn load_state() -> Result<State, String> { let path = state_path(); if !path.exists() { return Ok(State::default()); } let text = std::fs::read_to_string(&path).map_err(|e| format!("failed to read {}: {e}", path.display()))?; serde_json::from_str(&text).map_err(|e| format!("failed to parse {}: {e}", path.display())) }
-fn save_state(state: &State) -> Result<(), String> { let path = state_path(); if let Some(parent) = path.parent() { std::fs::create_dir_all(parent).map_err(|e| format!("failed to create {}: {e}", parent.display()))?; } let text = serde_json::to_string_pretty(state).map_err(|e| format!("failed to serialise quarantine state: {e}"))?; std::fs::write(&path, text).map_err(|e| format!("failed to write {}: {e}", path.display())) }
+fn state_path() -> PathBuf {
+    crate::config::data_dir().join(STATE_FILE)
+}
+fn load_state() -> Result<State, String> {
+    let path = state_path();
+    if !path.exists() {
+        return Ok(State::default());
+    }
+    let text = std::fs::read_to_string(&path)
+        .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    serde_json::from_str(&text).map_err(|e| format!("failed to parse {}: {e}", path.display()))
+}
+fn save_state(state: &State) -> Result<(), String> {
+    let path = state_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
+    }
+    let text = serde_json::to_string_pretty(state)
+        .map_err(|e| format!("failed to serialise quarantine state: {e}"))?;
+    std::fs::write(&path, text).map_err(|e| format!("failed to write {}: {e}", path.display()))
+}
 
 #[cfg(windows)]
 mod platform {
-    use std::path::PathBuf; use std::process::Command; use windows::Win32::System::SystemInformation::GetSystemWindowsDirectoryW; use winreg::enums::HKEY_LOCAL_MACHINE; use winreg::RegKey;
-    pub fn disable_usb_storage() -> Result<bool, String> { let hklm = RegKey::predef(HKEY_LOCAL_MACHINE); let (key, _) = hklm.create_subkey(r"SYSTEM\CurrentControlSet\Services\USBSTOR").map_err(|e| format!("failed to open USBSTOR key: {e}"))?; let current = key.get_value::<u32, _>("Start").unwrap_or(3); if current == 4 { return Ok(false); } key.set_value("Start", &4u32).map_err(|e| format!("failed to set USBSTOR Start=4: {e}"))?; Ok(true) }
-    pub fn restore_usb_storage() -> Result<(), String> { let hklm = RegKey::predef(HKEY_LOCAL_MACHINE); let (key, _) = hklm.create_subkey(r"SYSTEM\CurrentControlSet\Services\USBSTOR").map_err(|e| format!("failed to open USBSTOR key: {e}"))?; key.set_value("Start", &3u32).map_err(|e| format!("failed to set USBSTOR Start=3: {e}")) }
-    pub fn pause_scheduled_tasks() -> Result<Vec<String>, String> { let output = schtasks().args(["/Query", "/FO", "CSV", "/NH"]).output().map_err(|e| format!("failed to run schtasks /Query: {e}"))?; if !output.status.success() { return Err(format!("schtasks /Query failed with status {}", output.status)); } let text = String::from_utf8_lossy(&output.stdout); let mut paused = Vec::new(); for line in text.lines() { let line = line.trim(); if line.is_empty() { continue; } let mut cols = line.split('","').map(|s| s.trim_matches('"')); let Some(task_name) = cols.next() else { continue; }; if task_name.starts_with("\\Microsoft\\") || task_name.eq_ignore_ascii_case("TaskName") { continue; } let status = schtasks().args(["/Change", "/TN", task_name, "/Disable"]).status().map_err(|e| format!("failed to disable {task_name}: {e}"))?; if status.success() { paused.push(task_name.to_string()); } } Ok(paused) }
-    pub fn resume_scheduled_tasks(tasks: &[String]) -> Result<usize, String> { let mut restored = 0usize; for task in tasks { let status = schtasks().args(["/Change", "/TN", task, "/Enable"]).status().map_err(|e| format!("failed to enable {task}: {e}"))?; if status.success() { restored += 1; } } Ok(restored) }
-    fn schtasks() -> Command { let path = windows_directory().unwrap_or_else(|| PathBuf::from(r"C:\Windows")).join("System32").join("schtasks.exe"); Command::new(path) }
-    fn windows_directory() -> Option<PathBuf> { let mut buffer = vec![0u16; 260]; unsafe { let len = GetSystemWindowsDirectoryW(Some(&mut buffer)); if len == 0 { return None; } Some(PathBuf::from(String::from_utf16_lossy(&buffer[..len as usize]))) } }
+    use std::path::PathBuf;
+    use std::process::Command;
+    use windows::Win32::System::SystemInformation::GetSystemWindowsDirectoryW;
+    use winreg::enums::HKEY_LOCAL_MACHINE;
+    use winreg::RegKey;
+    pub fn disable_usb_storage() -> Result<bool, String> {
+        let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+        let (key, _) = hklm
+            .create_subkey(r"SYSTEM\CurrentControlSet\Services\USBSTOR")
+            .map_err(|e| format!("failed to open USBSTOR key: {e}"))?;
+        let current = key.get_value::<u32, _>("Start").unwrap_or(3);
+        if current == 4 {
+            return Ok(false);
+        }
+        key.set_value("Start", &4u32)
+            .map_err(|e| format!("failed to set USBSTOR Start=4: {e}"))?;
+        Ok(true)
+    }
+    pub fn restore_usb_storage() -> Result<(), String> {
+        let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+        let (key, _) = hklm
+            .create_subkey(r"SYSTEM\CurrentControlSet\Services\USBSTOR")
+            .map_err(|e| format!("failed to open USBSTOR key: {e}"))?;
+        key.set_value("Start", &3u32)
+            .map_err(|e| format!("failed to set USBSTOR Start=3: {e}"))
+    }
+    pub fn pause_scheduled_tasks() -> Result<Vec<String>, String> {
+        let output = schtasks()
+            .args(["/Query", "/FO", "CSV", "/NH"])
+            .output()
+            .map_err(|e| format!("failed to run schtasks /Query: {e}"))?;
+        if !output.status.success() {
+            return Err(format!(
+                "schtasks /Query failed with status {}",
+                output.status
+            ));
+        }
+        let text = String::from_utf8_lossy(&output.stdout);
+        let mut paused = Vec::new();
+        for line in text.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let mut cols = line.split("\",\"").map(|s| s.trim_matches('"'));
+            let Some(task_name) = cols.next() else {
+                continue;
+            };
+            if task_name.starts_with("\\Microsoft\\") || task_name.eq_ignore_ascii_case("TaskName")
+            {
+                continue;
+            }
+            let status = schtasks()
+                .args(["/Change", "/TN", task_name, "/Disable"])
+                .status()
+                .map_err(|e| format!("failed to disable {task_name}: {e}"))?;
+            if status.success() {
+                paused.push(task_name.to_string());
+            }
+        }
+        Ok(paused)
+    }
+    pub fn resume_scheduled_tasks(tasks: &[String]) -> Result<usize, String> {
+        let mut restored = 0usize;
+        for task in tasks {
+            let status = schtasks()
+                .args(["/Change", "/TN", task, "/Enable"])
+                .status()
+                .map_err(|e| format!("failed to enable {task}: {e}"))?;
+            if status.success() {
+                restored += 1;
+            }
+        }
+        Ok(restored)
+    }
+    fn schtasks() -> Command {
+        let path = windows_directory()
+            .unwrap_or_else(|| PathBuf::from(r"C:\Windows"))
+            .join("System32")
+            .join("schtasks.exe");
+        Command::new(path)
+    }
+    fn windows_directory() -> Option<PathBuf> {
+        let mut buffer = vec![0u16; 260];
+        unsafe {
+            let len = GetSystemWindowsDirectoryW(Some(&mut buffer));
+            if len == 0 {
+                return None;
+            }
+            Some(PathBuf::from(String::from_utf16_lossy(
+                &buffer[..len as usize],
+            )))
+        }
+    }
 }

--- a/src/response_rules.rs
+++ b/src/response_rules.rs
@@ -5,7 +5,11 @@
 //! existing active-response primitives so every action stays reversible and
 //! audited in the same way as the built-in controls.
 
-use crate::{active_response, audit, config::{normalise_name, Config}, types::ConnInfo};
+use crate::{
+    active_response, audit,
+    config::{normalise_name, Config},
+    types::ConnInfo,
+};
 use serde::Deserialize;
 use serde_json::json;
 use std::collections::HashMap;
@@ -25,17 +29,28 @@ struct RuleFile {
 #[derive(Debug, Deserialize)]
 pub struct ResponseRule {
     pub name: String,
-    #[serde(default)] pub min_score: Option<u8>,
-    #[serde(default)] pub process_name_contains: Option<String>,
-    #[serde(default)] pub remote_contains: Option<String>,
-    #[serde(default)] pub require_unsigned: bool,
-    #[serde(default)] pub require_pre_login: bool,
-    #[serde(default)] pub require_reputation_hit: bool,
-    #[serde(default)] pub require_dga: bool,
-    #[serde(default)] pub require_recently_dropped: bool,
-    #[serde(default)] pub require_long_lived: bool,
-    #[serde(default)] pub action: RuleAction,
-    #[serde(default)] pub duration: Option<String>,
+    #[serde(default)]
+    pub min_score: Option<u8>,
+    #[serde(default)]
+    pub process_name_contains: Option<String>,
+    #[serde(default)]
+    pub remote_contains: Option<String>,
+    #[serde(default)]
+    pub require_unsigned: bool,
+    #[serde(default)]
+    pub require_pre_login: bool,
+    #[serde(default)]
+    pub require_reputation_hit: bool,
+    #[serde(default)]
+    pub require_dga: bool,
+    #[serde(default)]
+    pub require_recently_dropped: bool,
+    #[serde(default)]
+    pub require_long_lived: bool,
+    #[serde(default)]
+    pub action: RuleAction,
+    #[serde(default)]
+    pub duration: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -49,7 +64,10 @@ pub enum RuleAction {
 }
 
 pub fn maybe_apply(conn: &ConnInfo, cfg: &Config, state: &mut EngineState) -> Option<String> {
-    if !cfg.response_rules_enabled || cfg.response_rules_path.trim().is_empty() || is_trusted_process(conn, cfg) {
+    if !cfg.response_rules_enabled
+        || cfg.response_rules_path.trim().is_empty()
+        || is_trusted_process(conn, cfg)
+    {
         return None;
     }
     let rules = load_rules(&cfg.response_rules_path).ok()?;
@@ -62,42 +80,81 @@ pub fn maybe_apply(conn: &ConnInfo, cfg: &Config, state: &mut EngineState) -> Op
     }
     let summary = describe_action(&rule.name, &action, conn);
     if cfg.response_rules_dry_run {
-        audit::record("response_rule", "dry_run", json!({"rule": rule.name, "summary": summary, "pid": conn.pid, "proc_name": conn.proc_name, "remote_addr": conn.remote_addr, "score": conn.score }));
+        audit::record(
+            "response_rule",
+            "dry_run",
+            json!({"rule": rule.name, "summary": summary, "pid": conn.pid, "proc_name": conn.proc_name, "remote_addr": conn.remote_addr, "score": conn.score }),
+        );
         return Some(format!("Response-rule dry run: {summary}."));
     }
     let result = execute(&action, conn);
     match result {
         Ok(message) => {
-            audit::record("response_rule", "success", json!({"rule": rule.name, "message": message, "pid": conn.pid, "proc_name": conn.proc_name, "remote_addr": conn.remote_addr, "score": conn.score }));
+            audit::record(
+                "response_rule",
+                "success",
+                json!({"rule": rule.name, "message": message, "pid": conn.pid, "proc_name": conn.proc_name, "remote_addr": conn.remote_addr, "score": conn.score }),
+            );
             Some(format!("Response rule: {message}"))
         }
         Err(err) => {
-            audit::record("response_rule", "failure", json!({"rule": rule.name, "error": err, "pid": conn.pid, "proc_name": conn.proc_name, "remote_addr": conn.remote_addr, "score": conn.score }));
+            audit::record(
+                "response_rule",
+                "failure",
+                json!({"rule": rule.name, "error": err, "pid": conn.pid, "proc_name": conn.proc_name, "remote_addr": conn.remote_addr, "score": conn.score }),
+            );
             Some(format!("Response rule failed: {summary} ({err})"))
         }
     }
 }
 
 fn load_rules(path: &str) -> Result<Vec<ResponseRule>, String> {
-    let text = std::fs::read_to_string(path).map_err(|e| format!("failed to read rule file {path}: {e}"))?;
-    let file: RuleFile = serde_yaml::from_str(&text).map_err(|e| format!("failed to parse YAML rule file {path}: {e}"))?;
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("failed to read rule file {path}: {e}"))?;
+    let file: RuleFile = serde_yaml::from_str(&text)
+        .map_err(|e| format!("failed to parse YAML rule file {path}: {e}"))?;
     Ok(file.rules)
 }
 
 fn matches_rule(rule: &ResponseRule, conn: &ConnInfo) -> bool {
-    if rule.min_score.is_some_and(|min| conn.score < min) { return false; }
-    if rule.require_unsigned && !conn.publisher.trim().is_empty() { return false; }
-    if rule.require_pre_login && !conn.pre_login { return false; }
-    if rule.require_reputation_hit && conn.reputation_hit.is_none() { return false; }
-    if rule.require_dga && !conn.dga_like { return false; }
-    if rule.require_recently_dropped && !conn.recently_dropped { return false; }
-    if rule.require_long_lived && !conn.long_lived { return false; }
+    if rule.min_score.is_some_and(|min| conn.score < min) {
+        return false;
+    }
+    if rule.require_unsigned && !conn.publisher.trim().is_empty() {
+        return false;
+    }
+    if rule.require_pre_login && !conn.pre_login {
+        return false;
+    }
+    if rule.require_reputation_hit && conn.reputation_hit.is_none() {
+        return false;
+    }
+    if rule.require_dga && !conn.dga_like {
+        return false;
+    }
+    if rule.require_recently_dropped && !conn.recently_dropped {
+        return false;
+    }
+    if rule.require_long_lived && !conn.long_lived {
+        return false;
+    }
     if let Some(text) = rule.process_name_contains.as_ref() {
-        if !normalise_name(&conn.proc_name).contains(&normalise_name(text)) { return false; }
+        if !normalise_name(&conn.proc_name).contains(&normalise_name(text)) {
+            return false;
+        }
     }
     if let Some(text) = rule.remote_contains.as_ref() {
         let text = text.to_ascii_lowercase();
-        if !conn.remote_addr.to_ascii_lowercase().contains(&text) && !conn.hostname.as_deref().unwrap_or_default().to_ascii_lowercase().contains(&text) { return false; }
+        if !conn.remote_addr.to_ascii_lowercase().contains(&text)
+            && !conn
+                .hostname
+                .as_deref()
+                .unwrap_or_default()
+                .to_ascii_lowercase()
+                .contains(&text)
+        {
+            return false;
+        }
     }
     true
 }
@@ -105,18 +162,42 @@ fn matches_rule(rule: &ResponseRule, conn: &ConnInfo) -> bool {
 #[derive(Debug, Clone)]
 enum PlannedAction {
     KillConnection,
-    BlockRemote { target: String, preset: active_response::DurationPreset },
-    BlockProcess { pid: u32, path: String, preset: active_response::DurationPreset },
-    Quarantine { pid: u32, path: String, proc_name: String },
+    BlockRemote {
+        target: String,
+        preset: active_response::DurationPreset,
+    },
+    BlockProcess {
+        pid: u32,
+        path: String,
+        preset: active_response::DurationPreset,
+    },
+    Quarantine {
+        pid: u32,
+        path: String,
+        proc_name: String,
+    },
 }
 
 fn plan_action(rule: &ResponseRule, conn: &ConnInfo) -> Option<PlannedAction> {
     let preset = parse_duration(rule.duration.as_deref());
     match rule.action {
-        RuleAction::KillConnection if active_response::can_kill_connection(conn) => Some(PlannedAction::KillConnection),
-        RuleAction::BlockRemote => active_response::extract_remote_target(&conn.remote_addr).map(|target| PlannedAction::BlockRemote { target, preset }),
-        RuleAction::BlockProcess if !conn.proc_path.trim().is_empty() => Some(PlannedAction::BlockProcess { pid: conn.pid, path: conn.proc_path.clone(), preset }),
-        RuleAction::Quarantine => Some(PlannedAction::Quarantine { pid: conn.pid, path: conn.proc_path.clone(), proc_name: conn.proc_name.clone() }),
+        RuleAction::KillConnection if active_response::can_kill_connection(conn) => {
+            Some(PlannedAction::KillConnection)
+        }
+        RuleAction::BlockRemote => active_response::extract_remote_target(&conn.remote_addr)
+            .map(|target| PlannedAction::BlockRemote { target, preset }),
+        RuleAction::BlockProcess if !conn.proc_path.trim().is_empty() => {
+            Some(PlannedAction::BlockProcess {
+                pid: conn.pid,
+                path: conn.proc_path.clone(),
+                preset,
+            })
+        }
+        RuleAction::Quarantine => Some(PlannedAction::Quarantine {
+            pid: conn.pid,
+            path: conn.proc_path.clone(),
+            proc_name: conn.proc_name.clone(),
+        }),
         _ => None,
     }
 }
@@ -131,18 +212,35 @@ fn parse_duration(text: Option<&str>) -> active_response::DurationPreset {
 
 fn execute(action: &PlannedAction, conn: &ConnInfo) -> Result<String, String> {
     match action {
-        PlannedAction::KillConnection => active_response::kill_connection(conn).map_err(|e| e.to_string()),
-        PlannedAction::BlockRemote { target, preset } => active_response::block_remote(target, *preset),
-        PlannedAction::BlockProcess { pid, path, preset } => active_response::block_process(*pid, path, *preset),
-        PlannedAction::Quarantine { pid, path, proc_name } => active_response::apply_quarantine_profile(*pid, path, proc_name),
+        PlannedAction::KillConnection => {
+            active_response::kill_connection(conn).map_err(|e| e.to_string())
+        }
+        PlannedAction::BlockRemote { target, preset } => {
+            active_response::block_remote(target, *preset)
+        }
+        PlannedAction::BlockProcess { pid, path, preset } => {
+            active_response::block_process(*pid, path, *preset)
+        }
+        PlannedAction::Quarantine {
+            pid,
+            path,
+            proc_name,
+        } => active_response::apply_quarantine_profile(*pid, path, proc_name),
     }
 }
 
 fn describe_action(rule_name: &str, action: &PlannedAction, conn: &ConnInfo) -> String {
     match action {
-        PlannedAction::KillConnection => format!("rule {rule_name} kills {} -> {}", conn.local_addr, conn.remote_addr),
-        PlannedAction::BlockRemote { target, .. } => format!("rule {rule_name} blocks remote {target}"),
-        PlannedAction::BlockProcess { path, .. } => format!("rule {rule_name} blocks process {path}"),
+        PlannedAction::KillConnection => format!(
+            "rule {rule_name} kills {} -> {}",
+            conn.local_addr, conn.remote_addr
+        ),
+        PlannedAction::BlockRemote { target, .. } => {
+            format!("rule {rule_name} blocks remote {target}")
+        }
+        PlannedAction::BlockProcess { path, .. } => {
+            format!("rule {rule_name} blocks process {path}")
+        }
         PlannedAction::Quarantine { pid, .. } => format!("rule {rule_name} quarantines pid {pid}"),
     }
 }
@@ -158,14 +256,23 @@ fn cooldown_key(action: &PlannedAction, conn: &ConnInfo) -> String {
 
 fn is_trusted_process(conn: &ConnInfo, cfg: &Config) -> bool {
     let key = normalise_name(&conn.proc_name);
-    cfg.trusted_processes.iter().any(|trusted| trusted.eq_ignore_ascii_case(&key))
+    cfg.trusted_processes
+        .iter()
+        .any(|trusted| trusted.eq_ignore_ascii_case(&key))
 }
 
 impl EngineState {
     fn try_acquire(&mut self, key: String, cooldown: Duration) -> bool {
         let now = Instant::now();
-        self.cooldowns.retain(|_, at| now.duration_since(*at) < cooldown.saturating_mul(2));
-        if self.cooldowns.get(&key).is_some_and(|previous| now.duration_since(*previous) < cooldown) { return false; }
+        self.cooldowns
+            .retain(|_, at| now.duration_since(*at) < cooldown.saturating_mul(2));
+        if self
+            .cooldowns
+            .get(&key)
+            .is_some_and(|previous| now.duration_since(*previous) < cooldown)
+        {
+            return false;
+        }
         self.cooldowns.insert(key, now);
         true
     }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -137,16 +137,65 @@ fn hero(ui: &mut egui::Ui) {
 }
 
 fn card(ui: &mut egui::Ui, title: &str, f: impl FnOnce(&mut egui::Ui)) {
-    egui::Frame::NONE.fill(theme::SURFACE).stroke(egui::Stroke::new(1.0, theme::BORDER)).corner_radius(12.0).inner_margin(egui::Margin::symmetric(16, 14)).show(ui, |ui| {
-        ui.label(RichText::new(title).color(theme::TEXT).size(13.5).strong());
-        ui.add_space(10.0);
-        f(ui);
-    });
+    egui::Frame::NONE
+        .fill(theme::SURFACE)
+        .stroke(egui::Stroke::new(1.0, theme::BORDER))
+        .corner_radius(12.0)
+        .inner_margin(egui::Margin::symmetric(16, 14))
+        .show(ui, |ui| {
+            ui.label(RichText::new(title).color(theme::TEXT).size(13.5).strong());
+            ui.add_space(10.0);
+            f(ui);
+        });
     ui.add_space(12.0);
 }
 
-fn chip(ui: &mut egui::Ui, text: &str) { ui.label(RichText::new(format!(" {text} ")).color(theme::ACCENT).background_color(theme::ACCENT_BG).size(10.5).strong()); }
-fn body(ui: &mut egui::Ui, text: &str) { ui.add(egui::Label::new(RichText::new(text).color(theme::TEXT2).size(11.7)).wrap()); }
-fn bullet(ui: &mut egui::Ui, key: &str, text: &str) { ui.horizontal(|ui| { ui.label(RichText::new(">").color(theme::ACCENT).size(11.0)); ui.add_space(2.0); ui.label(RichText::new(key).color(theme::TEXT).size(11.0).strong()); ui.add_space(6.0); ui.add(egui::Label::new(RichText::new(text).color(theme::TEXT2).size(11.0)).wrap()); }); ui.add_space(4.0); }
-fn score_row(ui: &mut egui::Ui, points: &str, color: egui::Color32, description: &str) { ui.horizontal(|ui| { ui.add_sized([34.0, 18.0], egui::Label::new(RichText::new(points).color(color).monospace().size(11.7).strong())); ui.add_space(4.0); ui.add(egui::Label::new(RichText::new(description).color(theme::TEXT2).size(11.2)).wrap()); }); ui.add_space(4.0); }
-fn field_row(ui: &mut egui::Ui, field: &str, description: &str) { ui.horizontal(|ui| { ui.add_sized([96.0, 18.0], egui::Label::new(RichText::new(field).color(theme::TEXT).size(11.7).strong())); ui.add(egui::Label::new(RichText::new(description).color(theme::TEXT2).size(11.2)).wrap()); }); ui.add_space(4.0); }
+fn chip(ui: &mut egui::Ui, text: &str) {
+    ui.label(
+        RichText::new(format!(" {text} "))
+            .color(theme::ACCENT)
+            .background_color(theme::ACCENT_BG)
+            .size(10.5)
+            .strong(),
+    );
+}
+fn body(ui: &mut egui::Ui, text: &str) {
+    ui.add(egui::Label::new(RichText::new(text).color(theme::TEXT2).size(11.7)).wrap());
+}
+fn bullet(ui: &mut egui::Ui, key: &str, text: &str) {
+    ui.horizontal(|ui| {
+        ui.label(RichText::new(">").color(theme::ACCENT).size(11.0));
+        ui.add_space(2.0);
+        ui.label(RichText::new(key).color(theme::TEXT).size(11.0).strong());
+        ui.add_space(6.0);
+        ui.add(egui::Label::new(RichText::new(text).color(theme::TEXT2).size(11.0)).wrap());
+    });
+    ui.add_space(4.0);
+}
+fn score_row(ui: &mut egui::Ui, points: &str, color: egui::Color32, description: &str) {
+    ui.horizontal(|ui| {
+        ui.add_sized(
+            [34.0, 18.0],
+            egui::Label::new(
+                RichText::new(points)
+                    .color(color)
+                    .monospace()
+                    .size(11.7)
+                    .strong(),
+            ),
+        );
+        ui.add_space(4.0);
+        ui.add(egui::Label::new(RichText::new(description).color(theme::TEXT2).size(11.2)).wrap());
+    });
+    ui.add_space(4.0);
+}
+fn field_row(ui: &mut egui::Ui, field: &str, description: &str) {
+    ui.horizontal(|ui| {
+        ui.add_sized(
+            [96.0, 18.0],
+            egui::Label::new(RichText::new(field).color(theme::TEXT).size(11.7).strong()),
+        );
+        ui.add(egui::Label::new(RichText::new(description).color(theme::TEXT2).size(11.2)).wrap());
+    });
+    ui.add_space(4.0);
+}

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -47,7 +47,7 @@ pub fn show(ui: &mut egui::Ui) {
 
                 cols[1].vertical(|ui| {
                     card(ui, "Active response", |ui| {
-                        body(ui, "Vigil supports reversible intervention: kill a live connection, block a remote IP for 1 hour, 24 hours, or permanently, block a process by executable path, block a resolved domain through the hosts file, suspend a process while you investigate, freeze autorun keys for later rollback, apply a quarantine preset, or isolate the machine with firewall rules. Active blocks show a countdown and a quick unblock action. All actions require administrator privileges on Windows and ask for confirmation.");
+                        body(ui, "Vigil supports reversible intervention: kill a live connection, block a remote IP for 1 hour, 24 hours, or permanently, block a process by executable path, block a resolved domain through the hosts file, suspend a process while you investigate, freeze autorun keys for later rollback, apply a quarantine preset, or isolate the machine. Active blocks show a countdown and a quick unblock action. Isolation is immediate and confirmed by connectivity checks; other destructive actions keep confirmation.");
                         ui.add_space(6.0);
                         bullet(ui, "Kill connection", "Terminate the selected live TCP socket immediately. Current Windows implementation uses the IPv4 TCP delete-TCB path.");
                         bullet(ui, "Suspend process", "Freeze every thread in the selected process without killing it. Resume process re-enables the same process later in the investigation.");
@@ -56,7 +56,7 @@ pub fn show(ui: &mut egui::Ui) {
                         bullet(ui, "Block remote", "Choose a 1h, 24h, or permanent block for the selected connection's remote IP through the Windows firewall. IPv4 and IPv6 remote addresses are supported.");
                         bullet(ui, "Block domain", "Add or remove Windows hosts-file entries that redirect the selected hostname to 127.0.0.1 and ::1. Best for persistent C2 or phishing domains.");
                         bullet(ui, "Block process", "Choose a 1h, 24h, or permanent block for all traffic from the selected executable path.");
-                        bullet(ui, "Isolate network", "Add reversible firewall rules that block inbound and outbound traffic. Break-glass recovery can restore them if Vigil dies during containment.");
+                        bullet(ui, "Isolate network", "Apply strict containment immediately: first harden firewall policy, then verify outbound reachability. If traffic is still reachable, Vigil falls back to emergency adapter cutoff. Break-glass and failsafe recovery restore saved state if the app dies.");
                     });
 
                     card(ui, "Auto response and allowlisting", |ui| {
@@ -86,11 +86,11 @@ pub fn show(ui: &mut egui::Ui) {
                     });
 
                     card(ui, "Break-glass recovery", |ui| {
-                        body(ui, "Break-glass recovery reduces the risk of locking yourself out during machine isolation. When enabled, Vigil arms a watchdog task while isolation is active, keeps a heartbeat file fresh, and restores networking if the heartbeat goes stale past the timeout.");
+                        body(ui, "Break-glass recovery reduces the risk of locking yourself out during machine isolation. Vigil always arms a watchdog task while isolation is active, keeps a heartbeat file fresh, and restores networking if the heartbeat goes stale past the timeout.");
                         ui.add_space(6.0);
                         bullet(ui, "Recovery timeout", "How long isolation may persist without a live heartbeat before the watchdog restores connectivity.");
                         bullet(ui, "Heartbeat interval", "How often the running app touches the heartbeat while healthy.");
-                        bullet(ui, "Watchdog task", "Current Windows implementation uses a scheduled task that runs the same Vigil binary with --break-glass-recover.");
+                        bullet(ui, "Watchdog task", "Vigil uses an OS scheduler entry to run the same binary with --break-glass-recover (Windows Task Scheduler, Linux cron, macOS launchd).");
                     });
 
                     card(ui, "Telemetry and reputation", |ui| {
@@ -106,7 +106,7 @@ pub fn show(ui: &mut egui::Ui) {
             });
         } else {
             card(ui, "What Vigil does", |ui| { body(ui, "Vigil watches TCP/UDP connections in real time, enriches each row with process context, and raises an alert when the score crosses the configured threshold."); });
-            card(ui, "Active response", |ui| { body(ui, "Active response includes connection kill, remote and process blocking, domain blocking, suspension, autorun freeze / revert, full quarantine, and machine isolation on Windows."); });
+            card(ui, "Active response", |ui| { body(ui, "Active response includes connection kill, remote and process blocking, domain blocking, suspension, autorun freeze / revert, full quarantine, and machine isolation. Isolation is strict and reversible across supported platforms."); });
             card(ui, "Auto response and allowlisting", |ui| { body(ui, "Auto response is optional and can dry-run. Allowlist-only mode can force containment for traffic from processes outside the trusted list, explicit allowlist, and current Microsoft-signed system processes."); });
             card(ui, "User-defined response rules", |ui| { body(ui, "Operator-supplied YAML rules can dry-run or execute kill_connection, block_remote, block_process, and quarantine actions. See response-rules.example.yaml."); });
             card(ui, "Forensics and honeypots", |ui| { body(ui, "Process dumps, PCAP capture, and decoy-file touches are optional and configurable in Settings."); });

--- a/src/ui/inspector.rs
+++ b/src/ui/inspector.rs
@@ -69,6 +69,7 @@ fn show_detail(ui: &mut Ui, sel: &ProcessSelection, kill_confirm: bool) -> Optio
     let kill_enabled = !ghost;
     let suspend_enabled = active_response::can_suspend_process(sel.pid) && !ghost;
     let response_enabled = active_response::can_modify_firewall();
+    let isolation_enabled = active_response::can_isolate_network();
     let domain_enabled = active_response::can_block_domain();
     let response_status = active_response::status();
     let remote_target = sel
@@ -191,13 +192,36 @@ fn show_detail(ui: &mut Ui, sel: &ProcessSelection, kill_confirm: bool) -> Optio
                     }
                 }
 
-                let isolate_label = if isolated { "Restore network" } else { "Isolate network" };
-                let iso_resp = ui.add_enabled(true, danger_btn(isolate_label));
-                let iso_resp = iso_resp.on_hover_cursor(egui::CursorIcon::PointingHand).on_hover_text(if isolated { "Remove the temporary network-isolation firewall rules." } else { "Temporarily block inbound and outbound traffic with reversible firewall rules." });
-                if iso_resp.clicked() { action = Some(if isolated { Action::RestoreNetwork } else { Action::IsolateMachine }); }
             });
-        } else {
-            ui.label(RichText::new("Administrator privileges are required for active response.").color(theme::TEXT3).size(10.5));
+        }
+        if isolation_enabled {
+            ui.add_space(6.0);
+            let isolate_label = if isolated {
+                "Restore network"
+            } else {
+                "Isolate network"
+            };
+            let iso_resp = ui
+                .add_enabled(true, danger_btn(isolate_label))
+                .on_hover_cursor(egui::CursorIcon::PointingHand)
+                .on_hover_text(if isolated {
+                    "Restore the saved firewall profile state and any adapter snapshot from before isolation."
+                } else {
+                    "Immediately isolate the machine. Vigil hardens firewall policy first and falls back to emergency adapter cutoff if connectivity is still reachable."
+                });
+            if iso_resp.clicked() {
+                action = Some(if isolated {
+                    Action::RestoreNetwork
+                } else {
+                    Action::IsolateMachine
+                });
+            }
+        } else if !response_enabled {
+            ui.label(
+                RichText::new("Administrator privileges are required for active response.")
+                    .color(theme::TEXT3)
+                    .size(10.5),
+            );
         }
 
         ui.add_space(6.0);

--- a/src/ui/inspector.rs
+++ b/src/ui/inspector.rs
@@ -35,7 +35,11 @@ pub enum Action {
     KillCancelled,
 }
 
-pub fn show(ui: &mut Ui, selection: Option<&ProcessSelection>, kill_confirm: bool) -> Option<Action> {
+pub fn show(
+    ui: &mut Ui,
+    selection: Option<&ProcessSelection>,
+    kill_confirm: bool,
+) -> Option<Action> {
     match selection {
         Some(selection) => show_detail(ui, selection, kill_confirm),
         None => {
@@ -47,7 +51,13 @@ pub fn show(ui: &mut Ui, selection: Option<&ProcessSelection>, kill_confirm: boo
 
 fn show_placeholder(ui: &mut Ui) {
     let rect = ui.available_rect_before_wrap();
-    ui.painter().text(rect.center(), egui::Align2::CENTER_CENTER, "Select a process\nto inspect", egui::FontId::proportional(12.0), theme::TEXT3);
+    ui.painter().text(
+        rect.center(),
+        egui::Align2::CENTER_CENTER,
+        "Select a process\nto inspect",
+        egui::FontId::proportional(12.0),
+        theme::TEXT3,
+    );
 }
 
 fn show_detail(ui: &mut Ui, sel: &ProcessSelection, kill_confirm: bool) -> Option<Action> {
@@ -61,17 +71,33 @@ fn show_detail(ui: &mut Ui, sel: &ProcessSelection, kill_confirm: bool) -> Optio
     let response_enabled = active_response::can_modify_firewall();
     let domain_enabled = active_response::can_block_domain();
     let response_status = active_response::status();
-    let remote_target = sel.selected_connection.as_ref().and_then(|conn| active_response::extract_remote_target(&conn.remote_addr));
-    let remote_blocked = remote_target.as_deref().is_some_and(active_response::is_blocked);
-    let remote_remaining = remote_target.as_deref().and_then(active_response::remote_block_remaining);
-    let domain_target = sel.selected_connection.as_ref().and_then(active_response::extract_domain_target);
-    let domain_blocked = domain_target.as_deref().is_some_and(active_response::is_domain_blocked);
+    let remote_target = sel
+        .selected_connection
+        .as_ref()
+        .and_then(|conn| active_response::extract_remote_target(&conn.remote_addr));
+    let remote_blocked = remote_target
+        .as_deref()
+        .is_some_and(active_response::is_blocked);
+    let remote_remaining = remote_target
+        .as_deref()
+        .and_then(active_response::remote_block_remaining);
+    let domain_target = sel
+        .selected_connection
+        .as_ref()
+        .and_then(active_response::extract_domain_target);
+    let domain_blocked = domain_target
+        .as_deref()
+        .is_some_and(active_response::is_domain_blocked);
     let process_blocked = active_response::is_process_blocked(sel.pid, &sel.proc_path);
     let process_remaining = active_response::process_block_remaining(sel.pid, &sel.proc_path);
     let process_suspended = active_response::is_process_suspended(sel.pid, &sel.proc_path);
-    let connection_kill_enabled = sel.selected_connection.as_ref().is_some_and(active_response::can_kill_connection);
+    let connection_kill_enabled = sel
+        .selected_connection
+        .as_ref()
+        .is_some_and(active_response::can_kill_connection);
     let isolated = response_status.isolated;
-    let quarantine_ready = active_response::can_apply_quarantine_profile(sel.pid, &sel.proc_path) && !ghost;
+    let quarantine_ready =
+        active_response::can_apply_quarantine_profile(sel.pid, &sel.proc_path) && !ghost;
     let quarantine_active = isolated || process_blocked || process_suspended;
     let autoruns_frozen = active_response::has_frozen_autoruns();
 
@@ -280,40 +306,187 @@ fn show_detail(ui: &mut Ui, sel: &ProcessSelection, kill_confirm: bool) -> Optio
 
 fn process_hero(ui: &mut Ui, sel: &ProcessSelection) {
     let ghost = is_ghost_process_name(&sel.proc_name);
-    egui::Frame::NONE.fill(theme::SURFACE2).stroke(egui::Stroke::new(1.0, theme::ACCENT_BG)).corner_radius(12.0).inner_margin(egui::Margin::symmetric(14, 12)).show(ui, |ui| {
-        ui.horizontal(|ui| {
-            score_badge(ui, sel.score);
+    egui::Frame::NONE
+        .fill(theme::SURFACE2)
+        .stroke(egui::Stroke::new(1.0, theme::ACCENT_BG))
+        .corner_radius(12.0)
+        .inner_margin(egui::Margin::symmetric(14, 12))
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                score_badge(ui, sel.score);
+                ui.add_space(8.0);
+                ui.vertical(|ui| {
+                    ui.label(
+                        RichText::new(&sel.proc_name)
+                            .color(theme::TEXT)
+                            .size(14.5)
+                            .strong(),
+                    );
+                    ui.label(
+                        RichText::new(format!("PID {} | {}", sel.pid, sel.timestamp))
+                            .color(theme::TEXT2)
+                            .size(10.5),
+                    );
+                    ui.label(
+                        RichText::new(format!("Latest: {} to {}", sel.status, sel.remote_addr))
+                            .color(theme::TEXT3)
+                            .size(10.0),
+                    );
+                });
+            });
             ui.add_space(8.0);
-            ui.vertical(|ui| {
-                ui.label(RichText::new(&sel.proc_name).color(theme::TEXT).size(14.5).strong());
-                ui.label(RichText::new(format!("PID {} | {}", sel.pid, sel.timestamp)).color(theme::TEXT2).size(10.5));
-                ui.label(RichText::new(format!("Latest: {} to {}", sel.status, sel.remote_addr)).color(theme::TEXT3).size(10.0));
+            ui.label(
+                RichText::new(if sel.proc_path.is_empty() {
+                    "No executable path available"
+                } else {
+                    sel.proc_path.as_str()
+                })
+                .color(theme::TEXT2)
+                .size(10.5),
+            );
+            ui.add_space(8.0);
+            ui.horizontal_wrapped(|ui| {
+                chip(ui, &format!("{} connections", sel.connection_count));
+                chip(ui, &format!("{} ports", sel.distinct_ports));
+                chip(ui, &format!("{} remotes", sel.distinct_remotes));
+                if ghost {
+                    chip(ui, "Unresolved PID");
+                }
+                if sel.proc_path.is_empty() {
+                    chip(ui, "No location");
+                }
+                if sel.selected_connection.is_some() {
+                    chip(ui, "Connection selected");
+                } else {
+                    chip(ui, "Process summary");
+                }
             });
         });
-        ui.add_space(8.0);
-        ui.label(RichText::new(if sel.proc_path.is_empty() { "No executable path available" } else { sel.proc_path.as_str() }).color(theme::TEXT2).size(10.5));
-        ui.add_space(8.0);
-        ui.horizontal_wrapped(|ui| {
-            chip(ui, &format!("{} connections", sel.connection_count));
-            chip(ui, &format!("{} ports", sel.distinct_ports));
-            chip(ui, &format!("{} remotes", sel.distinct_remotes));
-            if ghost { chip(ui, "Unresolved PID"); }
-            if sel.proc_path.is_empty() { chip(ui, "No location"); }
-            if sel.selected_connection.is_some() { chip(ui, "Connection selected"); } else { chip(ui, "Process summary"); }
-        });
-    });
 }
 
-fn separator(ui: &mut Ui) { let rect = egui::Rect::from_min_size(ui.cursor().min, egui::vec2(ui.available_width(), 1.0)); ui.painter().rect_filled(rect, 0.0, theme::BORDER); ui.advance_cursor_after_rect(rect); }
-fn section_header(ui: &mut Ui, title: &str) { ui.label(RichText::new(title).color(theme::TEXT2).size(10.5).strong()); ui.add_space(4.0); }
-fn kv(ui: &mut Ui, key: &str, val: &str) { ui.horizontal(|ui| { ui.add_sized([88.0, 16.0], egui::Label::new(RichText::new(key).color(theme::TEXT3).size(11.0))); ui.add(egui::Label::new(RichText::new(val).color(theme::TEXT).size(11.0)).wrap()); }); ui.add_space(2.0); }
-fn kv_mono(ui: &mut Ui, key: &str, val: &str) { ui.horizontal(|ui| { ui.add_sized([88.0, 16.0], egui::Label::new(RichText::new(key).color(theme::TEXT3).size(11.0))); ui.add(egui::Label::new(RichText::new(val).color(theme::TEXT).monospace().size(10.5)).wrap()); }); ui.add_space(2.0); }
-fn score_badge(ui: &mut Ui, score: u8) { let (fg, bg) = theme::score_colors(score); ui.label(RichText::new(format!(" {score:>2} ")).color(fg).background_color(bg).monospace().size(12.0).strong()); }
-fn chip(ui: &mut Ui, text: &str) { ui.label(RichText::new(format!(" {text} ")).color(theme::TEXT2).background_color(theme::SURFACE3).size(10.0).strong()); }
-fn blocked_status_row(ui: &mut Ui, label: &str, remaining: Option<std::time::Duration>, hover_prefix: &str, unblock_action: Action, action: &mut Option<Action>) { ui.add_space(4.0); ui.horizontal_wrapped(|ui| { let status = match remaining { Some(duration) => format!("{label} {}", format_remaining(duration)), None => format!("{label} permanently") }; chip(ui, &status); let unblock = ui.add(accent_btn("Unblock")); let unblock = unblock.on_hover_cursor(egui::CursorIcon::PointingHand).on_hover_text(format!("{}.", hover_prefix)); if unblock.clicked() { *action = Some(unblock_action); } }); }
-fn nonempty(text: &str) -> &str { if text.is_empty() { "n/a" } else { text } }
-fn accent_btn(text: &str) -> egui::Button<'_> { egui::Button::new(RichText::new(text).color(theme::ACCENT).size(11.5)).fill(theme::ACCENT_BG).stroke(egui::Stroke::new(1.0, theme::ACCENT)).corner_radius(6.0) }
-fn block_btn(preset: active_response::DurationPreset, text: &str) -> egui::Button<'_> { let (fg, bg, border) = match preset { active_response::DurationPreset::OneHour => (theme::ACCENT, theme::ACCENT_BG, theme::ACCENT), active_response::DurationPreset::OneDay => (theme::WARN, theme::WARN_BG, theme::WARN), active_response::DurationPreset::Permanent => (theme::DANGER, theme::DANGER_BG, theme::DANGER) }; egui::Button::new(RichText::new(text).color(fg).size(11.5)).fill(bg).stroke(egui::Stroke::new(1.0, border)).corner_radius(6.0) }
-fn muted_btn(text: &str) -> egui::Button<'_> { egui::Button::new(RichText::new(text).color(theme::TEXT2).size(11.5)).fill(theme::SURFACE2).stroke(egui::Stroke::new(1.0, theme::BORDER)).corner_radius(6.0) }
-fn danger_btn(text: &str) -> egui::Button<'_> { egui::Button::new(RichText::new(text).color(theme::DANGER).size(11.5)).fill(theme::DANGER_BG).stroke(egui::Stroke::new(1.0, theme::DANGER)).corner_radius(6.0) }
-fn format_remaining(duration: std::time::Duration) -> String { let secs = duration.as_secs(); let hours = secs / 3_600; let mins = (secs % 3_600) / 60; let secs = secs % 60; if hours > 0 { format!("{hours:02}:{mins:02}:{secs:02}") } else { format!("{mins:02}:{secs:02}") } }
+fn separator(ui: &mut Ui) {
+    let rect = egui::Rect::from_min_size(ui.cursor().min, egui::vec2(ui.available_width(), 1.0));
+    ui.painter().rect_filled(rect, 0.0, theme::BORDER);
+    ui.advance_cursor_after_rect(rect);
+}
+fn section_header(ui: &mut Ui, title: &str) {
+    ui.label(RichText::new(title).color(theme::TEXT2).size(10.5).strong());
+    ui.add_space(4.0);
+}
+fn kv(ui: &mut Ui, key: &str, val: &str) {
+    ui.horizontal(|ui| {
+        ui.add_sized(
+            [88.0, 16.0],
+            egui::Label::new(RichText::new(key).color(theme::TEXT3).size(11.0)),
+        );
+        ui.add(egui::Label::new(RichText::new(val).color(theme::TEXT).size(11.0)).wrap());
+    });
+    ui.add_space(2.0);
+}
+fn kv_mono(ui: &mut Ui, key: &str, val: &str) {
+    ui.horizontal(|ui| {
+        ui.add_sized(
+            [88.0, 16.0],
+            egui::Label::new(RichText::new(key).color(theme::TEXT3).size(11.0)),
+        );
+        ui.add(
+            egui::Label::new(RichText::new(val).color(theme::TEXT).monospace().size(10.5)).wrap(),
+        );
+    });
+    ui.add_space(2.0);
+}
+fn score_badge(ui: &mut Ui, score: u8) {
+    let (fg, bg) = theme::score_colors(score);
+    ui.label(
+        RichText::new(format!(" {score:>2} "))
+            .color(fg)
+            .background_color(bg)
+            .monospace()
+            .size(12.0)
+            .strong(),
+    );
+}
+fn chip(ui: &mut Ui, text: &str) {
+    ui.label(
+        RichText::new(format!(" {text} "))
+            .color(theme::TEXT2)
+            .background_color(theme::SURFACE3)
+            .size(10.0)
+            .strong(),
+    );
+}
+fn blocked_status_row(
+    ui: &mut Ui,
+    label: &str,
+    remaining: Option<std::time::Duration>,
+    hover_prefix: &str,
+    unblock_action: Action,
+    action: &mut Option<Action>,
+) {
+    ui.add_space(4.0);
+    ui.horizontal_wrapped(|ui| {
+        let status = match remaining {
+            Some(duration) => format!("{label} {}", format_remaining(duration)),
+            None => format!("{label} permanently"),
+        };
+        chip(ui, &status);
+        let unblock = ui.add(accent_btn("Unblock"));
+        let unblock = unblock
+            .on_hover_cursor(egui::CursorIcon::PointingHand)
+            .on_hover_text(format!("{}.", hover_prefix));
+        if unblock.clicked() {
+            *action = Some(unblock_action);
+        }
+    });
+}
+fn nonempty(text: &str) -> &str {
+    if text.is_empty() {
+        "n/a"
+    } else {
+        text
+    }
+}
+fn accent_btn(text: &str) -> egui::Button<'_> {
+    egui::Button::new(RichText::new(text).color(theme::ACCENT).size(11.5))
+        .fill(theme::ACCENT_BG)
+        .stroke(egui::Stroke::new(1.0, theme::ACCENT))
+        .corner_radius(6.0)
+}
+fn block_btn(preset: active_response::DurationPreset, text: &str) -> egui::Button<'_> {
+    let (fg, bg, border) = match preset {
+        active_response::DurationPreset::OneHour => {
+            (theme::ACCENT, theme::ACCENT_BG, theme::ACCENT)
+        }
+        active_response::DurationPreset::OneDay => (theme::WARN, theme::WARN_BG, theme::WARN),
+        active_response::DurationPreset::Permanent => {
+            (theme::DANGER, theme::DANGER_BG, theme::DANGER)
+        }
+    };
+    egui::Button::new(RichText::new(text).color(fg).size(11.5))
+        .fill(bg)
+        .stroke(egui::Stroke::new(1.0, border))
+        .corner_radius(6.0)
+}
+fn muted_btn(text: &str) -> egui::Button<'_> {
+    egui::Button::new(RichText::new(text).color(theme::TEXT2).size(11.5))
+        .fill(theme::SURFACE2)
+        .stroke(egui::Stroke::new(1.0, theme::BORDER))
+        .corner_radius(6.0)
+}
+fn danger_btn(text: &str) -> egui::Button<'_> {
+    egui::Button::new(RichText::new(text).color(theme::DANGER).size(11.5))
+        .fill(theme::DANGER_BG)
+        .stroke(egui::Stroke::new(1.0, theme::DANGER))
+        .corner_radius(6.0)
+}
+fn format_remaining(duration: std::time::Duration) -> String {
+    let secs = duration.as_secs();
+    let hours = secs / 3_600;
+    let mins = (secs % 3_600) / 60;
+    let secs = secs % 60;
+    if hours > 0 {
+        format!("{hours:02}:{mins:02}:{secs:02}")
+    } else {
+        format!("{mins:02}:{secs:02}")
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -23,6 +23,7 @@ use chrono::{Local, Timelike};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashSet, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
 use std::sync::{Arc, Mutex, RwLock};
 use tab_bar::Tab;
 use tokio::sync::broadcast;
@@ -87,6 +88,32 @@ impl Default for UiState {
             alerts_table: TableState::new(4, false),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NotificationKind {
+    Info,
+    Success,
+    Warning,
+    Error,
+}
+
+#[derive(Debug, Clone)]
+struct Notification {
+    id: u64,
+    kind: NotificationKind,
+    text: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NetworkOperationKind {
+    Isolate,
+    Restore,
+}
+
+struct NetworkOperation {
+    kind: NetworkOperationKind,
+    rx: mpsc::Receiver<String>,
 }
 
 #[derive(Clone)]
@@ -186,8 +213,9 @@ pub struct VigilApp {
     kill_confirm: bool,
     response_confirm: Option<PendingResponse>,
     response_status: active_response::Status,
-    response_message: Option<(String, std::time::Instant)>,
-    admin_message: Option<(String, std::time::Instant)>,
+    network_operation: Option<NetworkOperation>,
+    notifications: VecDeque<Notification>,
+    next_notification_id: u64,
     auto_response_state: auto_response::EngineState,
     response_rule_state: response_rules::EngineState,
     exit_requested: bool,
@@ -237,8 +265,9 @@ impl VigilApp {
             kill_confirm: false,
             response_confirm: None,
             response_status: active_response::status(),
-            response_message: None,
-            admin_message: None,
+            network_operation: None,
+            notifications: VecDeque::new(),
+            next_notification_id: 1,
             auto_response_state: auto_response::EngineState::default(),
             response_rule_state: response_rules::EngineState::default(),
             exit_requested: false,
@@ -288,13 +317,13 @@ impl VigilApp {
         let cfg = self.cfg.read().unwrap().clone();
         if let Some(message) = auto_response::maybe_apply(info, &cfg, &mut self.auto_response_state)
         {
-            self.response_message = Some((message, std::time::Instant::now()));
+            self.push_notification(NotificationKind::Info, message);
             self.response_status = active_response::status();
         }
         if let Some(message) =
             response_rules::maybe_apply(info, &cfg, &mut self.response_rule_state)
         {
-            self.response_message = Some((message, std::time::Instant::now()));
+            self.push_notification(NotificationKind::Info, message);
             self.response_status = active_response::status();
         }
     }
@@ -438,26 +467,25 @@ impl VigilApp {
                 }
             }
             inspector::Action::IsolateMachine => {
-                self.response_confirm = Some(PendingResponse::IsolateMachine)
+                self.start_network_operation(NetworkOperationKind::Isolate);
             }
             inspector::Action::RestoreNetwork => {
-                self.scheduled_lockdown_active = false;
-                self.response_confirm = Some(PendingResponse::RestoreNetwork);
+                self.start_network_operation(NetworkOperationKind::Restore);
             }
             inspector::Action::RequestAdmin => match crate::autostart::relaunch_as_admin() {
                 Ok(()) => {
                     self.exit_requested = true;
-                    self.admin_message = Some((
-                        "Reopened Vigil as administrator.".into(),
-                        std::time::Instant::now(),
-                    ));
+                    self.push_notification(
+                        NotificationKind::Info,
+                        "Reopened Vigil as administrator.",
+                    );
                     ctx.send_viewport_cmd(egui::ViewportCommand::Close);
                 }
                 Err(err) => {
-                    self.admin_message = Some((
+                    self.push_notification(
+                        NotificationKind::Error,
                         format!("Could not relaunch as admin: {err}"),
-                        std::time::Instant::now(),
-                    ));
+                    );
                 }
             },
             inspector::Action::KillConfirmed => {
@@ -493,6 +521,7 @@ impl VigilApp {
     }
     fn show_header(&mut self, ui: &mut egui::Ui) -> Option<inspector::Action> {
         let mut action = None;
+        let network_busy = self.network_operation.is_some();
 
         ui.horizontal_centered(|ui| {
             ui.add_space(12.0);
@@ -591,7 +620,9 @@ impl VigilApp {
                 .fill(theme::SURFACE2)
                 .stroke(egui::Stroke::new(1.0, theme::BORDER))
                 .corner_radius(4.0);
-                let resp = ui.add(btn).on_hover_cursor(egui::CursorIcon::PointingHand);
+                let resp = ui
+                    .add_enabled(!network_busy, btn)
+                    .on_hover_cursor(egui::CursorIcon::PointingHand);
                 if resp.clicked() {
                     self.paused = !self.paused;
                     if !self.paused {
@@ -606,9 +637,9 @@ impl VigilApp {
                 } else {
                     "Isolate Net"
                 };
-                let can_act = active_response::can_modify_firewall();
+                let can_act = active_response::can_isolate_network();
                 let resp_btn = ui.add_enabled(
-                    can_act,
+                    can_act && !network_busy,
                     egui::Button::new(
                         egui::RichText::new(isolate_label)
                             .color(theme::DANGER)
@@ -618,7 +649,9 @@ impl VigilApp {
                     .stroke(egui::Stroke::new(1.0, theme::DANGER))
                     .corner_radius(4.0),
                 );
-                let resp_btn = if can_act {
+                let resp_btn = if network_busy {
+                    resp_btn.on_hover_text("A network action is already in progress.")
+                } else if can_act {
                     resp_btn.on_hover_cursor(egui::CursorIcon::PointingHand)
                 } else {
                     resp_btn.on_hover_text("Administrator privileges are required for network isolation.")
@@ -640,6 +673,7 @@ impl eframe::App for VigilApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         let ctx = ui.ctx().clone();
         self.refresh_active_response_state();
+        self.poll_network_operation();
         if self.show_window.swap(false, Ordering::Relaxed) {
             ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
             ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
@@ -720,45 +754,8 @@ impl eframe::App for VigilApp {
         if let Some(action) = inspector_action {
             self.handle_inspector_action(action, &ctx);
         }
-        if let Some(message) = self.response_message.as_ref() {
-            if message.1.elapsed().as_secs() < 4 {
-                egui::Panel::top("active_response_message")
-                    .exact_size(28.0)
-                    .frame(egui::Frame::NONE.fill(theme::BG))
-                    .show_inside(ui, |ui| {
-                        ui.horizontal(|ui| {
-                            ui.label(
-                                egui::RichText::new(&message.0)
-                                    .color(theme::DANGER)
-                                    .size(10.8)
-                                    .strong(),
-                            );
-                        });
-                    });
-            } else {
-                self.response_message = None;
-            }
-        }
-        if let Some(message) = self.admin_message.as_ref() {
-            if message.1.elapsed().as_secs() < 4 {
-                egui::Panel::top("admin_message")
-                    .exact_size(28.0)
-                    .frame(egui::Frame::NONE.fill(theme::BG))
-                    .show_inside(ui, |ui| {
-                        ui.horizontal(|ui| {
-                            ui.label(
-                                egui::RichText::new(&message.0)
-                                    .color(theme::ACCENT)
-                                    .size(10.8)
-                                    .strong(),
-                            );
-                        });
-                    });
-            } else {
-                self.admin_message = None;
-            }
-        }
         self.show_response_confirm(ctx.clone());
+        self.show_notifications(ui);
         egui::CentralPanel::default()
             .frame(
                 egui::Frame::NONE
@@ -809,6 +806,7 @@ impl eframe::App for VigilApp {
                 }
                 Tab::Help => help::show(ui),
             });
+        self.show_network_operation_overlay(&ctx);
         ctx.request_repaint_after(std::time::Duration::from_millis(16));
     }
     fn clear_color(&self, _visuals: &egui::Visuals) -> [f32; 4] {
@@ -858,12 +856,15 @@ impl VigilApp {
         }
     }
     fn apply_scheduled_lockdown(&mut self) {
+        if self.network_operation.is_some() {
+            return;
+        }
         let cfg = self.cfg.read().unwrap().clone();
         if !cfg.scheduled_lockdown_enabled {
             self.scheduled_lockdown_active = false;
             return;
         }
-        if !active_response::can_modify_firewall() {
+        if !active_response::can_isolate_network() {
             return;
         }
         let now = Local::now();
@@ -883,35 +884,31 @@ impl VigilApp {
             match active_response::isolate_machine() {
                 Ok(msg) => {
                     self.scheduled_lockdown_active = true;
-                    self.response_message = Some((
+                    self.push_notification(
+                        NotificationKind::Success,
                         format!("Scheduled lockdown: {msg}"),
-                        std::time::Instant::now(),
-                    ));
+                    );
                     self.response_status = active_response::status();
                 }
-                Err(err) => {
-                    self.response_message = Some((
-                        format!("Scheduled lockdown failed: {err}"),
-                        std::time::Instant::now(),
-                    ))
-                }
+                Err(err) => self.push_notification(
+                    NotificationKind::Error,
+                    format!("Scheduled lockdown failed: {err}"),
+                ),
             }
         } else if !should_lock && self.scheduled_lockdown_active {
             match active_response::restore_machine() {
                 Ok(msg) => {
                     self.scheduled_lockdown_active = false;
-                    self.response_message = Some((
+                    self.push_notification(
+                        NotificationKind::Success,
                         format!("Scheduled lockdown ended: {msg}"),
-                        std::time::Instant::now(),
-                    ));
+                    );
                     self.response_status = active_response::status();
                 }
-                Err(err) => {
-                    self.response_message = Some((
-                        format!("Scheduled restore failed: {err}"),
-                        std::time::Instant::now(),
-                    ))
-                }
+                Err(err) => self.push_notification(
+                    NotificationKind::Error,
+                    format!("Scheduled restore failed: {err}"),
+                ),
             }
         }
     }
@@ -949,8 +946,9 @@ impl VigilApp {
                         )
                         .on_hover_cursor(egui::CursorIcon::PointingHand);
                     if confirm.clicked() {
-                        let result = self.execute_pending_response(&pending);
-                        self.response_message = Some((result, std::time::Instant::now()));
+                        let result = Self::execute_pending_response(&pending);
+                        let kind = Self::kind_from_message(&result);
+                        self.push_notification(kind, result);
                         self.response_status = active_response::status();
                         self.response_confirm = None;
                     }
@@ -971,7 +969,7 @@ impl VigilApp {
                 });
             });
     }
-    fn execute_pending_response(&mut self, pending: &PendingResponse) -> String {
+    fn execute_pending_response(pending: &PendingResponse) -> String {
         match pending {
             PendingResponse::BlockRemote { target, preset } => {
                 match active_response::block_remote(target, *preset) {
@@ -1061,6 +1059,251 @@ impl VigilApp {
                 Err(err) => format!("Could not restore the network: {err}"),
             },
         }
+    }
+    fn start_network_operation(&mut self, kind: NetworkOperationKind) {
+        if self.network_operation.is_some() {
+            return;
+        }
+        let pending = match kind {
+            NetworkOperationKind::Isolate => PendingResponse::IsolateMachine,
+            NetworkOperationKind::Restore => PendingResponse::RestoreNetwork,
+        };
+        let (tx, rx) = mpsc::channel();
+        let thread_name = match kind {
+            NetworkOperationKind::Isolate => "vigil-isolate-machine",
+            NetworkOperationKind::Restore => "vigil-restore-network",
+        };
+        match std::thread::Builder::new()
+            .name(thread_name.into())
+            .spawn(move || {
+                let result = Self::execute_pending_response(&pending);
+                let _ = tx.send(result);
+            }) {
+            Ok(_) => {
+                self.network_operation = Some(NetworkOperation { kind, rx });
+                if matches!(kind, NetworkOperationKind::Restore) {
+                    self.scheduled_lockdown_active = false;
+                }
+            }
+            Err(err) => self.push_notification(
+                NotificationKind::Error,
+                format!("Could not start network action: {err}"),
+            ),
+        }
+    }
+    fn poll_network_operation(&mut self) {
+        let Some(operation) = self.network_operation.as_ref() else {
+            return;
+        };
+        match operation.rx.try_recv() {
+            Ok(message) => {
+                self.network_operation = None;
+                let kind = Self::kind_from_message(&message);
+                self.push_notification(kind, message);
+                self.response_status = active_response::status();
+            }
+            Err(mpsc::TryRecvError::Empty) => {}
+            Err(mpsc::TryRecvError::Disconnected) => {
+                self.network_operation = None;
+                self.push_notification(
+                    NotificationKind::Error,
+                    "Network action worker stopped unexpectedly.",
+                );
+                self.response_status = active_response::status();
+            }
+        }
+    }
+    fn show_network_operation_overlay(&self, ctx: &egui::Context) {
+        let Some(operation) = self.network_operation.as_ref() else {
+            return;
+        };
+        let screen = ctx.content_rect();
+        egui::Area::new(egui::Id::new("network_operation_blocker"))
+            .order(egui::Order::Foreground)
+            .fixed_pos(screen.min)
+            .show(ctx, |ui| {
+                ui.set_min_size(screen.size());
+                let rect = egui::Rect::from_min_size(egui::Pos2::ZERO, screen.size());
+                let response = ui.allocate_rect(rect, egui::Sense::click_and_drag());
+                ui.painter()
+                    .rect_filled(rect, 0.0, egui::Color32::from_black_alpha(170));
+                response.on_hover_cursor(egui::CursorIcon::Progress);
+            });
+        let label = match operation.kind {
+            NetworkOperationKind::Isolate => "Isolating...",
+            NetworkOperationKind::Restore => "Restoring network...",
+        };
+        egui::Area::new(egui::Id::new("network_operation_modal"))
+            .order(egui::Order::Foreground)
+            .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
+            .show(ctx, |ui| {
+                egui::Frame::NONE
+                    .fill(theme::SURFACE2)
+                    .stroke(egui::Stroke::new(1.0, theme::BORDER))
+                    .corner_radius(12.0)
+                    .inner_margin(egui::Margin::symmetric(18, 14))
+                    .show(ui, |ui| {
+                        ui.set_min_width(280.0);
+                        ui.vertical_centered(|ui| {
+                            ui.add(egui::Spinner::new().size(24.0).color(theme::ACCENT));
+                            ui.add_space(10.0);
+                            ui.label(
+                                egui::RichText::new(label)
+                                    .color(theme::TEXT)
+                                    .size(12.0)
+                                    .strong(),
+                            );
+                            ui.add_space(4.0);
+                            ui.label(
+                                egui::RichText::new(
+                                    "Applying containment rules and validating connectivity.",
+                                )
+                                .color(theme::TEXT3)
+                                .size(10.8),
+                            );
+                        });
+                    });
+            });
+    }
+    fn push_notification(&mut self, kind: NotificationKind, text: impl Into<String>) {
+        self.notifications.push_back(Notification {
+            id: self.next_notification_id,
+            kind,
+            text: text.into(),
+        });
+        self.next_notification_id = self.next_notification_id.saturating_add(1);
+        while self.notifications.len() > 8 {
+            self.notifications.pop_front();
+        }
+    }
+    fn kind_from_message(text: &str) -> NotificationKind {
+        let lower = text.to_ascii_lowercase();
+        if lower.contains("enabled with warnings")
+            || lower.contains("removed with warnings")
+            || lower.contains("with warnings:")
+        {
+            NotificationKind::Warning
+        } else if lower.contains("could not")
+            || lower.contains("failed")
+            || lower.contains("error")
+            || lower.contains("denied")
+        {
+            NotificationKind::Error
+        } else if lower.contains("warning") {
+            NotificationKind::Warning
+        } else {
+            NotificationKind::Success
+        }
+    }
+    fn show_notifications(&mut self, ui: &mut egui::Ui) {
+        if self.notifications.is_empty() {
+            return;
+        }
+        let count = self.notifications.len().min(4);
+        let height = (count as f32 * 52.0 + 20.0).min(220.0);
+        egui::Panel::bottom("notifications")
+            .exact_size(height)
+            .frame(
+                egui::Frame::NONE
+                    .fill(theme::BG)
+                    .stroke(egui::Stroke::new(1.0, theme::BORDER)),
+            )
+            .show_inside(ui, |ui| {
+                ui.add_space(6.0);
+                ui.horizontal(|ui| {
+                    ui.label(
+                        egui::RichText::new("Notifications")
+                            .color(theme::TEXT2)
+                            .size(10.5)
+                            .strong(),
+                    );
+                    ui.add_space(6.0);
+                    ui.label(
+                        egui::RichText::new(format!("{} open", self.notifications.len()))
+                            .color(theme::TEXT3)
+                            .size(10.0),
+                    );
+                });
+                ui.add_space(6.0);
+                egui::ScrollArea::vertical()
+                    .auto_shrink([false, false])
+                    .show(ui, |ui| {
+                        let ids: Vec<u64> = self.notifications.iter().map(|n| n.id).collect();
+                        for id in ids {
+                            let Some(index) = self.notifications.iter().position(|n| n.id == id)
+                            else {
+                                continue;
+                            };
+                            let (kind, text) = {
+                                let n = &self.notifications[index];
+                                (n.kind, n.text.clone())
+                            };
+                            let (accent, label) = match kind {
+                                NotificationKind::Info => (theme::ACCENT, "Info"),
+                                NotificationKind::Success => (theme::ACCENT, "Success"),
+                                NotificationKind::Warning => (theme::WARN, "Warning"),
+                                NotificationKind::Error => (theme::DANGER, "Error"),
+                            };
+                            egui::Frame::NONE
+                                .fill(theme::SURFACE2)
+                                .stroke(egui::Stroke::new(1.0, theme::BORDER))
+                                .corner_radius(10.0)
+                                .inner_margin(egui::Margin::symmetric(12, 10))
+                                .show(ui, |ui| {
+                                    ui.horizontal_top(|ui| {
+                                        let (bar_rect, _) = ui.allocate_exact_size(
+                                            egui::vec2(4.0, 34.0),
+                                            egui::Sense::hover(),
+                                        );
+                                        ui.painter().rect_filled(bar_rect, 2.0, accent);
+                                        ui.add_space(8.0);
+                                        ui.vertical(|ui| {
+                                            ui.label(
+                                                egui::RichText::new(label)
+                                                    .color(accent)
+                                                    .size(10.0)
+                                                    .strong(),
+                                            );
+                                            ui.add(
+                                                egui::Label::new(
+                                                    egui::RichText::new(text)
+                                                        .color(theme::TEXT)
+                                                        .size(11.0),
+                                                )
+                                                .wrap(),
+                                            );
+                                        });
+                                        ui.with_layout(
+                                            egui::Layout::right_to_left(egui::Align::TOP),
+                                            |ui| {
+                                                let close = ui
+                                                    .add(
+                                                        egui::Button::new(
+                                                            egui::RichText::new("x")
+                                                                .color(theme::TEXT2)
+                                                                .size(10.5),
+                                                        )
+                                                        .fill(theme::SURFACE3)
+                                                        .stroke(egui::Stroke::new(
+                                                            1.0,
+                                                            theme::BORDER,
+                                                        ))
+                                                        .corner_radius(4.0),
+                                                    )
+                                                    .on_hover_cursor(egui::CursorIcon::PointingHand)
+                                                    .on_hover_text("Dismiss this notification.");
+                                                if close.clicked() {
+                                                    self.notifications.remove(index);
+                                                }
+                                            },
+                                        );
+                                    });
+                                });
+                            ui.add_space(8.0);
+                        }
+                    });
+                ui.add_space(4.0);
+            });
     }
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -28,101 +28,1073 @@ use tab_bar::Tab;
 use tokio::sync::broadcast;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TableState { pub filter: String, pub sort_col: usize, pub sort_asc: bool, #[serde(default)] pub collapsed_pids: HashSet<u32> }
-impl TableState { pub fn new(default_col: usize, default_asc: bool) -> Self { Self { filter: String::new(), sort_col: default_col, sort_asc: default_asc, collapsed_pids: HashSet::new() } } pub fn toggle(&mut self, col: usize) { if self.sort_col == col { self.sort_asc = !self.sort_asc; } else { self.sort_col = col; self.sort_asc = true; } } pub fn arrow(&self, col: usize) -> &'static str { if self.sort_col == col { if self.sort_asc { " ^" } else { " v" } } else { "" } } pub fn is_collapsed(&self, pid: u32) -> bool { self.collapsed_pids.contains(&pid) } pub fn toggle_collapsed(&mut self, pid: u32) { if !self.collapsed_pids.insert(pid) { self.collapsed_pids.remove(&pid); } } }
+pub struct TableState {
+    pub filter: String,
+    pub sort_col: usize,
+    pub sort_asc: bool,
+    #[serde(default)]
+    pub collapsed_pids: HashSet<u32>,
+}
+impl TableState {
+    pub fn new(default_col: usize, default_asc: bool) -> Self {
+        Self {
+            filter: String::new(),
+            sort_col: default_col,
+            sort_asc: default_asc,
+            collapsed_pids: HashSet::new(),
+        }
+    }
+    pub fn toggle(&mut self, col: usize) {
+        if self.sort_col == col {
+            self.sort_asc = !self.sort_asc;
+        } else {
+            self.sort_col = col;
+            self.sort_asc = true;
+        }
+    }
+    pub fn arrow(&self, col: usize) -> &'static str {
+        if self.sort_col == col {
+            if self.sort_asc {
+                " ^"
+            } else {
+                " v"
+            }
+        } else {
+            ""
+        }
+    }
+    pub fn is_collapsed(&self, pid: u32) -> bool {
+        self.collapsed_pids.contains(&pid)
+    }
+    pub fn toggle_collapsed(&mut self, pid: u32) {
+        if !self.collapsed_pids.insert(pid) {
+            self.collapsed_pids.remove(&pid);
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct UiState { active_tab: Tab, activity_table: TableState, alerts_table: TableState }
-impl Default for UiState { fn default() -> Self { Self { active_tab: Tab::Activity, activity_table: TableState::new(0, false), alerts_table: TableState::new(4, false) } } }
+struct UiState {
+    active_tab: Tab,
+    activity_table: TableState,
+    alerts_table: TableState,
+}
+impl Default for UiState {
+    fn default() -> Self {
+        Self {
+            active_tab: Tab::Activity,
+            activity_table: TableState::new(0, false),
+            alerts_table: TableState::new(4, false),
+        }
+    }
+}
 
 #[derive(Clone)]
 pub struct ProcessSelection {
-    pub pid: u32, pub proc_name: String, pub proc_path: String, pub proc_user: String, pub parent_name: String, pub parent_pid: u32, pub service_name: String, pub publisher: String, pub score: u8, pub reasons: Vec<String>, pub timestamp: String, pub status: String, pub remote_addr: String, pub connection_count: usize, pub distinct_ports: usize, pub distinct_remotes: usize, pub statuses: Vec<String>, pub selected_connection: Option<ConnInfo>,
+    pub pid: u32,
+    pub proc_name: String,
+    pub proc_path: String,
+    pub proc_user: String,
+    pub parent_name: String,
+    pub parent_pid: u32,
+    pub service_name: String,
+    pub publisher: String,
+    pub score: u8,
+    pub reasons: Vec<String>,
+    pub timestamp: String,
+    pub status: String,
+    pub remote_addr: String,
+    pub connection_count: usize,
+    pub distinct_ports: usize,
+    pub distinct_remotes: usize,
+    pub statuses: Vec<String>,
+    pub selected_connection: Option<ConnInfo>,
 }
 
 #[derive(Clone)]
-enum PendingResponse { BlockRemote { target: String, preset: active_response::DurationPreset }, BlockDomain { domain: String }, BlockProcess { pid: u32, path: String, preset: active_response::DurationPreset }, SuspendProcess { pid: u32, path: String, proc_name: String }, ResumeProcess { pid: u32, path: String }, FreezeAutoruns, RevertAutoruns, QuarantineProfile { pid: u32, path: String, proc_name: String }, ClearQuarantineProfile { pid: u32, path: String }, KillConnection(ConnInfo), UnblockRemote(String), UnblockDomain(String), UnblockProcess { pid: u32, path: String }, IsolateMachine, RestoreNetwork }
+enum PendingResponse {
+    BlockRemote {
+        target: String,
+        preset: active_response::DurationPreset,
+    },
+    BlockDomain {
+        domain: String,
+    },
+    BlockProcess {
+        pid: u32,
+        path: String,
+        preset: active_response::DurationPreset,
+    },
+    SuspendProcess {
+        pid: u32,
+        path: String,
+        proc_name: String,
+    },
+    ResumeProcess {
+        pid: u32,
+        path: String,
+    },
+    FreezeAutoruns,
+    RevertAutoruns,
+    QuarantineProfile {
+        pid: u32,
+        path: String,
+        proc_name: String,
+    },
+    ClearQuarantineProfile {
+        pid: u32,
+        path: String,
+    },
+    KillConnection(Box<ConnInfo>),
+    UnblockRemote(String),
+    UnblockDomain(String),
+    UnblockProcess {
+        pid: u32,
+        path: String,
+    },
+    IsolateMachine,
+    RestoreNetwork,
+}
 
-pub fn is_ghost_process_name(name: &str) -> bool { let Some(inner) = name.trim().strip_prefix('<').and_then(|s| s.strip_suffix('>')) else { return false; }; !inner.is_empty() && inner.chars().all(|c| c.is_ascii_digit()) }
-pub fn has_known_location(sel: &ProcessSelection) -> bool { !sel.proc_path.is_empty() && !is_ghost_process_name(&sel.proc_name) }
+pub fn is_ghost_process_name(name: &str) -> bool {
+    let Some(inner) = name
+        .trim()
+        .strip_prefix('<')
+        .and_then(|s| s.strip_suffix('>'))
+    else {
+        return false;
+    };
+    !inner.is_empty() && inner.chars().all(|c| c.is_ascii_digit())
+}
+pub fn has_known_location(sel: &ProcessSelection) -> bool {
+    !sel.proc_path.is_empty() && !is_ghost_process_name(&sel.proc_name)
+}
 
 pub struct VigilApp {
-    activity: VecDeque<ConnInfo>, alerts: VecDeque<ConnInfo>, selected_activity: Option<ProcessSelection>, selected_alert: Option<ProcessSelection>, active_tab: Tab, unseen_alerts: usize,
-    event_rx: broadcast::Receiver<ConnEvent>, tray_tx: std::sync::mpsc::SyncSender<TrayCmd>, show_window: Arc<AtomicBool>, pending_nav: Arc<Mutex<Option<ConnInfo>>>, cfg: Arc<RwLock<Config>>, settings: settings::SettingsDraft,
-    kill_confirm: bool, response_confirm: Option<PendingResponse>, response_status: active_response::Status, response_message: Option<(String, std::time::Instant)>, admin_message: Option<(String, std::time::Instant)>, auto_response_state: auto_response::EngineState, response_rule_state: response_rules::EngineState,
-    exit_requested: bool, last_response_reconcile: std::time::Instant, last_schedule_check: std::time::Instant, scheduled_lockdown_active: bool, paused: bool, activity_table: TableState, alerts_table: TableState,
+    activity: VecDeque<ConnInfo>,
+    alerts: VecDeque<ConnInfo>,
+    selected_activity: Option<ProcessSelection>,
+    selected_alert: Option<ProcessSelection>,
+    active_tab: Tab,
+    unseen_alerts: usize,
+    event_rx: broadcast::Receiver<ConnEvent>,
+    tray_tx: std::sync::mpsc::SyncSender<TrayCmd>,
+    show_window: Arc<AtomicBool>,
+    pending_nav: Arc<Mutex<Option<ConnInfo>>>,
+    cfg: Arc<RwLock<Config>>,
+    settings: settings::SettingsDraft,
+    kill_confirm: bool,
+    response_confirm: Option<PendingResponse>,
+    response_status: active_response::Status,
+    response_message: Option<(String, std::time::Instant)>,
+    admin_message: Option<(String, std::time::Instant)>,
+    auto_response_state: auto_response::EngineState,
+    response_rule_state: response_rules::EngineState,
+    exit_requested: bool,
+    last_response_reconcile: std::time::Instant,
+    last_schedule_check: std::time::Instant,
+    scheduled_lockdown_active: bool,
+    paused: bool,
+    activity_table: TableState,
+    alerts_table: TableState,
 }
-const ACTIVITY_CAP: usize = 4096; const ALERTS_CAP: usize = 2048;
+const ACTIVITY_CAP: usize = 4096;
+const ALERTS_CAP: usize = 2048;
 
 impl VigilApp {
-    pub fn new(cc: &eframe::CreationContext<'_>, cfg: Arc<RwLock<Config>>, event_rx: broadcast::Receiver<ConnEvent>, tray_tx: std::sync::mpsc::SyncSender<TrayCmd>, show_window: Arc<AtomicBool>, pending_nav: Arc<Mutex<Option<ConnInfo>>>) -> Self {
-        theme::apply(&cc.egui_ctx); let settings = { let c = cfg.read().unwrap(); settings::SettingsDraft::from_config(&c) }; let persisted = cc.storage.and_then(|storage| eframe::get_value::<UiState>(storage, "ui")).unwrap_or_default(); cc.egui_ctx.request_repaint_after(std::time::Duration::from_millis(16));
-        Self { activity: VecDeque::new(), alerts: VecDeque::new(), selected_activity: None, selected_alert: None, active_tab: persisted.active_tab, unseen_alerts: 0, event_rx, tray_tx, show_window, pending_nav, cfg, settings, kill_confirm: false, response_confirm: None, response_status: active_response::status(), response_message: None, admin_message: None, auto_response_state: auto_response::EngineState::default(), response_rule_state: response_rules::EngineState::default(), exit_requested: false, last_response_reconcile: std::time::Instant::now(), last_schedule_check: std::time::Instant::now() - std::time::Duration::from_secs(60), scheduled_lockdown_active: false, paused: false, activity_table: persisted.activity_table, alerts_table: persisted.alerts_table }
-    }
-    fn drain_events(&mut self) -> bool { use broadcast::error::TryRecvError; let mut handled=false; loop { match self.event_rx.try_recv() { Ok(event)=>{ handled=true; if self.paused { continue; } match event { ConnEvent::Alert(info)=>{ push_capped(&mut self.activity, info.clone(), ACTIVITY_CAP); push_capped(&mut self.alerts, info.clone(), ALERTS_CAP); self.unseen_alerts += 1; let _ = self.tray_tx.try_send(TrayCmd::Alert(Box::new(info.clone()))); self.maybe_apply_auto_response(&info); } ConnEvent::New(info)=>{ push_capped(&mut self.activity, info.clone(), ACTIVITY_CAP); self.maybe_apply_auto_response(&info); } ConnEvent::Closed { .. }=>{} } } Err(TryRecvError::Empty)=>break, Err(TryRecvError::Lagged(n))=>tracing::warn!("UI dropped {n} broadcast events"), Err(TryRecvError::Closed)=>break } } handled }
-    fn maybe_apply_auto_response(&mut self, info: &ConnInfo) { let cfg = self.cfg.read().unwrap().clone(); if let Some(message) = auto_response::maybe_apply(info, &cfg, &mut self.auto_response_state) { self.response_message = Some((message, std::time::Instant::now())); self.response_status = active_response::status(); } if let Some(message) = response_rules::maybe_apply(info, &cfg, &mut self.response_rule_state) { self.response_message = Some((message, std::time::Instant::now())); self.response_status = active_response::status(); } }
-    fn handle_inspector_action(&mut self, action: inspector::Action, ctx: &egui::Context) {
-        let selected_info: Option<ProcessSelection> = match self.active_tab { Tab::Activity => self.selected_activity.clone(), Tab::Alerts => self.selected_alert.clone(), _ => None };
-        match action {
-            inspector::Action::Trust => if let Some(info)=selected_info { if !has_known_location(&info) { return; } let mut cfg=self.cfg.write().unwrap(); if cfg.add_trusted(&info.proc_name) { cfg.save(); self.settings=settings::SettingsDraft::from_config(&cfg); } },
-            inspector::Action::OpenLocation => if let Some(info)=selected_info { if has_known_location(&info) { let path=std::path::Path::new(&info.proc_path); let dir=path.parent().unwrap_or(path); let _=open::that(dir); } },
-            inspector::Action::Kill => self.kill_confirm = true,
-            inspector::Action::SuspendProcess => if let Some(info)=selected_info { self.response_confirm=Some(PendingResponse::SuspendProcess{pid:info.pid,path:info.proc_path,proc_name:info.proc_name}); },
-            inspector::Action::ResumeProcess => if let Some(info)=selected_info { self.response_confirm=Some(PendingResponse::ResumeProcess{pid:info.pid,path:info.proc_path}); },
-            inspector::Action::FreezeAutoruns => self.response_confirm = Some(PendingResponse::FreezeAutoruns),
-            inspector::Action::RevertAutoruns => self.response_confirm = Some(PendingResponse::RevertAutoruns),
-            inspector::Action::QuarantineProfile => if let Some(info)=selected_info { self.response_confirm=Some(PendingResponse::QuarantineProfile{pid:info.pid,path:info.proc_path,proc_name:info.proc_name}); },
-            inspector::Action::ClearQuarantineProfile => if let Some(info)=selected_info { self.response_confirm=Some(PendingResponse::ClearQuarantineProfile{pid:info.pid,path:info.proc_path}); },
-            inspector::Action::BlockRemote(preset) => if let Some(info)=selected_info { if let Some(conn)=info.selected_connection.as_ref() { if let Some(target)=active_response::extract_remote_target(&conn.remote_addr) { self.response_confirm=Some(PendingResponse::BlockRemote{target,preset}); } } },
-            inspector::Action::BlockDomain => if let Some(info)=selected_info { if let Some(conn)=info.selected_connection.as_ref() { if let Some(domain)=active_response::extract_domain_target(conn) { self.response_confirm=Some(PendingResponse::BlockDomain{domain}); } } },
-            inspector::Action::BlockProcess(preset) => if let Some(info)=selected_info { if has_known_location(&info) { self.response_confirm=Some(PendingResponse::BlockProcess{pid:info.pid,path:info.proc_path,preset}); } },
-            inspector::Action::KillConnection => if let Some(info)=selected_info { if let Some(conn)=info.selected_connection { self.response_confirm=Some(PendingResponse::KillConnection(conn)); } },
-            inspector::Action::UnblockRemote => if let Some(info)=selected_info { if let Some(conn)=info.selected_connection.as_ref() { if let Some(target)=active_response::extract_remote_target(&conn.remote_addr) { self.response_confirm=Some(PendingResponse::UnblockRemote(target)); } } },
-            inspector::Action::UnblockDomain => if let Some(info)=selected_info { if let Some(conn)=info.selected_connection.as_ref() { if let Some(domain)=active_response::extract_domain_target(conn) { self.response_confirm=Some(PendingResponse::UnblockDomain(domain)); } } },
-            inspector::Action::UnblockProcess => if let Some(info)=selected_info { if has_known_location(&info) { self.response_confirm=Some(PendingResponse::UnblockProcess{pid:info.pid,path:info.proc_path}); } },
-            inspector::Action::IsolateMachine => self.response_confirm=Some(PendingResponse::IsolateMachine),
-            inspector::Action::RestoreNetwork => { self.scheduled_lockdown_active=false; self.response_confirm=Some(PendingResponse::RestoreNetwork); },
-            inspector::Action::RequestAdmin => match crate::autostart::relaunch_as_admin() { Ok(()) => { self.exit_requested=true; self.admin_message=Some(("Reopened Vigil as administrator.".into(), std::time::Instant::now())); ctx.send_viewport_cmd(egui::ViewportCommand::Close); } Err(err) => { self.admin_message=Some((format!("Could not relaunch as admin: {err}"), std::time::Instant::now())); } },
-            inspector::Action::KillConfirmed => { if let Some(info)=selected_info { if !is_ghost_process_name(&info.proc_name) { kill_process(info.pid); remove_pid(&mut self.activity, info.pid); remove_pid(&mut self.alerts, info.pid); if self.selected_activity.as_ref().is_some_and(|sel| sel.pid == info.pid) { self.selected_activity=None; } if self.selected_alert.as_ref().is_some_and(|sel| sel.pid == info.pid) { self.selected_alert=None; } if self.alerts.is_empty() { self.unseen_alerts=0; let _=self.tray_tx.try_send(TrayCmd::ResetOk); } } } self.kill_confirm=false; },
-            inspector::Action::KillCancelled => self.kill_confirm=false,
+    pub fn new(
+        cc: &eframe::CreationContext<'_>,
+        cfg: Arc<RwLock<Config>>,
+        event_rx: broadcast::Receiver<ConnEvent>,
+        tray_tx: std::sync::mpsc::SyncSender<TrayCmd>,
+        show_window: Arc<AtomicBool>,
+        pending_nav: Arc<Mutex<Option<ConnInfo>>>,
+    ) -> Self {
+        theme::apply(&cc.egui_ctx);
+        let settings = {
+            let c = cfg.read().unwrap();
+            settings::SettingsDraft::from_config(&c)
+        };
+        let persisted = cc
+            .storage
+            .and_then(|storage| eframe::get_value::<UiState>(storage, "ui"))
+            .unwrap_or_default();
+        cc.egui_ctx
+            .request_repaint_after(std::time::Duration::from_millis(16));
+        Self {
+            activity: VecDeque::new(),
+            alerts: VecDeque::new(),
+            selected_activity: None,
+            selected_alert: None,
+            active_tab: persisted.active_tab,
+            unseen_alerts: 0,
+            event_rx,
+            tray_tx,
+            show_window,
+            pending_nav,
+            cfg,
+            settings,
+            kill_confirm: false,
+            response_confirm: None,
+            response_status: active_response::status(),
+            response_message: None,
+            admin_message: None,
+            auto_response_state: auto_response::EngineState::default(),
+            response_rule_state: response_rules::EngineState::default(),
+            exit_requested: false,
+            last_response_reconcile: std::time::Instant::now(),
+            last_schedule_check: std::time::Instant::now() - std::time::Duration::from_secs(60),
+            scheduled_lockdown_active: false,
+            paused: false,
+            activity_table: persisted.activity_table,
+            alerts_table: persisted.alerts_table,
         }
     }
-    fn show_header(&mut self, ui: &mut egui::Ui) -> Option<inspector::Action> { let mut action=None; ui.horizontal_centered(|ui| { ui.add_space(12.0); ui.label(egui::RichText::new("Vigil").color(theme::TEXT).size(16.0).strong()); ui.add_space(10.0); let admin=crate::autostart::is_elevated(); let (label,color,filled)=if self.paused { ("Paused", theme::TEXT2, false) } else { ("Monitoring", theme::ACCENT, true) }; ui.horizontal_wrapped(|ui| { let (dot_rect,_) = ui.allocate_exact_size(egui::vec2(8.0,8.0), egui::Sense::hover()); if filled { ui.painter().circle_filled(dot_rect.center(),4.0,color); } else { ui.painter().circle_stroke(dot_rect.center(),4.0,egui::Stroke::new(1.4,color)); } ui.add_space(4.0); ui.label(egui::RichText::new(label).color(color).size(11.5)); ui.add_space(6.0); if admin { admin_chip(ui); } else { let relaunch=ui.add(admin_btn("Run as Admin")).on_hover_cursor(egui::CursorIcon::PointingHand).on_hover_text("Relaunch Vigil with administrator privileges so it can inspect more network activity."); if relaunch.clicked() { action=Some(inspector::Action::RequestAdmin); } } if self.settings.scheduled_lockdown_enabled { let schedule_label=if self.scheduled_lockdown_active { format!(" Scheduled {:02}:{:02}-{:02}:{:02} ", self.settings.scheduled_lockdown_start_hour, self.settings.scheduled_lockdown_start_minute, self.settings.scheduled_lockdown_end_hour, self.settings.scheduled_lockdown_end_minute) } else { format!(" Schedule {:02}:{:02}-{:02}:{:02} ", self.settings.scheduled_lockdown_start_hour, self.settings.scheduled_lockdown_start_minute, self.settings.scheduled_lockdown_end_hour, self.settings.scheduled_lockdown_end_minute) }; ui.label(egui::RichText::new(schedule_label).color(if self.scheduled_lockdown_active { theme::DANGER } else { theme::TEXT2 }).background_color(if self.scheduled_lockdown_active { theme::DANGER_BG } else { theme::SURFACE2 }).size(10.0).strong()); } if self.response_status.frozen_autoruns { ui.label(egui::RichText::new(" Autoruns frozen ").color(theme::WARN).background_color(theme::WARN_BG).size(10.0).strong()); } }); ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| { ui.add_space(12.0); let btn_label=if self.paused { "Resume" } else { "Pause" }; let btn=egui::Button::new(egui::RichText::new(btn_label).color(theme::TEXT2).size(11.0)).fill(theme::SURFACE2).stroke(egui::Stroke::new(1.0, theme::BORDER)).corner_radius(4.0); let resp=ui.add(btn).on_hover_cursor(egui::CursorIcon::PointingHand); if resp.clicked() { self.paused=!self.paused; if !self.paused { let _=self.tray_tx.try_send(TrayCmd::ResetOk); } } ui.add_space(8.0); let isolate_label=if self.response_status.isolated { "Restore Net" } else { "Isolate Net" }; let can_act=active_response::can_modify_firewall(); let resp_btn=ui.add_enabled(can_act, egui::Button::new(egui::RichText::new(isolate_label).color(theme::DANGER).size(11.0)).fill(theme::DANGER_BG).stroke(egui::Stroke::new(1.0, theme::DANGER)).corner_radius(4.0)); let resp_btn=if can_act { resp_btn.on_hover_cursor(egui::CursorIcon::PointingHand) } else { resp_btn.on_hover_text("Administrator privileges are required for network isolation.") }; if resp_btn.clicked() { action=Some(if self.response_status.isolated { inspector::Action::RestoreNetwork } else { inspector::Action::IsolateMachine }); } }); }); action }
+    fn drain_events(&mut self) -> bool {
+        use broadcast::error::TryRecvError;
+        let mut handled = false;
+        loop {
+            match self.event_rx.try_recv() {
+                Ok(event) => {
+                    handled = true;
+                    if self.paused {
+                        continue;
+                    }
+                    match event {
+                        ConnEvent::Alert(info) => {
+                            push_capped(&mut self.activity, info.clone(), ACTIVITY_CAP);
+                            push_capped(&mut self.alerts, info.clone(), ALERTS_CAP);
+                            self.unseen_alerts += 1;
+                            let _ = self
+                                .tray_tx
+                                .try_send(TrayCmd::Alert(Box::new(info.clone())));
+                            self.maybe_apply_auto_response(&info);
+                        }
+                        ConnEvent::New(info) => {
+                            push_capped(&mut self.activity, info.clone(), ACTIVITY_CAP);
+                            self.maybe_apply_auto_response(&info);
+                        }
+                        ConnEvent::Closed { .. } => {}
+                    }
+                }
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Lagged(n)) => tracing::warn!("UI dropped {n} broadcast events"),
+                Err(TryRecvError::Closed) => break,
+            }
+        }
+        handled
+    }
+    fn maybe_apply_auto_response(&mut self, info: &ConnInfo) {
+        let cfg = self.cfg.read().unwrap().clone();
+        if let Some(message) = auto_response::maybe_apply(info, &cfg, &mut self.auto_response_state)
+        {
+            self.response_message = Some((message, std::time::Instant::now()));
+            self.response_status = active_response::status();
+        }
+        if let Some(message) =
+            response_rules::maybe_apply(info, &cfg, &mut self.response_rule_state)
+        {
+            self.response_message = Some((message, std::time::Instant::now()));
+            self.response_status = active_response::status();
+        }
+    }
+    fn handle_inspector_action(&mut self, action: inspector::Action, ctx: &egui::Context) {
+        let selected_info: Option<ProcessSelection> = match self.active_tab {
+            Tab::Activity => self.selected_activity.clone(),
+            Tab::Alerts => self.selected_alert.clone(),
+            _ => None,
+        };
+        match action {
+            inspector::Action::Trust => {
+                if let Some(info) = selected_info {
+                    if !has_known_location(&info) {
+                        return;
+                    }
+                    let mut cfg = self.cfg.write().unwrap();
+                    if cfg.add_trusted(&info.proc_name) {
+                        cfg.save();
+                        self.settings = settings::SettingsDraft::from_config(&cfg);
+                    }
+                }
+            }
+            inspector::Action::OpenLocation => {
+                if let Some(info) = selected_info {
+                    if has_known_location(&info) {
+                        let path = std::path::Path::new(&info.proc_path);
+                        let dir = path.parent().unwrap_or(path);
+                        let _ = open::that(dir);
+                    }
+                }
+            }
+            inspector::Action::Kill => self.kill_confirm = true,
+            inspector::Action::SuspendProcess => {
+                if let Some(info) = selected_info {
+                    self.response_confirm = Some(PendingResponse::SuspendProcess {
+                        pid: info.pid,
+                        path: info.proc_path,
+                        proc_name: info.proc_name,
+                    });
+                }
+            }
+            inspector::Action::ResumeProcess => {
+                if let Some(info) = selected_info {
+                    self.response_confirm = Some(PendingResponse::ResumeProcess {
+                        pid: info.pid,
+                        path: info.proc_path,
+                    });
+                }
+            }
+            inspector::Action::FreezeAutoruns => {
+                self.response_confirm = Some(PendingResponse::FreezeAutoruns)
+            }
+            inspector::Action::RevertAutoruns => {
+                self.response_confirm = Some(PendingResponse::RevertAutoruns)
+            }
+            inspector::Action::QuarantineProfile => {
+                if let Some(info) = selected_info {
+                    self.response_confirm = Some(PendingResponse::QuarantineProfile {
+                        pid: info.pid,
+                        path: info.proc_path,
+                        proc_name: info.proc_name,
+                    });
+                }
+            }
+            inspector::Action::ClearQuarantineProfile => {
+                if let Some(info) = selected_info {
+                    self.response_confirm = Some(PendingResponse::ClearQuarantineProfile {
+                        pid: info.pid,
+                        path: info.proc_path,
+                    });
+                }
+            }
+            inspector::Action::BlockRemote(preset) => {
+                if let Some(info) = selected_info {
+                    if let Some(conn) = info.selected_connection.as_ref() {
+                        if let Some(target) =
+                            active_response::extract_remote_target(&conn.remote_addr)
+                        {
+                            self.response_confirm =
+                                Some(PendingResponse::BlockRemote { target, preset });
+                        }
+                    }
+                }
+            }
+            inspector::Action::BlockDomain => {
+                if let Some(info) = selected_info {
+                    if let Some(conn) = info.selected_connection.as_ref() {
+                        if let Some(domain) = active_response::extract_domain_target(conn) {
+                            self.response_confirm = Some(PendingResponse::BlockDomain { domain });
+                        }
+                    }
+                }
+            }
+            inspector::Action::BlockProcess(preset) => {
+                if let Some(info) = selected_info {
+                    if has_known_location(&info) {
+                        self.response_confirm = Some(PendingResponse::BlockProcess {
+                            pid: info.pid,
+                            path: info.proc_path,
+                            preset,
+                        });
+                    }
+                }
+            }
+            inspector::Action::KillConnection => {
+                if let Some(info) = selected_info {
+                    if let Some(conn) = info.selected_connection {
+                        self.response_confirm =
+                            Some(PendingResponse::KillConnection(Box::new(conn)));
+                    }
+                }
+            }
+            inspector::Action::UnblockRemote => {
+                if let Some(info) = selected_info {
+                    if let Some(conn) = info.selected_connection.as_ref() {
+                        if let Some(target) =
+                            active_response::extract_remote_target(&conn.remote_addr)
+                        {
+                            self.response_confirm = Some(PendingResponse::UnblockRemote(target));
+                        }
+                    }
+                }
+            }
+            inspector::Action::UnblockDomain => {
+                if let Some(info) = selected_info {
+                    if let Some(conn) = info.selected_connection.as_ref() {
+                        if let Some(domain) = active_response::extract_domain_target(conn) {
+                            self.response_confirm = Some(PendingResponse::UnblockDomain(domain));
+                        }
+                    }
+                }
+            }
+            inspector::Action::UnblockProcess => {
+                if let Some(info) = selected_info {
+                    if has_known_location(&info) {
+                        self.response_confirm = Some(PendingResponse::UnblockProcess {
+                            pid: info.pid,
+                            path: info.proc_path,
+                        });
+                    }
+                }
+            }
+            inspector::Action::IsolateMachine => {
+                self.response_confirm = Some(PendingResponse::IsolateMachine)
+            }
+            inspector::Action::RestoreNetwork => {
+                self.scheduled_lockdown_active = false;
+                self.response_confirm = Some(PendingResponse::RestoreNetwork);
+            }
+            inspector::Action::RequestAdmin => match crate::autostart::relaunch_as_admin() {
+                Ok(()) => {
+                    self.exit_requested = true;
+                    self.admin_message = Some((
+                        "Reopened Vigil as administrator.".into(),
+                        std::time::Instant::now(),
+                    ));
+                    ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                }
+                Err(err) => {
+                    self.admin_message = Some((
+                        format!("Could not relaunch as admin: {err}"),
+                        std::time::Instant::now(),
+                    ));
+                }
+            },
+            inspector::Action::KillConfirmed => {
+                if let Some(info) = selected_info {
+                    if !is_ghost_process_name(&info.proc_name) {
+                        kill_process(info.pid);
+                        remove_pid(&mut self.activity, info.pid);
+                        remove_pid(&mut self.alerts, info.pid);
+                        if self
+                            .selected_activity
+                            .as_ref()
+                            .is_some_and(|sel| sel.pid == info.pid)
+                        {
+                            self.selected_activity = None;
+                        }
+                        if self
+                            .selected_alert
+                            .as_ref()
+                            .is_some_and(|sel| sel.pid == info.pid)
+                        {
+                            self.selected_alert = None;
+                        }
+                        if self.alerts.is_empty() {
+                            self.unseen_alerts = 0;
+                            let _ = self.tray_tx.try_send(TrayCmd::ResetOk);
+                        }
+                    }
+                }
+                self.kill_confirm = false;
+            }
+            inspector::Action::KillCancelled => self.kill_confirm = false,
+        }
+    }
+    fn show_header(&mut self, ui: &mut egui::Ui) -> Option<inspector::Action> {
+        let mut action = None;
+
+        ui.horizontal_centered(|ui| {
+            ui.add_space(12.0);
+            ui.label(egui::RichText::new("Vigil").color(theme::TEXT).size(16.0).strong());
+            ui.add_space(10.0);
+
+            let admin = crate::autostart::is_elevated();
+            let (label, color, filled) = if self.paused {
+                ("Paused", theme::TEXT2, false)
+            } else {
+                ("Monitoring", theme::ACCENT, true)
+            };
+
+            ui.horizontal_wrapped(|ui| {
+                let (dot_rect, _) = ui.allocate_exact_size(egui::vec2(8.0, 8.0), egui::Sense::hover());
+                if filled {
+                    ui.painter().circle_filled(dot_rect.center(), 4.0, color);
+                } else {
+                    ui.painter()
+                        .circle_stroke(dot_rect.center(), 4.0, egui::Stroke::new(1.4, color));
+                }
+
+                ui.add_space(4.0);
+                ui.label(egui::RichText::new(label).color(color).size(11.5));
+                ui.add_space(6.0);
+
+                if admin {
+                    admin_chip(ui);
+                } else {
+                    let relaunch = ui
+                        .add(admin_btn("Run as Admin"))
+                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                        .on_hover_text(
+                            "Relaunch Vigil with administrator privileges so it can inspect more network activity.",
+                        );
+                    if relaunch.clicked() {
+                        action = Some(inspector::Action::RequestAdmin);
+                    }
+                }
+
+                if self.settings.scheduled_lockdown_enabled {
+                    let schedule_label = if self.scheduled_lockdown_active {
+                        format!(
+                            " Scheduled {:02}:{:02}-{:02}:{:02} ",
+                            self.settings.scheduled_lockdown_start_hour,
+                            self.settings.scheduled_lockdown_start_minute,
+                            self.settings.scheduled_lockdown_end_hour,
+                            self.settings.scheduled_lockdown_end_minute
+                        )
+                    } else {
+                        format!(
+                            " Schedule {:02}:{:02}-{:02}:{:02} ",
+                            self.settings.scheduled_lockdown_start_hour,
+                            self.settings.scheduled_lockdown_start_minute,
+                            self.settings.scheduled_lockdown_end_hour,
+                            self.settings.scheduled_lockdown_end_minute
+                        )
+                    };
+                    ui.label(
+                        egui::RichText::new(schedule_label)
+                            .color(if self.scheduled_lockdown_active {
+                                theme::DANGER
+                            } else {
+                                theme::TEXT2
+                            })
+                            .background_color(if self.scheduled_lockdown_active {
+                                theme::DANGER_BG
+                            } else {
+                                theme::SURFACE2
+                            })
+                            .size(10.0)
+                            .strong(),
+                    );
+                }
+
+                if self.response_status.frozen_autoruns {
+                    ui.label(
+                        egui::RichText::new(" Autoruns frozen ")
+                            .color(theme::WARN)
+                            .background_color(theme::WARN_BG)
+                            .size(10.0)
+                            .strong(),
+                    );
+                }
+            });
+
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                ui.add_space(12.0);
+
+                let btn_label = if self.paused { "Resume" } else { "Pause" };
+                let btn = egui::Button::new(
+                    egui::RichText::new(btn_label)
+                        .color(theme::TEXT2)
+                        .size(11.0),
+                )
+                .fill(theme::SURFACE2)
+                .stroke(egui::Stroke::new(1.0, theme::BORDER))
+                .corner_radius(4.0);
+                let resp = ui.add(btn).on_hover_cursor(egui::CursorIcon::PointingHand);
+                if resp.clicked() {
+                    self.paused = !self.paused;
+                    if !self.paused {
+                        let _ = self.tray_tx.try_send(TrayCmd::ResetOk);
+                    }
+                }
+
+                ui.add_space(8.0);
+
+                let isolate_label = if self.response_status.isolated {
+                    "Restore Net"
+                } else {
+                    "Isolate Net"
+                };
+                let can_act = active_response::can_modify_firewall();
+                let resp_btn = ui.add_enabled(
+                    can_act,
+                    egui::Button::new(
+                        egui::RichText::new(isolate_label)
+                            .color(theme::DANGER)
+                            .size(11.0),
+                    )
+                    .fill(theme::DANGER_BG)
+                    .stroke(egui::Stroke::new(1.0, theme::DANGER))
+                    .corner_radius(4.0),
+                );
+                let resp_btn = if can_act {
+                    resp_btn.on_hover_cursor(egui::CursorIcon::PointingHand)
+                } else {
+                    resp_btn.on_hover_text("Administrator privileges are required for network isolation.")
+                };
+                if resp_btn.clicked() {
+                    action = Some(if self.response_status.isolated {
+                        inspector::Action::RestoreNetwork
+                    } else {
+                        inspector::Action::IsolateMachine
+                    });
+                }
+            });
+        });
+        action
+    }
 }
 
 impl eframe::App for VigilApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        let ctx=ui.ctx().clone(); self.refresh_active_response_state(); if self.show_window.swap(false, Ordering::Relaxed) { ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true)); ctx.send_viewport_cmd(egui::ViewportCommand::Focus); }
-        if let Some(nav)=self.pending_nav.lock().unwrap().take() { ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true)); ctx.send_viewport_cmd(egui::ViewportCommand::Focus); self.active_tab=Tab::Alerts; self.kill_confirm=false; self.unseen_alerts=0; let _=self.tray_tx.try_send(TrayCmd::ResetOk); self.selected_alert=process_list::selection_for_pid(&self.alerts, nav.pid, self.alerts.iter().find(|a| a.timestamp == nav.timestamp && a.proc_name == nav.proc_name && a.remote_addr == nav.remote_addr), process_list::Kind::Alerts); }
-        if ctx.input(|i| i.viewport().close_requested()) && !self.exit_requested { ctx.send_viewport_cmd(egui::ViewportCommand::Visible(false)); ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose); }
-        let handled_events=self.drain_events(); if handled_events { ctx.request_repaint(); }
-        if self.active_tab == Tab::Alerts && self.unseen_alerts > 0 { self.unseen_alerts=0; let _=self.tray_tx.try_send(TrayCmd::ResetOk); }
-        let header_action=egui::Panel::top("header").exact_size(48.0).frame(egui::Frame::NONE.fill(theme::SURFACE)).show_inside(ui, |ui| self.show_header(ui)); if let Some(action)=header_action.inner { self.handle_inspector_action(action, &ctx); }
-        let new_tab=egui::Panel::top("tabs").exact_size(36.0).frame(egui::Frame::NONE.fill(theme::SURFACE)).show_inside(ui, |ui| tab_bar::tab_bar(ui, self.active_tab, process_count(&self.activity), process_count(&self.alerts))).inner; if new_tab != self.active_tab { self.active_tab=new_tab; self.kill_confirm=false; }
-        let mut inspector_action: Option<inspector::Action>=None; if matches!(self.active_tab, Tab::Activity | Tab::Alerts) { let selected_info: Option<&ProcessSelection>=match self.active_tab { Tab::Activity => self.selected_activity.as_ref(), Tab::Alerts => self.selected_alert.as_ref(), _ => None }; let kill_confirm=self.kill_confirm; inspector_action=egui::Panel::right("inspector").exact_size(320.0).resizable(false).frame(egui::Frame::NONE.fill(theme::SURFACE).stroke(egui::Stroke::new(1.0, theme::BORDER)).inner_margin(egui::Margin::symmetric(12, 0))).show_inside(ui, |ui| inspector::show(ui, selected_info, kill_confirm)).inner; }
-        if let Some(action)=inspector_action { self.handle_inspector_action(action, &ctx); }
-        if let Some(message)=self.response_message.as_ref() { if message.1.elapsed().as_secs() < 4 { egui::Panel::top("active_response_message").exact_size(28.0).frame(egui::Frame::NONE.fill(theme::BG)).show_inside(ui, |ui| { ui.horizontal(|ui| { ui.label(egui::RichText::new(&message.0).color(theme::DANGER).size(10.8).strong()); }); }); } else { self.response_message=None; } }
-        if let Some(message)=self.admin_message.as_ref() { if message.1.elapsed().as_secs() < 4 { egui::Panel::top("admin_message").exact_size(28.0).frame(egui::Frame::NONE.fill(theme::BG)).show_inside(ui, |ui| { ui.horizontal(|ui| { ui.label(egui::RichText::new(&message.0).color(theme::ACCENT).size(10.8).strong()); }); }); } else { self.admin_message=None; } }
+        let ctx = ui.ctx().clone();
+        self.refresh_active_response_state();
+        if self.show_window.swap(false, Ordering::Relaxed) {
+            ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
+            ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
+        }
+        if let Some(nav) = self.pending_nav.lock().unwrap().take() {
+            ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
+            ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
+            self.active_tab = Tab::Alerts;
+            self.kill_confirm = false;
+            self.unseen_alerts = 0;
+            let _ = self.tray_tx.try_send(TrayCmd::ResetOk);
+            self.selected_alert = process_list::selection_for_pid(
+                &self.alerts,
+                nav.pid,
+                self.alerts.iter().find(|a| {
+                    a.timestamp == nav.timestamp
+                        && a.proc_name == nav.proc_name
+                        && a.remote_addr == nav.remote_addr
+                }),
+                process_list::Kind::Alerts,
+            );
+        }
+        if ctx.input(|i| i.viewport().close_requested()) && !self.exit_requested {
+            ctx.send_viewport_cmd(egui::ViewportCommand::Visible(false));
+            ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose);
+        }
+        let handled_events = self.drain_events();
+        if handled_events {
+            ctx.request_repaint();
+        }
+        if self.active_tab == Tab::Alerts && self.unseen_alerts > 0 {
+            self.unseen_alerts = 0;
+            let _ = self.tray_tx.try_send(TrayCmd::ResetOk);
+        }
+        let header_action = egui::Panel::top("header")
+            .exact_size(48.0)
+            .frame(egui::Frame::NONE.fill(theme::SURFACE))
+            .show_inside(ui, |ui| self.show_header(ui));
+        if let Some(action) = header_action.inner {
+            self.handle_inspector_action(action, &ctx);
+        }
+        let new_tab = egui::Panel::top("tabs")
+            .exact_size(36.0)
+            .frame(egui::Frame::NONE.fill(theme::SURFACE))
+            .show_inside(ui, |ui| {
+                tab_bar::tab_bar(
+                    ui,
+                    self.active_tab,
+                    process_count(&self.activity),
+                    process_count(&self.alerts),
+                )
+            })
+            .inner;
+        if new_tab != self.active_tab {
+            self.active_tab = new_tab;
+            self.kill_confirm = false;
+        }
+        let mut inspector_action: Option<inspector::Action> = None;
+        if matches!(self.active_tab, Tab::Activity | Tab::Alerts) {
+            let selected_info: Option<&ProcessSelection> = match self.active_tab {
+                Tab::Activity => self.selected_activity.as_ref(),
+                Tab::Alerts => self.selected_alert.as_ref(),
+                _ => None,
+            };
+            let kill_confirm = self.kill_confirm;
+            inspector_action = egui::Panel::right("inspector")
+                .exact_size(320.0)
+                .resizable(false)
+                .frame(
+                    egui::Frame::NONE
+                        .fill(theme::SURFACE)
+                        .stroke(egui::Stroke::new(1.0, theme::BORDER))
+                        .inner_margin(egui::Margin::symmetric(12, 0)),
+                )
+                .show_inside(ui, |ui| inspector::show(ui, selected_info, kill_confirm))
+                .inner;
+        }
+        if let Some(action) = inspector_action {
+            self.handle_inspector_action(action, &ctx);
+        }
+        if let Some(message) = self.response_message.as_ref() {
+            if message.1.elapsed().as_secs() < 4 {
+                egui::Panel::top("active_response_message")
+                    .exact_size(28.0)
+                    .frame(egui::Frame::NONE.fill(theme::BG))
+                    .show_inside(ui, |ui| {
+                        ui.horizontal(|ui| {
+                            ui.label(
+                                egui::RichText::new(&message.0)
+                                    .color(theme::DANGER)
+                                    .size(10.8)
+                                    .strong(),
+                            );
+                        });
+                    });
+            } else {
+                self.response_message = None;
+            }
+        }
+        if let Some(message) = self.admin_message.as_ref() {
+            if message.1.elapsed().as_secs() < 4 {
+                egui::Panel::top("admin_message")
+                    .exact_size(28.0)
+                    .frame(egui::Frame::NONE.fill(theme::BG))
+                    .show_inside(ui, |ui| {
+                        ui.horizontal(|ui| {
+                            ui.label(
+                                egui::RichText::new(&message.0)
+                                    .color(theme::ACCENT)
+                                    .size(10.8)
+                                    .strong(),
+                            );
+                        });
+                    });
+            } else {
+                self.admin_message = None;
+            }
+        }
         self.show_response_confirm(ctx.clone());
-        egui::CentralPanel::default().frame(egui::Frame::NONE.fill(theme::BG).inner_margin(egui::Margin::same(12))).show_inside(ui, |ui| match self.active_tab { Tab::Activity => { if activity::show(ui, &self.activity, &mut self.selected_activity, &mut self.activity_table) { self.activity.clear(); self.selected_activity=None; } } Tab::Alerts => { if alerts::show(ui, &self.alerts, &mut self.selected_alert, &mut self.alerts_table) { self.alerts.clear(); self.selected_alert=None; self.unseen_alerts=0; let _=self.tray_tx.try_send(TrayCmd::ResetOk); } } Tab::Settings => { let changed=settings::show(ui, &mut self.settings); if changed { let mut cfg=self.cfg.write().unwrap(); self.settings.apply_to(&mut cfg); if cfg.autostart { if crate::autostart::enable() { cfg.autostart=true; } } else { crate::autostart::disable(); } cfg.save(); self.settings.status_msg=Some(("Settings auto-saved.".into(), std::time::Instant::now())); } } Tab::Help => help::show(ui) });
+        egui::CentralPanel::default()
+            .frame(
+                egui::Frame::NONE
+                    .fill(theme::BG)
+                    .inner_margin(egui::Margin::same(12)),
+            )
+            .show_inside(ui, |ui| match self.active_tab {
+                Tab::Activity => {
+                    if activity::show(
+                        ui,
+                        &self.activity,
+                        &mut self.selected_activity,
+                        &mut self.activity_table,
+                    ) {
+                        self.activity.clear();
+                        self.selected_activity = None;
+                    }
+                }
+                Tab::Alerts => {
+                    if alerts::show(
+                        ui,
+                        &self.alerts,
+                        &mut self.selected_alert,
+                        &mut self.alerts_table,
+                    ) {
+                        self.alerts.clear();
+                        self.selected_alert = None;
+                        self.unseen_alerts = 0;
+                        let _ = self.tray_tx.try_send(TrayCmd::ResetOk);
+                    }
+                }
+                Tab::Settings => {
+                    let changed = settings::show(ui, &mut self.settings);
+                    if changed {
+                        let mut cfg = self.cfg.write().unwrap();
+                        self.settings.apply_to(&mut cfg);
+                        if cfg.autostart {
+                            if crate::autostart::enable() {
+                                cfg.autostart = true;
+                            }
+                        } else {
+                            crate::autostart::disable();
+                        }
+                        cfg.save();
+                        self.settings.status_msg =
+                            Some(("Settings auto-saved.".into(), std::time::Instant::now()));
+                    }
+                }
+                Tab::Help => help::show(ui),
+            });
         ctx.request_repaint_after(std::time::Duration::from_millis(16));
     }
-    fn clear_color(&self, _visuals: &egui::Visuals) -> [f32; 4] { [0x14 as f32 / 255.0, 0x15 as f32 / 255.0, 0x1A as f32 / 255.0, 1.0] }
-    fn save(&mut self, storage: &mut dyn eframe::Storage) { let state=UiState { active_tab: self.active_tab, activity_table: self.activity_table.clone(), alerts_table: self.alerts_table.clone() }; eframe::set_value(storage, "ui", &state); }
+    fn clear_color(&self, _visuals: &egui::Visuals) -> [f32; 4] {
+        [
+            0x14 as f32 / 255.0,
+            0x15 as f32 / 255.0,
+            0x1A as f32 / 255.0,
+            1.0,
+        ]
+    }
+    fn save(&mut self, storage: &mut dyn eframe::Storage) {
+        let state = UiState {
+            active_tab: self.active_tab,
+            activity_table: self.activity_table.clone(),
+            alerts_table: self.alerts_table.clone(),
+        };
+        eframe::set_value(storage, "ui", &state);
+    }
 }
 
-fn admin_chip(ui:&mut egui::Ui){ ui.label(egui::RichText::new(" Admin ").color(theme::ACCENT).background_color(theme::ACCENT_BG).size(10.5).strong()); }
-fn admin_btn(text:&str)->egui::Button<'_>{ egui::Button::new(egui::RichText::new(text).color(theme::ACCENT).size(11.0)).fill(theme::ACCENT_BG).stroke(egui::Stroke::new(1.0, theme::ACCENT)).corner_radius(4.0) }
+fn admin_chip(ui: &mut egui::Ui) {
+    ui.label(
+        egui::RichText::new(" Admin ")
+            .color(theme::ACCENT)
+            .background_color(theme::ACCENT_BG)
+            .size(10.5)
+            .strong(),
+    );
+}
+fn admin_btn(text: &str) -> egui::Button<'_> {
+    egui::Button::new(egui::RichText::new(text).color(theme::ACCENT).size(11.0))
+        .fill(theme::ACCENT_BG)
+        .stroke(egui::Stroke::new(1.0, theme::ACCENT))
+        .corner_radius(4.0)
+}
 
 impl VigilApp {
-    fn refresh_active_response_state(&mut self) { if self.last_response_reconcile.elapsed().as_secs() >= 1 { active_response::reconcile(); self.response_status=active_response::status(); self.last_response_reconcile=std::time::Instant::now(); } if self.last_schedule_check.elapsed().as_secs() >= 30 { self.apply_scheduled_lockdown(); self.last_schedule_check=std::time::Instant::now(); } }
-    fn apply_scheduled_lockdown(&mut self) { let cfg=self.cfg.read().unwrap().clone(); if !cfg.scheduled_lockdown_enabled { self.scheduled_lockdown_active=false; return; } if !active_response::can_modify_firewall() { return; } let now=Local::now(); let minute_of_day=now.hour()*60 + now.minute(); let start=u32::from(cfg.scheduled_lockdown_start_hour.min(23))*60 + u32::from(cfg.scheduled_lockdown_start_minute.min(59)); let end=u32::from(cfg.scheduled_lockdown_end_hour.min(23))*60 + u32::from(cfg.scheduled_lockdown_end_minute.min(59)); let should_lock=if start == end { false } else if start < end { minute_of_day >= start && minute_of_day < end } else { minute_of_day >= start || minute_of_day < end }; if should_lock && !self.scheduled_lockdown_active { match active_response::isolate_machine() { Ok(msg)=>{ self.scheduled_lockdown_active=true; self.response_message=Some((format!("Scheduled lockdown: {msg}"), std::time::Instant::now())); self.response_status=active_response::status(); } Err(err)=> self.response_message=Some((format!("Scheduled lockdown failed: {err}"), std::time::Instant::now())) } } else if !should_lock && self.scheduled_lockdown_active { match active_response::restore_machine() { Ok(msg)=>{ self.scheduled_lockdown_active=false; self.response_message=Some((format!("Scheduled lockdown ended: {msg}"), std::time::Instant::now())); self.response_status=active_response::status(); } Err(err)=> self.response_message=Some((format!("Scheduled restore failed: {err}"), std::time::Instant::now())) } } }
-    fn show_response_confirm(&mut self, ctx: egui::Context) { let Some(pending)=self.response_confirm.clone() else { return; }; let (title, body, confirm_label)=match &pending { PendingResponse::BlockRemote { target, preset } => { let (duration,label)=match preset { active_response::DurationPreset::OneHour => ("1 hour","Block 1h"), active_response::DurationPreset::OneDay => ("24 hours","Block 24h"), active_response::DurationPreset::Permanent => ("an unlimited duration","Block permanent") }; ("Block remote IP", format!("Temporarily block outbound traffic to {target} for {duration}?"), label.to_string()) } PendingResponse::BlockDomain { domain } => ("Block domain", format!("Redirect {domain} to the local machine through the Windows hosts file?"), "Block domain".to_string()), PendingResponse::BlockProcess { path, preset, .. } => { let (duration,label)=match preset { active_response::DurationPreset::OneHour => ("1 hour","Block process"), active_response::DurationPreset::OneDay => ("24 hours","Block process"), active_response::DurationPreset::Permanent => ("an unlimited duration","Block process") }; ("Block process", format!("Temporarily block inbound and outbound traffic for {path} for {duration}?"), label.to_string()) } PendingResponse::SuspendProcess { pid, path, .. } => ("Suspend process", if path.is_empty() { format!("Freeze PID {pid} until you explicitly resume it?") } else { format!("Freeze PID {pid} ({path}) until you explicitly resume it?") }, "Suspend".to_string()), PendingResponse::ResumeProcess { pid, path } => ("Resume process", if path.is_empty() { format!("Resume every suspended thread in PID {pid}?") } else { format!("Resume every suspended thread in PID {pid} ({path})?") }, "Resume".to_string()), PendingResponse::FreezeAutoruns => ("Freeze autoruns", "Capture the current Run and RunOnce autorun keys as a baseline so Vigil can later remove additions and restore baseline values.".to_string(), "Freeze".to_string()), PendingResponse::RevertAutoruns => ("Revert autoruns", "Remove autorun entries added after the baseline and restore any baseline Run / RunOnce values that changed?".to_string(), "Revert".to_string()), PendingResponse::QuarantineProfile { pid, path, .. } => ("Quarantine profile", if path.is_empty() { format!("Apply the quarantine preset to PID {pid}? This isolates the network and suspends the process when possible.") } else { format!("Apply the quarantine preset to PID {pid} ({path})? This isolates the network, blocks the executable path, and suspends the process when possible.") }, "Quarantine".to_string()), PendingResponse::ClearQuarantineProfile { pid, path } => ("Clear quarantine", if path.is_empty() { format!("Undo the quarantine preset for PID {pid}? This restores the network and resumes the process when possible.") } else { format!("Undo the quarantine preset for PID {pid} ({path})? This restores the network, removes the process block, and resumes the process when possible.") }, "Clear".to_string()), PendingResponse::KillConnection(conn) => ("Kill connection", format!("Immediately terminate the live TCP connection {} -> {}?", conn.local_addr, conn.remote_addr), "Kill connection".to_string()), PendingResponse::UnblockRemote(target) => ("Remove remote block", format!("Remove the temporary firewall rule for {target}?"), "Unblock".to_string()), PendingResponse::UnblockDomain(domain) => ("Remove domain block", format!("Remove the local hosts-file block for {domain}?"), "Unblock domain".to_string()), PendingResponse::UnblockProcess { path, .. } => ("Remove process block", format!("Remove the temporary firewall rules for {path}?"), "Unblock".to_string()), PendingResponse::IsolateMachine => ("Isolate machine", "Temporarily block inbound and outbound traffic with reversible firewall rules.".to_string(), "Isolate".to_string()), PendingResponse::RestoreNetwork => ("Restore network", "Remove the temporary network-isolation firewall rules?".to_string(), "Restore".to_string()) }; egui::Window::new(title).id(egui::Id::new("active_response_confirm")).collapsible(false).resizable(false).anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0,0.0)).frame(egui::Frame::NONE.fill(theme::SURFACE2).stroke(egui::Stroke::new(1.0, theme::BORDER)).corner_radius(12.0)).show(&ctx, |ui| { ui.set_min_width(360.0); ui.label(egui::RichText::new(body).color(theme::TEXT2).size(11.5)); ui.add_space(12.0); ui.horizontal(|ui| { let confirm=ui.add(egui::Button::new(egui::RichText::new(confirm_label.as_str()).color(theme::DANGER).size(11.0)).fill(theme::DANGER_BG).stroke(egui::Stroke::new(1.0, theme::DANGER)).corner_radius(6.0)).on_hover_cursor(egui::CursorIcon::PointingHand); if confirm.clicked() { let result=self.execute_pending_response(&pending); self.response_message=Some((result, std::time::Instant::now())); self.response_status=active_response::status(); self.response_confirm=None; } if ui.add(egui::Button::new(egui::RichText::new("Cancel").color(theme::TEXT2).size(11.0)).fill(theme::SURFACE3).stroke(egui::Stroke::new(1.0, theme::BORDER)).corner_radius(6.0)).on_hover_cursor(egui::CursorIcon::PointingHand).clicked() { self.response_confirm=None; } }); }); }
-    fn execute_pending_response(&mut self, pending:&PendingResponse)->String { match pending { PendingResponse::BlockRemote { target, preset } => match active_response::block_remote(target,*preset) { Ok(msg)=>msg, Err(err)=>format!("Could not block {target}: {err}") }, PendingResponse::BlockDomain { domain } => match active_response::block_domain(domain) { Ok(msg)=>msg, Err(err)=>format!("Could not block {domain}: {err}") }, PendingResponse::BlockProcess { pid, path, preset } => match active_response::block_process(*pid,path,*preset) { Ok(msg)=>msg, Err(err)=>format!("Could not block {path}: {err}") }, PendingResponse::SuspendProcess { pid, path, proc_name } => match active_response::suspend_process(*pid,path,proc_name) { Ok(msg)=>msg, Err(err)=>format!("Could not suspend PID {pid}: {err}") }, PendingResponse::ResumeProcess { pid, path } => match active_response::resume_process(*pid,path) { Ok(msg)=>msg, Err(err)=>format!("Could not resume PID {pid}: {err}") }, PendingResponse::FreezeAutoruns => match active_response::freeze_autoruns() { Ok(msg)=>msg, Err(err)=>format!("Could not freeze autoruns: {err}") }, PendingResponse::RevertAutoruns => match active_response::revert_frozen_autoruns() { Ok(msg)=>msg, Err(err)=>format!("Could not revert autoruns: {err}") }, PendingResponse::QuarantineProfile { pid, path, proc_name } => match active_response::apply_quarantine_profile(*pid,path,proc_name) { Ok(msg)=>msg, Err(err)=>format!("Could not apply quarantine profile: {err}") }, PendingResponse::ClearQuarantineProfile { pid, path } => match active_response::clear_quarantine_profile(*pid,path) { Ok(msg)=>msg, Err(err)=>format!("Could not clear quarantine profile: {err}") }, PendingResponse::KillConnection(conn) => match active_response::kill_connection(conn) { Ok(msg)=>msg, Err(err)=>format!("Could not kill {} -> {}: {err}", conn.local_addr, conn.remote_addr) }, PendingResponse::UnblockRemote(target) => match active_response::unblock_remote(target) { Ok(msg)=>msg, Err(err)=>format!("Could not unblock {target}: {err}") }, PendingResponse::UnblockDomain(domain) => match active_response::unblock_domain(domain) { Ok(msg)=>msg, Err(err)=>format!("Could not unblock {domain}: {err}") }, PendingResponse::UnblockProcess { pid, path } => match active_response::unblock_process(*pid,path) { Ok(msg)=>msg, Err(err)=>format!("Could not unblock {path}: {err}") }, PendingResponse::IsolateMachine => match active_response::isolate_machine() { Ok(msg)=>msg, Err(err)=>format!("Could not isolate the machine: {err}") }, PendingResponse::RestoreNetwork => match active_response::restore_machine() { Ok(msg)=>msg, Err(err)=>format!("Could not restore the network: {err}") } } }
+    fn refresh_active_response_state(&mut self) {
+        if self.last_response_reconcile.elapsed().as_secs() >= 1 {
+            active_response::reconcile();
+            self.response_status = active_response::status();
+            self.last_response_reconcile = std::time::Instant::now();
+        }
+        if self.last_schedule_check.elapsed().as_secs() >= 30 {
+            self.apply_scheduled_lockdown();
+            self.last_schedule_check = std::time::Instant::now();
+        }
+    }
+    fn apply_scheduled_lockdown(&mut self) {
+        let cfg = self.cfg.read().unwrap().clone();
+        if !cfg.scheduled_lockdown_enabled {
+            self.scheduled_lockdown_active = false;
+            return;
+        }
+        if !active_response::can_modify_firewall() {
+            return;
+        }
+        let now = Local::now();
+        let minute_of_day = now.hour() * 60 + now.minute();
+        let start = u32::from(cfg.scheduled_lockdown_start_hour.min(23)) * 60
+            + u32::from(cfg.scheduled_lockdown_start_minute.min(59));
+        let end = u32::from(cfg.scheduled_lockdown_end_hour.min(23)) * 60
+            + u32::from(cfg.scheduled_lockdown_end_minute.min(59));
+        let should_lock = if start == end {
+            false
+        } else if start < end {
+            minute_of_day >= start && minute_of_day < end
+        } else {
+            minute_of_day >= start || minute_of_day < end
+        };
+        if should_lock && !self.scheduled_lockdown_active {
+            match active_response::isolate_machine() {
+                Ok(msg) => {
+                    self.scheduled_lockdown_active = true;
+                    self.response_message = Some((
+                        format!("Scheduled lockdown: {msg}"),
+                        std::time::Instant::now(),
+                    ));
+                    self.response_status = active_response::status();
+                }
+                Err(err) => {
+                    self.response_message = Some((
+                        format!("Scheduled lockdown failed: {err}"),
+                        std::time::Instant::now(),
+                    ))
+                }
+            }
+        } else if !should_lock && self.scheduled_lockdown_active {
+            match active_response::restore_machine() {
+                Ok(msg) => {
+                    self.scheduled_lockdown_active = false;
+                    self.response_message = Some((
+                        format!("Scheduled lockdown ended: {msg}"),
+                        std::time::Instant::now(),
+                    ));
+                    self.response_status = active_response::status();
+                }
+                Err(err) => {
+                    self.response_message = Some((
+                        format!("Scheduled restore failed: {err}"),
+                        std::time::Instant::now(),
+                    ))
+                }
+            }
+        }
+    }
+    fn show_response_confirm(&mut self, ctx: egui::Context) {
+        let Some(pending) = self.response_confirm.clone() else {
+            return;
+        };
+        let (title, body, confirm_label)=match &pending { PendingResponse::BlockRemote { target, preset } => { let (duration,label)=match preset { active_response::DurationPreset::OneHour => ("1 hour","Block 1h"), active_response::DurationPreset::OneDay => ("24 hours","Block 24h"), active_response::DurationPreset::Permanent => ("an unlimited duration","Block permanent") }; ("Block remote IP", format!("Temporarily block outbound traffic to {target} for {duration}?"), label.to_string()) } PendingResponse::BlockDomain { domain } => ("Block domain", format!("Redirect {domain} to the local machine through the Windows hosts file?"), "Block domain".to_string()), PendingResponse::BlockProcess { path, preset, .. } => { let (duration,label)=match preset { active_response::DurationPreset::OneHour => ("1 hour","Block process"), active_response::DurationPreset::OneDay => ("24 hours","Block process"), active_response::DurationPreset::Permanent => ("an unlimited duration","Block process") }; ("Block process", format!("Temporarily block inbound and outbound traffic for {path} for {duration}?"), label.to_string()) } PendingResponse::SuspendProcess { pid, path, .. } => ("Suspend process", if path.is_empty() { format!("Freeze PID {pid} until you explicitly resume it?") } else { format!("Freeze PID {pid} ({path}) until you explicitly resume it?") }, "Suspend".to_string()), PendingResponse::ResumeProcess { pid, path } => ("Resume process", if path.is_empty() { format!("Resume every suspended thread in PID {pid}?") } else { format!("Resume every suspended thread in PID {pid} ({path})?") }, "Resume".to_string()), PendingResponse::FreezeAutoruns => ("Freeze autoruns", "Capture the current Run and RunOnce autorun keys as a baseline so Vigil can later remove additions and restore baseline values.".to_string(), "Freeze".to_string()), PendingResponse::RevertAutoruns => ("Revert autoruns", "Remove autorun entries added after the baseline and restore any baseline Run / RunOnce values that changed?".to_string(), "Revert".to_string()), PendingResponse::QuarantineProfile { pid, path, .. } => ("Quarantine profile", if path.is_empty() { format!("Apply the quarantine preset to PID {pid}? This isolates the network and suspends the process when possible.") } else { format!("Apply the quarantine preset to PID {pid} ({path})? This isolates the network, blocks the executable path, and suspends the process when possible.") }, "Quarantine".to_string()), PendingResponse::ClearQuarantineProfile { pid, path } => ("Clear quarantine", if path.is_empty() { format!("Undo the quarantine preset for PID {pid}? This restores the network and resumes the process when possible.") } else { format!("Undo the quarantine preset for PID {pid} ({path})? This restores the network, removes the process block, and resumes the process when possible.") }, "Clear".to_string()), PendingResponse::KillConnection(conn) => ("Kill connection", format!("Immediately terminate the live TCP connection {} -> {}?", conn.local_addr, conn.remote_addr), "Kill connection".to_string()), PendingResponse::UnblockRemote(target) => ("Remove remote block", format!("Remove the temporary firewall rule for {target}?"), "Unblock".to_string()), PendingResponse::UnblockDomain(domain) => ("Remove domain block", format!("Remove the local hosts-file block for {domain}?"), "Unblock domain".to_string()), PendingResponse::UnblockProcess { path, .. } => ("Remove process block", format!("Remove the temporary firewall rules for {path}?"), "Unblock".to_string()), PendingResponse::IsolateMachine => ("Isolate machine", "Temporarily block inbound and outbound traffic with reversible firewall rules.".to_string(), "Isolate".to_string()), PendingResponse::RestoreNetwork => ("Restore network", "Remove the temporary network-isolation firewall rules?".to_string(), "Restore".to_string()) };
+        egui::Window::new(title)
+            .id(egui::Id::new("active_response_confirm"))
+            .collapsible(false)
+            .resizable(false)
+            .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
+            .frame(
+                egui::Frame::NONE
+                    .fill(theme::SURFACE2)
+                    .stroke(egui::Stroke::new(1.0, theme::BORDER))
+                    .corner_radius(12.0),
+            )
+            .show(&ctx, |ui| {
+                ui.set_min_width(360.0);
+                ui.label(egui::RichText::new(body).color(theme::TEXT2).size(11.5));
+                ui.add_space(12.0);
+                ui.horizontal(|ui| {
+                    let confirm = ui
+                        .add(
+                            egui::Button::new(
+                                egui::RichText::new(confirm_label.as_str())
+                                    .color(theme::DANGER)
+                                    .size(11.0),
+                            )
+                            .fill(theme::DANGER_BG)
+                            .stroke(egui::Stroke::new(1.0, theme::DANGER))
+                            .corner_radius(6.0),
+                        )
+                        .on_hover_cursor(egui::CursorIcon::PointingHand);
+                    if confirm.clicked() {
+                        let result = self.execute_pending_response(&pending);
+                        self.response_message = Some((result, std::time::Instant::now()));
+                        self.response_status = active_response::status();
+                        self.response_confirm = None;
+                    }
+                    if ui
+                        .add(
+                            egui::Button::new(
+                                egui::RichText::new("Cancel").color(theme::TEXT2).size(11.0),
+                            )
+                            .fill(theme::SURFACE3)
+                            .stroke(egui::Stroke::new(1.0, theme::BORDER))
+                            .corner_radius(6.0),
+                        )
+                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                        .clicked()
+                    {
+                        self.response_confirm = None;
+                    }
+                });
+            });
+    }
+    fn execute_pending_response(&mut self, pending: &PendingResponse) -> String {
+        match pending {
+            PendingResponse::BlockRemote { target, preset } => {
+                match active_response::block_remote(target, *preset) {
+                    Ok(msg) => msg,
+                    Err(err) => format!("Could not block {target}: {err}"),
+                }
+            }
+            PendingResponse::BlockDomain { domain } => {
+                match active_response::block_domain(domain) {
+                    Ok(msg) => msg,
+                    Err(err) => format!("Could not block {domain}: {err}"),
+                }
+            }
+            PendingResponse::BlockProcess { pid, path, preset } => {
+                match active_response::block_process(*pid, path, *preset) {
+                    Ok(msg) => msg,
+                    Err(err) => format!("Could not block {path}: {err}"),
+                }
+            }
+            PendingResponse::SuspendProcess {
+                pid,
+                path,
+                proc_name,
+            } => match active_response::suspend_process(*pid, path, proc_name) {
+                Ok(msg) => msg,
+                Err(err) => format!("Could not suspend PID {pid}: {err}"),
+            },
+            PendingResponse::ResumeProcess { pid, path } => {
+                match active_response::resume_process(*pid, path) {
+                    Ok(msg) => msg,
+                    Err(err) => format!("Could not resume PID {pid}: {err}"),
+                }
+            }
+            PendingResponse::FreezeAutoruns => match active_response::freeze_autoruns() {
+                Ok(msg) => msg,
+                Err(err) => format!("Could not freeze autoruns: {err}"),
+            },
+            PendingResponse::RevertAutoruns => match active_response::revert_frozen_autoruns() {
+                Ok(msg) => msg,
+                Err(err) => format!("Could not revert autoruns: {err}"),
+            },
+            PendingResponse::QuarantineProfile {
+                pid,
+                path,
+                proc_name,
+            } => match active_response::apply_quarantine_profile(*pid, path, proc_name) {
+                Ok(msg) => msg,
+                Err(err) => format!("Could not apply quarantine profile: {err}"),
+            },
+            PendingResponse::ClearQuarantineProfile { pid, path } => {
+                match active_response::clear_quarantine_profile(*pid, path) {
+                    Ok(msg) => msg,
+                    Err(err) => format!("Could not clear quarantine profile: {err}"),
+                }
+            }
+            PendingResponse::KillConnection(conn) => {
+                match active_response::kill_connection(conn.as_ref()) {
+                    Ok(msg) => msg,
+                    Err(err) => format!(
+                        "Could not kill {} -> {}: {err}",
+                        conn.local_addr, conn.remote_addr
+                    ),
+                }
+            }
+            PendingResponse::UnblockRemote(target) => match active_response::unblock_remote(target)
+            {
+                Ok(msg) => msg,
+                Err(err) => format!("Could not unblock {target}: {err}"),
+            },
+            PendingResponse::UnblockDomain(domain) => match active_response::unblock_domain(domain)
+            {
+                Ok(msg) => msg,
+                Err(err) => format!("Could not unblock {domain}: {err}"),
+            },
+            PendingResponse::UnblockProcess { pid, path } => {
+                match active_response::unblock_process(*pid, path) {
+                    Ok(msg) => msg,
+                    Err(err) => format!("Could not unblock {path}: {err}"),
+                }
+            }
+            PendingResponse::IsolateMachine => match active_response::isolate_machine() {
+                Ok(msg) => msg,
+                Err(err) => format!("Could not isolate the machine: {err}"),
+            },
+            PendingResponse::RestoreNetwork => match active_response::restore_machine() {
+                Ok(msg) => msg,
+                Err(err) => format!("Could not restore the network: {err}"),
+            },
+        }
+    }
 }
 
-fn push_capped<T>(deque:&mut VecDeque<T>, item:T, cap:usize){ deque.push_front(item); if deque.len() > cap { deque.pop_back(); } }
-pub fn conn_matches_selection(info:&ConnInfo, selected:Option<&ConnInfo>)->bool { selected.is_some_and(|sel| info.timestamp == sel.timestamp && info.pid == sel.pid && info.proc_name == sel.proc_name && info.local_addr == sel.local_addr && info.remote_addr == sel.remote_addr) }
-fn remove_pid(rows:&mut VecDeque<ConnInfo>, pid:u32){ rows.retain(|info| info.pid != pid); }
-fn process_count(rows:&VecDeque<ConnInfo>)->usize{ use std::collections::HashSet; rows.iter().map(|info| info.pid).collect::<HashSet<_>>().len() }
-fn kill_process(pid:u32){ use sysinfo::{Pid, ProcessesToUpdate, System}; let target=Pid::from_u32(pid); let mut sys=System::new(); sys.refresh_processes(ProcessesToUpdate::Some(&[target]), false); if let Some(proc)=sys.process(target){ proc.kill(); } }
+fn push_capped<T>(deque: &mut VecDeque<T>, item: T, cap: usize) {
+    deque.push_front(item);
+    if deque.len() > cap {
+        deque.pop_back();
+    }
+}
+pub fn conn_matches_selection(info: &ConnInfo, selected: Option<&ConnInfo>) -> bool {
+    selected.is_some_and(|sel| {
+        info.timestamp == sel.timestamp
+            && info.pid == sel.pid
+            && info.proc_name == sel.proc_name
+            && info.local_addr == sel.local_addr
+            && info.remote_addr == sel.remote_addr
+    })
+}
+fn remove_pid(rows: &mut VecDeque<ConnInfo>, pid: u32) {
+    rows.retain(|info| info.pid != pid);
+}
+fn process_count(rows: &VecDeque<ConnInfo>) -> usize {
+    use std::collections::HashSet;
+    rows.iter()
+        .map(|info| info.pid)
+        .collect::<HashSet<_>>()
+        .len()
+}
+fn kill_process(pid: u32) {
+    use sysinfo::{Pid, ProcessesToUpdate, System};
+    let target = Pid::from_u32(pid);
+    let mut sys = System::new();
+    sys.refresh_processes(ProcessesToUpdate::Some(&[target]), false);
+    if let Some(proc) = sys.process(target) {
+        proc.kill();
+    }
+}

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -51,7 +51,6 @@ pub struct SettingsDraft {
     pub honeypot_auto_isolate: bool,
     pub honeypot_poll_secs: u64,
     pub honeypot_decoy_names_text: String,
-    pub break_glass_enabled: bool,
     pub break_glass_timeout_mins: u64,
     pub break_glass_heartbeat_secs: u64,
     pub status_msg: Option<(String, std::time::Instant)>,
@@ -100,7 +99,6 @@ impl SettingsDraft {
             honeypot_auto_isolate: cfg.honeypot_auto_isolate,
             honeypot_poll_secs: cfg.honeypot_poll_secs,
             honeypot_decoy_names_text: cfg.honeypot_decoy_names.join("\n"),
-            break_glass_enabled: cfg.break_glass_enabled,
             break_glass_timeout_mins: cfg.break_glass_timeout_mins,
             break_glass_heartbeat_secs: cfg.break_glass_heartbeat_secs,
             status_msg: None,
@@ -146,7 +144,7 @@ impl SettingsDraft {
         cfg.honeypot_auto_isolate = self.honeypot_auto_isolate;
         cfg.honeypot_poll_secs = self.honeypot_poll_secs.clamp(5, 300);
         cfg.honeypot_decoy_names = split_lines(&self.honeypot_decoy_names_text);
-        cfg.break_glass_enabled = self.break_glass_enabled;
+        cfg.break_glass_enabled = true;
         cfg.break_glass_timeout_mins = self.break_glass_timeout_mins.clamp(1, 240);
         cfg.break_glass_heartbeat_secs = self.break_glass_heartbeat_secs.clamp(5, 300);
     }
@@ -396,38 +394,46 @@ fn inner(ui: &mut egui::Ui, draft: &mut SettingsDraft, changed: &mut bool) {
 
     ui.add_space(16.0);
     section_header(ui, "Break-glass recovery");
-    ui.label(RichText::new("When machine isolation is active, Vigil can arm a recovery watchdog. It keeps touching a heartbeat file while the app is alive, and a scheduled watchdog task restores the network if the heartbeat goes stale past the timeout.").color(theme::TEXT2).size(12.0));
+    ui.label(RichText::new("When machine isolation is active, Vigil always arms a recovery watchdog. It keeps touching a heartbeat file while the app is alive, and a scheduled watchdog task restores the network if the heartbeat goes stale past the timeout.").color(theme::TEXT2).size(12.0));
     ui.add_space(8.0);
-    setting_row(ui, label_w, "Enable break-glass", |ui| {
-        *changed |= ui
-            .checkbox(
-                &mut draft.break_glass_enabled,
-                RichText::new("automatically recover from a stale isolation lockout")
-                    .color(theme::TEXT2)
-                    .size(11.5),
-            )
-            .changed();
+    setting_row(ui, label_w, "Fail-safe mode", |ui| {
+        ui.label(
+            RichText::new("always on during isolation (safety override)")
+                .color(theme::TEXT2)
+                .size(11.5),
+        );
     });
-    ui.add_enabled_ui(draft.break_glass_enabled, |ui| {
-        setting_row(ui, label_w, "Recovery timeout", |ui| {
-            ui.horizontal(|ui| {
-                let resp = ui.add(egui::Slider::new(&mut draft.break_glass_timeout_mins, 1_u64..=240_u64).suffix(" min").clamping(egui::SliderClamping::Always));
-                *changed |= resp.changed();
-                ui.label(RichText::new("  restores networking after this timeout if the heartbeat is stale").color(theme::TEXT3).size(11.0));
-            });
+    setting_row(ui, label_w, "Recovery timeout", |ui| {
+        ui.horizontal(|ui| {
+            let resp = ui.add(
+                egui::Slider::new(&mut draft.break_glass_timeout_mins, 1_u64..=240_u64)
+                    .suffix(" min")
+                    .clamping(egui::SliderClamping::Always),
+            );
+            *changed |= resp.changed();
+            ui.label(
+                RichText::new("  restores networking after this timeout if the heartbeat is stale")
+                    .color(theme::TEXT3)
+                    .size(11.0),
+            );
         });
-        setting_row(ui, label_w, "Heartbeat interval", |ui| {
-            ui.horizontal(|ui| {
-                let resp = ui.add(egui::Slider::new(&mut draft.break_glass_heartbeat_secs, 5_u64..=300_u64).suffix(" s").clamping(egui::SliderClamping::Always));
-                *changed |= resp.changed();
-                ui.label(RichText::new("  Vigil refreshes the heartbeat at this cadence while running").color(theme::TEXT3).size(11.0));
-            });
-        });
-        ui.label(RichText::new("Current implementation is Windows-only and uses a scheduled task that runs the same Vigil binary with --break-glass-recover.").color(theme::TEXT3).size(10.8));
     });
-    if !draft.break_glass_enabled {
-        ui.label(RichText::new("Break-glass recovery is disabled, so an operator must manually restore networking after a crash during isolation.").color(theme::TEXT3).size(10.8));
-    }
+    setting_row(ui, label_w, "Heartbeat interval", |ui| {
+        ui.horizontal(|ui| {
+            let resp = ui.add(
+                egui::Slider::new(&mut draft.break_glass_heartbeat_secs, 5_u64..=300_u64)
+                    .suffix(" s")
+                    .clamping(egui::SliderClamping::Always),
+            );
+            *changed |= resp.changed();
+            ui.label(
+                RichText::new("  Vigil refreshes the heartbeat at this cadence while running")
+                    .color(theme::TEXT3)
+                    .size(11.0),
+            );
+        });
+    });
+    ui.label(RichText::new("Watchdog implementation uses the local OS scheduler (Windows Task Scheduler, Linux cron, macOS launchd) and runs the same Vigil binary with --break-glass-recover.").color(theme::TEXT3).size(10.8));
 
     ui.add_space(16.0);
     section_header(ui, "Forensics on alert");

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -156,7 +156,11 @@ fn split_lines(text: &str) -> Vec<String> {
     let mut out = Vec::new();
     for line in text.lines() {
         let trimmed = line.trim();
-        if !trimmed.is_empty() && !out.iter().any(|item: &String| item.eq_ignore_ascii_case(trimmed)) {
+        if !trimmed.is_empty()
+            && !out
+                .iter()
+                .any(|item: &String| item.eq_ignore_ascii_case(trimmed))
+        {
             out.push(trimmed.to_string());
         }
     }
@@ -165,16 +169,18 @@ fn split_lines(text: &str) -> Vec<String> {
 
 pub fn show(ui: &mut egui::Ui, draft: &mut SettingsDraft) -> bool {
     let mut changed = false;
-    egui::ScrollArea::vertical().id_salt("settings_scroll").show(ui, |ui| {
-        ui.add_space(16.0);
-        ui.vertical(|ui| {
-            let content_w = ui.available_width();
-            ui.set_max_width(content_w);
-            ui.set_width(content_w);
-            inner(ui, draft, &mut changed);
+    egui::ScrollArea::vertical()
+        .id_salt("settings_scroll")
+        .show(ui, |ui| {
+            ui.add_space(16.0);
+            ui.vertical(|ui| {
+                let content_w = ui.available_width();
+                ui.set_max_width(content_w);
+                ui.set_width(content_w);
+                inner(ui, draft, &mut changed);
+            });
+            ui.add_space(18.0);
         });
-        ui.add_space(18.0);
-    });
     changed
 }
 
@@ -184,20 +190,42 @@ fn inner(ui: &mut egui::Ui, draft: &mut SettingsDraft, changed: &mut bool) {
     section_header(ui, "Detection");
     setting_row(ui, label_w, "Alert threshold", |ui| {
         ui.horizontal(|ui| {
-            let resp = ui.add(egui::Slider::new(&mut draft.alert_threshold, 1_u8..=10_u8).clamping(egui::SliderClamping::Always));
+            let resp = ui.add(
+                egui::Slider::new(&mut draft.alert_threshold, 1_u8..=10_u8)
+                    .clamping(egui::SliderClamping::Always),
+            );
             *changed |= resp.changed();
-            ui.label(RichText::new(format!("  score >= {} => alert", draft.alert_threshold)).color(theme::TEXT3).size(11.0));
+            ui.label(
+                RichText::new(format!("  score >= {} => alert", draft.alert_threshold))
+                    .color(theme::TEXT3)
+                    .size(11.0),
+            );
         });
     });
     setting_row(ui, label_w, "Poll interval", |ui| {
         ui.horizontal(|ui| {
-            let resp = ui.add(egui::Slider::new(&mut draft.poll_interval_secs, 2_u64..=60_u64).suffix(" s").clamping(egui::SliderClamping::Always));
+            let resp = ui.add(
+                egui::Slider::new(&mut draft.poll_interval_secs, 2_u64..=60_u64)
+                    .suffix(" s")
+                    .clamping(egui::SliderClamping::Always),
+            );
             *changed |= resp.changed();
-            ui.label(RichText::new("  (ETW uses longer interval)").color(theme::TEXT3).size(11.0));
+            ui.label(
+                RichText::new("  (ETW uses longer interval)")
+                    .color(theme::TEXT3)
+                    .size(11.0),
+            );
         });
     });
     setting_row(ui, label_w, "Log all connections", |ui| {
-        *changed |= ui.checkbox(&mut draft.log_all_connections, RichText::new("include score-0 connections in the log and activity table").color(theme::TEXT2).size(11.5)).changed();
+        *changed |= ui
+            .checkbox(
+                &mut draft.log_all_connections,
+                RichText::new("include score-0 connections in the log and activity table")
+                    .color(theme::TEXT2)
+                    .size(11.5),
+            )
+            .changed();
     });
 
     ui.add_space(16.0);
@@ -205,10 +233,24 @@ fn inner(ui: &mut egui::Ui, draft: &mut SettingsDraft, changed: &mut bool) {
     ui.label(RichText::new("Optional and disabled by default. Vigil only auto-acts when this is enabled, the selected action type is enabled, the process is not trusted, and strong corroborating signals are present.").color(theme::TEXT2).size(12.0));
     ui.add_space(8.0);
     setting_row(ui, label_w, "Enable auto response", |ui| {
-        *changed |= ui.checkbox(&mut draft.auto_response_enabled, RichText::new("allow Vigil to take automated containment actions").color(theme::TEXT2).size(11.5)).changed();
+        *changed |= ui
+            .checkbox(
+                &mut draft.auto_response_enabled,
+                RichText::new("allow Vigil to take automated containment actions")
+                    .color(theme::TEXT2)
+                    .size(11.5),
+            )
+            .changed();
     });
     setting_row(ui, label_w, "Dry run", |ui| {
-        *changed |= ui.checkbox(&mut draft.auto_response_dry_run, RichText::new("log and surface planned actions without executing them").color(theme::TEXT2).size(11.5)).changed();
+        *changed |= ui
+            .checkbox(
+                &mut draft.auto_response_dry_run,
+                RichText::new("log and surface planned actions without executing them")
+                    .color(theme::TEXT2)
+                    .size(11.5),
+            )
+            .changed();
     });
     ui.add_enabled_ui(draft.auto_response_enabled, |ui| {
         setting_row(ui, label_w, "Minimum score", |ui| {
@@ -247,13 +289,32 @@ fn inner(ui: &mut egui::Ui, draft: &mut SettingsDraft, changed: &mut bool) {
     ui.label(RichText::new("Optional restrictive policy. When enabled, Vigil treats traffic from processes outside the trusted list, the custom allowlist, and Microsoft-signed system processes as containment candidates.").color(theme::TEXT2).size(12.0));
     ui.add_space(8.0);
     setting_row(ui, label_w, "Enable allowlist mode", |ui| {
-        *changed |= ui.checkbox(&mut draft.allowlist_mode_enabled, RichText::new("enforce network allowlisting for processes").color(theme::TEXT2).size(11.5)).changed();
+        *changed |= ui
+            .checkbox(
+                &mut draft.allowlist_mode_enabled,
+                RichText::new("enforce network allowlisting for processes")
+                    .color(theme::TEXT2)
+                    .size(11.5),
+            )
+            .changed();
     });
     setting_row(ui, label_w, "Allowlist dry run", |ui| {
-        *changed |= ui.checkbox(&mut draft.allowlist_mode_dry_run, RichText::new("log planned allowlist containment without executing it").color(theme::TEXT2).size(11.5)).changed();
+        *changed |= ui
+            .checkbox(
+                &mut draft.allowlist_mode_dry_run,
+                RichText::new("log planned allowlist containment without executing it")
+                    .color(theme::TEXT2)
+                    .size(11.5),
+            )
+            .changed();
     });
     setting_row(ui, label_w, "Allowed processes", |ui| {
-        let resp = ui.add(egui::TextEdit::multiline(&mut draft.allowlist_processes_text).hint_text("one process name or full executable path per line").desired_width(420.0).desired_rows(5));
+        let resp = ui.add(
+            egui::TextEdit::multiline(&mut draft.allowlist_processes_text)
+                .hint_text("one process name or full executable path per line")
+                .desired_width(420.0)
+                .desired_rows(5),
+        );
         *changed |= resp.changed();
     });
     ui.label(RichText::new("Trusted processes are always treated as allowed. One entry per line; names are matched case-insensitively and .exe is ignored.").color(theme::TEXT3).size(10.8));
@@ -263,13 +324,31 @@ fn inner(ui: &mut egui::Ui, draft: &mut SettingsDraft, changed: &mut bool) {
     ui.label(RichText::new("Optional YAML rule engine. Rules are evaluated in order, first match wins, and can dry-run or execute the same containment actions used elsewhere in Vigil.").color(theme::TEXT2).size(12.0));
     ui.add_space(8.0);
     setting_row(ui, label_w, "Enable rules", |ui| {
-        *changed |= ui.checkbox(&mut draft.response_rules_enabled, RichText::new("load and evaluate a YAML response-rules file").color(theme::TEXT2).size(11.5)).changed();
+        *changed |= ui
+            .checkbox(
+                &mut draft.response_rules_enabled,
+                RichText::new("load and evaluate a YAML response-rules file")
+                    .color(theme::TEXT2)
+                    .size(11.5),
+            )
+            .changed();
     });
     setting_row(ui, label_w, "Rules dry run", |ui| {
-        *changed |= ui.checkbox(&mut draft.response_rules_dry_run, RichText::new("log matching rules without executing their actions").color(theme::TEXT2).size(11.5)).changed();
+        *changed |= ui
+            .checkbox(
+                &mut draft.response_rules_dry_run,
+                RichText::new("log matching rules without executing their actions")
+                    .color(theme::TEXT2)
+                    .size(11.5),
+            )
+            .changed();
     });
     setting_row(ui, label_w, "Rules file", |ui| {
-        let resp = ui.add(egui::TextEdit::singleline(&mut draft.response_rules_path).hint_text("path to response-rules.yaml").desired_width(420.0));
+        let resp = ui.add(
+            egui::TextEdit::singleline(&mut draft.response_rules_path)
+                .hint_text("path to response-rules.yaml")
+                .desired_width(420.0),
+        );
         *changed |= resp.changed();
     });
     ui.label(RichText::new("Supported rule actions currently include kill_connection, block_remote, block_process, and quarantine.").color(theme::TEXT3).size(10.8));
@@ -279,7 +358,14 @@ fn inner(ui: &mut egui::Ui, draft: &mut SettingsDraft, changed: &mut bool) {
     ui.label(RichText::new("Optionally isolate the machine automatically during a fixed time window. This reuses the same reversible firewall rules as the panic button and is currently implemented on Windows.").color(theme::TEXT2).size(12.0));
     ui.add_space(8.0);
     setting_row(ui, label_w, "Enable schedule", |ui| {
-        *changed |= ui.checkbox(&mut draft.scheduled_lockdown_enabled, RichText::new("automatically isolate the network during the selected hours").color(theme::TEXT2).size(11.5)).changed();
+        *changed |= ui
+            .checkbox(
+                &mut draft.scheduled_lockdown_enabled,
+                RichText::new("automatically isolate the network during the selected hours")
+                    .color(theme::TEXT2)
+                    .size(11.5),
+            )
+            .changed();
     });
     ui.add_enabled_ui(draft.scheduled_lockdown_enabled, |ui| {
         setting_row(ui, label_w, "Start time", |ui| {
@@ -301,7 +387,11 @@ fn inner(ui: &mut egui::Ui, draft: &mut SettingsDraft, changed: &mut bool) {
         ui.label(RichText::new("Overnight windows are supported. Example: 23:00 to 06:00 isolates overnight and restores in the morning.").color(theme::TEXT3).size(10.8));
     });
     if !draft.scheduled_lockdown_enabled {
-        ui.label(RichText::new("Scheduled lockdown is currently disabled.").color(theme::TEXT3).size(10.8));
+        ui.label(
+            RichText::new("Scheduled lockdown is currently disabled.")
+                .color(theme::TEXT3)
+                .size(10.8),
+        );
     }
 
     ui.add_space(16.0);
@@ -309,7 +399,14 @@ fn inner(ui: &mut egui::Ui, draft: &mut SettingsDraft, changed: &mut bool) {
     ui.label(RichText::new("When machine isolation is active, Vigil can arm a recovery watchdog. It keeps touching a heartbeat file while the app is alive, and a scheduled watchdog task restores the network if the heartbeat goes stale past the timeout.").color(theme::TEXT2).size(12.0));
     ui.add_space(8.0);
     setting_row(ui, label_w, "Enable break-glass", |ui| {
-        *changed |= ui.checkbox(&mut draft.break_glass_enabled, RichText::new("automatically recover from a stale isolation lockout").color(theme::TEXT2).size(11.5)).changed();
+        *changed |= ui
+            .checkbox(
+                &mut draft.break_glass_enabled,
+                RichText::new("automatically recover from a stale isolation lockout")
+                    .color(theme::TEXT2)
+                    .size(11.5),
+            )
+            .changed();
     });
     ui.add_enabled_ui(draft.break_glass_enabled, |ui| {
         setting_row(ui, label_w, "Recovery timeout", |ui| {
@@ -337,7 +434,14 @@ fn inner(ui: &mut egui::Ui, draft: &mut SettingsDraft, changed: &mut bool) {
     ui.label(RichText::new("Optional forensic capture for high-confidence alerts. Current implementation is Windows-only and can write process memory dumps and short packet captures when enabled.").color(theme::TEXT2).size(12.0));
     ui.add_space(8.0);
     setting_row(ui, label_w, "Enable process dump", |ui| {
-        *changed |= ui.checkbox(&mut draft.process_dump_on_alert, RichText::new("capture a process memory dump on sufficiently high-score alerts").color(theme::TEXT2).size(11.5)).changed();
+        *changed |= ui
+            .checkbox(
+                &mut draft.process_dump_on_alert,
+                RichText::new("capture a process memory dump on sufficiently high-score alerts")
+                    .color(theme::TEXT2)
+                    .size(11.5),
+            )
+            .changed();
     });
     ui.add_enabled_ui(draft.process_dump_on_alert, |ui| {
         setting_row(ui, label_w, "Dump minimum score", |ui| {
@@ -361,12 +465,23 @@ fn inner(ui: &mut egui::Ui, draft: &mut SettingsDraft, changed: &mut bool) {
         ui.label(RichText::new("Windows implementation uses the built-in comsvcs MiniDump helper. Empty dump directory uses Vigil's per-user data folder.").color(theme::TEXT3).size(10.8));
     });
     if !draft.process_dump_on_alert {
-        ui.label(RichText::new("Process dump on alert is currently disabled.").color(theme::TEXT3).size(10.8));
+        ui.label(
+            RichText::new("Process dump on alert is currently disabled.")
+                .color(theme::TEXT3)
+                .size(10.8),
+        );
     }
 
     ui.add_space(8.0);
     setting_row(ui, label_w, "Enable PCAP capture", |ui| {
-        *changed |= ui.checkbox(&mut draft.pcap_on_alert, RichText::new("capture a short packet window on sufficiently high-score alerts").color(theme::TEXT2).size(11.5)).changed();
+        *changed |= ui
+            .checkbox(
+                &mut draft.pcap_on_alert,
+                RichText::new("capture a short packet window on sufficiently high-score alerts")
+                    .color(theme::TEXT2)
+                    .size(11.5),
+            )
+            .changed();
     });
     ui.add_enabled_ui(draft.pcap_on_alert, |ui| {
         setting_row(ui, label_w, "PCAP minimum score", |ui| {
@@ -404,7 +519,11 @@ fn inner(ui: &mut egui::Ui, draft: &mut SettingsDraft, changed: &mut bool) {
         ui.label(RichText::new("Windows implementation uses pktmon and converts the ETL trace to pcapng. Only one packet capture runs at a time.").color(theme::TEXT3).size(10.8));
     });
     if !draft.pcap_on_alert {
-        ui.label(RichText::new("PCAP capture on alert is currently disabled.").color(theme::TEXT3).size(10.8));
+        ui.label(
+            RichText::new("PCAP capture on alert is currently disabled.")
+                .color(theme::TEXT3)
+                .size(10.8),
+        );
     }
 
     ui.add_space(16.0);
@@ -412,31 +531,75 @@ fn inner(ui: &mut egui::Ui, draft: &mut SettingsDraft, changed: &mut bool) {
     ui.label(RichText::new("Optional canary documents. Vigil plants decoy files in common user folders, watches for touches, raises a synthetic alert, and can optionally isolate the machine.").color(theme::TEXT2).size(12.0));
     ui.add_space(8.0);
     setting_row(ui, label_w, "Enable decoys", |ui| {
-        *changed |= ui.checkbox(&mut draft.honeypot_decoys_enabled, RichText::new("create and monitor honeypot decoy files").color(theme::TEXT2).size(11.5)).changed();
+        *changed |= ui
+            .checkbox(
+                &mut draft.honeypot_decoys_enabled,
+                RichText::new("create and monitor honeypot decoy files")
+                    .color(theme::TEXT2)
+                    .size(11.5),
+            )
+            .changed();
     });
     setting_row(ui, label_w, "Auto isolate on touch", |ui| {
-        *changed |= ui.checkbox(&mut draft.honeypot_auto_isolate, RichText::new("automatically isolate the machine when a decoy is touched").color(theme::TEXT2).size(11.5)).changed();
+        *changed |= ui
+            .checkbox(
+                &mut draft.honeypot_auto_isolate,
+                RichText::new("automatically isolate the machine when a decoy is touched")
+                    .color(theme::TEXT2)
+                    .size(11.5),
+            )
+            .changed();
     });
     setting_row(ui, label_w, "Poll interval", |ui| {
         ui.horizontal(|ui| {
-            let resp = ui.add(egui::Slider::new(&mut draft.honeypot_poll_secs, 5_u64..=300_u64).suffix(" s").clamping(egui::SliderClamping::Always));
+            let resp = ui.add(
+                egui::Slider::new(&mut draft.honeypot_poll_secs, 5_u64..=300_u64)
+                    .suffix(" s")
+                    .clamping(egui::SliderClamping::Always),
+            );
             *changed |= resp.changed();
-            ui.label(RichText::new("  how often Vigil checks decoy timestamps").color(theme::TEXT3).size(11.0));
+            ui.label(
+                RichText::new("  how often Vigil checks decoy timestamps")
+                    .color(theme::TEXT3)
+                    .size(11.0),
+            );
         });
     });
     setting_row(ui, label_w, "Decoy names", |ui| {
-        let resp = ui.add(egui::TextEdit::multiline(&mut draft.honeypot_decoy_names_text).hint_text("one decoy filename per line").desired_width(420.0).desired_rows(4));
+        let resp = ui.add(
+            egui::TextEdit::multiline(&mut draft.honeypot_decoy_names_text)
+                .hint_text("one decoy filename per line")
+                .desired_width(420.0)
+                .desired_rows(4),
+        );
         *changed |= resp.changed();
     });
-    ui.label(RichText::new("Desktop, Documents, Downloads, and Public Documents are used when available.").color(theme::TEXT3).size(10.8));
+    ui.label(
+        RichText::new(
+            "Desktop, Documents, Downloads, and Public Documents are used when available.",
+        )
+        .color(theme::TEXT3)
+        .size(10.8),
+    );
 
     ui.add_space(16.0);
     section_header(ui, "Startup");
     setting_row(ui, label_w, "Run at login", |ui| {
         ui.vertical(|ui| {
-            *changed |= ui.checkbox(&mut draft.autostart, RichText::new("start Vigil automatically when you log in").color(theme::TEXT2).size(11.5)).changed();
+            *changed |= ui
+                .checkbox(
+                    &mut draft.autostart,
+                    RichText::new("start Vigil automatically when you log in")
+                        .color(theme::TEXT2)
+                        .size(11.5),
+                )
+                .changed();
             ui.add_space(2.0);
-            ui.label(RichText::new("On Windows, elevated runs use a highest-privilege scheduled task.").color(theme::TEXT3).size(10.2));
+            ui.label(
+                RichText::new("On Windows, elevated runs use a highest-privilege scheduled task.")
+                    .color(theme::TEXT3)
+                    .size(10.2),
+            );
         });
     });
 
@@ -447,13 +610,28 @@ fn inner(ui: &mut egui::Ui, draft: &mut SettingsDraft, changed: &mut bool) {
     ui.add_space(10.0);
 
     ui.horizontal(|ui| {
-        let te = egui::TextEdit::singleline(&mut draft.new_trusted_input).hint_text("process name…").desired_width(280.0);
+        let te = egui::TextEdit::singleline(&mut draft.new_trusted_input)
+            .hint_text("process name…")
+            .desired_width(280.0);
         let resp = ui.add(te);
-        let add_clicked = ui.add(egui::Button::new(RichText::new("  Add  ").color(theme::TEXT).size(12.0)).fill(theme::ACCENT).stroke(egui::Stroke::new(1.0, theme::ACCENT)).corner_radius(4.0)).on_hover_cursor(egui::CursorIcon::PointingHand).clicked();
+        let add_clicked = ui
+            .add(
+                egui::Button::new(RichText::new("  Add  ").color(theme::TEXT).size(12.0))
+                    .fill(theme::ACCENT)
+                    .stroke(egui::Stroke::new(1.0, theme::ACCENT))
+                    .corner_radius(4.0),
+            )
+            .on_hover_cursor(egui::CursorIcon::PointingHand)
+            .clicked();
         let enter = resp.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter));
         if (add_clicked || enter) && !draft.new_trusted_input.trim().is_empty() {
             let key = normalise_name(draft.new_trusted_input.trim());
-            if !key.is_empty() && !draft.trusted_processes.iter().any(|t| t.eq_ignore_ascii_case(&key)) {
+            if !key.is_empty()
+                && !draft
+                    .trusted_processes
+                    .iter()
+                    .any(|t| t.eq_ignore_ascii_case(&key))
+            {
                 draft.trusted_processes.push(key);
                 draft.trusted_processes.sort_unstable();
                 *changed = true;
@@ -461,38 +639,89 @@ fn inner(ui: &mut egui::Ui, draft: &mut SettingsDraft, changed: &mut bool) {
             draft.new_trusted_input.clear();
         }
         ui.add_space(10.0);
-        if ui.add(egui::Button::new(RichText::new("Reset shipped defaults").color(theme::TEXT2).size(11.0)).fill(theme::SURFACE2).stroke(egui::Stroke::new(1.0, theme::BORDER)).corner_radius(4.0)).on_hover_text("Restore the trusted list that ships with Vigil").on_hover_cursor(egui::CursorIcon::PointingHand).clicked() {
+        if ui
+            .add(
+                egui::Button::new(
+                    RichText::new("Reset shipped defaults")
+                        .color(theme::TEXT2)
+                        .size(11.0),
+                )
+                .fill(theme::SURFACE2)
+                .stroke(egui::Stroke::new(1.0, theme::BORDER))
+                .corner_radius(4.0),
+            )
+            .on_hover_text("Restore the trusted list that ships with Vigil")
+            .on_hover_cursor(egui::CursorIcon::PointingHand)
+            .clicked()
+        {
             draft.trusted_processes = Config::default().trusted_processes;
             draft.trusted_filter.clear();
             draft.new_trusted_input.clear();
-            draft.status_msg = Some(("Restored shipped trusted defaults.".into(), std::time::Instant::now()));
+            draft.status_msg = Some((
+                "Restored shipped trusted defaults.".into(),
+                std::time::Instant::now(),
+            ));
             *changed = true;
         }
     });
 
     ui.add_space(10.0);
     if let Some((msg, at)) = &draft.status_msg {
-        if at.elapsed().as_secs() < 3 { ui.label(RichText::new(msg).color(theme::ACCENT).size(11.5)); ui.add_space(8.0); } else { draft.status_msg = None; }
+        if at.elapsed().as_secs() < 3 {
+            ui.label(RichText::new(msg).color(theme::ACCENT).size(11.5));
+            ui.add_space(8.0);
+        } else {
+            draft.status_msg = None;
+        }
     }
 
     let mut remove_idx: Option<usize> = None;
     if draft.trusted_processes.is_empty() {
-        ui.label(RichText::new("No trusted processes yet.").color(theme::TEXT3).size(11.5));
+        ui.label(
+            RichText::new("No trusted processes yet.")
+                .color(theme::TEXT3)
+                .size(11.5),
+        );
     } else {
         let total = draft.trusted_processes.len();
         if total > 4 {
             ui.horizontal(|ui| {
-                ui.add(egui::TextEdit::singleline(&mut draft.trusted_filter).hint_text("filter…").desired_width(180.0));
-                if !draft.trusted_filter.is_empty() && ui.add(egui::Button::new(RichText::new("x").color(theme::TEXT2).size(11.0)).fill(egui::Color32::TRANSPARENT).stroke(egui::Stroke::NONE)).on_hover_cursor(egui::CursorIcon::PointingHand).clicked() {
+                ui.add(
+                    egui::TextEdit::singleline(&mut draft.trusted_filter)
+                        .hint_text("filter…")
+                        .desired_width(180.0),
+                );
+                if !draft.trusted_filter.is_empty()
+                    && ui
+                        .add(
+                            egui::Button::new(RichText::new("x").color(theme::TEXT2).size(11.0))
+                                .fill(egui::Color32::TRANSPARENT)
+                                .stroke(egui::Stroke::NONE),
+                        )
+                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                        .clicked()
+                {
                     draft.trusted_filter.clear();
                 }
             });
             ui.add_space(6.0);
         }
         let filter_lower = draft.trusted_filter.to_lowercase();
-        let filtered: Vec<usize> = draft.trusted_processes.iter().enumerate().filter(|(_, name)| filter_lower.is_empty() || name.to_lowercase().contains(&filter_lower)).map(|(i, _)| i).collect();
+        let filtered: Vec<usize> = draft
+            .trusted_processes
+            .iter()
+            .enumerate()
+            .filter(|(_, name)| {
+                filter_lower.is_empty() || name.to_lowercase().contains(&filter_lower)
+            })
+            .map(|(i, _)| i)
+            .collect();
         let visible = filtered.len();
-        let count_label = if filter_lower.is_empty() || visible == total { format!("{} process{}", total, if total == 1 { "" } else { "es" }) } else { format!("{} / {} processes", visible, total) };
+        let count_label = if filter_lower.is_empty() || visible == total {
+            format!("{} process{}", total, if total == 1 { "" } else { "es" })
+        } else {
+            format!("{} / {} processes", visible, total)
+        };
         ui.label(RichText::new(&count_label).color(theme::TEXT3).size(11.5));
         ui.add_space(8.0);
         egui::Frame::NONE.fill(theme::SURFACE3).stroke(egui::Stroke::new(1.0, theme::BORDER)).corner_radius(12.0).inner_margin(egui::Margin::symmetric(12, 10)).show(ui, |ui| {
@@ -546,7 +775,10 @@ fn section_header(ui: &mut egui::Ui, title: &str) {
 
 fn setting_row(ui: &mut egui::Ui, label_w: f32, label: &str, ctrl: impl FnOnce(&mut egui::Ui)) {
     ui.horizontal(|ui| {
-        ui.add_sized([label_w, 20.0], egui::Label::new(RichText::new(label).color(theme::TEXT).size(12.0)));
+        ui.add_sized(
+            [label_w, 20.0],
+            egui::Label::new(RichText::new(label).color(theme::TEXT).size(12.0)),
+        );
         ui.add_space(8.0);
         ctrl(ui);
     });


### PR DESCRIPTION
## Summary\n- harden panic/isolation recovery so break-glass watchdog is enforced while isolation is active\n- add strict isolation verification + adapter cutoff fallback improvements and timeout-based reconcile restore\n- hide Windows shell windows for active-response/break-glass commands and add blocking progress overlay (Isolating/Restoring)\n- improve restore behavior to reconnect only previously active network paths (capture connected Wi-Fi profile and reconnect that profile only)\n- update help/settings/README wording, including a top warning line in README\n\n## Validation\n- cargo fmt --all\n- cargo clippy --all-targets --all-features -- -D warnings\n- cargo test --all-targets --all-features\n- cargo build --release\n- rebuilt Windows installer output\n\nPrepared with Codex (GPT-5.4-Mini).