### PR TITLE
Fix Windows suspicious path fragment defaults

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -292,11 +292,11 @@ impl Default for Config {
                 5901, 4899, 8888,
             ],
             suspicious_path_fragments: [
-                r"\\Temp\\",
-                r"\\AppData\\Local\\Temp\\",
-                r"\\AppData\\Roaming\\",
-                r"\\Downloads\\",
-                r"\\Public\\",
+                r"\Temp\",
+                r"\AppData\Local\Temp\",
+                r"\AppData\Roaming\",
+                r"\Downloads\",
+                r"\Public\",
                 "/tmp/",
                 "/var/tmp/",
             ]


### PR DESCRIPTION
### Motivation
- The default `suspicious_path_fragments` used doubled backslashes in raw string literals which do not appear in typical Windows process paths returned by `sysinfo`, causing the substring-based heuristic to miss common suspicious locations. 
- Restoring single-backslash Windows patterns ensures the existing detection heuristic will match paths like `C:\Temp\evil.exe` again. 

### Description
- Updated `suspicious_path_fragments` in `src/config.rs` to use single backslashes for Windows paths (e.g. `"\Temp\"`, `"\AppData\Local\Temp\"`) instead of doubled backslashes. 
- Preserved existing scoring logic in `src/score.rs` which performs a case-insensitive substring match against `cfg.suspicious_path_fragments`. 
- Left POSIX fragments (`"/tmp/"`, `"/var/tmp/"`) and all other configuration values unchanged. 
- Change is minimal and focused on restoring correct default behavior without altering heuristics. 

### Testing
- Ran `cargo test -q`, but the test run failed to compile due to an unrelated dependency (`winit`) reporting the platform is unsupported, so automated tests could not complete. 
- Performed code inspection to confirm `src/score.rs` uses a case-insensitive `contains` check, validating that the updated fragments will match normal Windows paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e4fc198b5c832891be031cca51b1b1)