### PR TITLE
Fix all 3 dependabot alerts (glib, maxminddb, rand)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,6 +2035,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnetwork"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
+
+[[package]]
 name = "is-docker"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2365,14 +2371,15 @@ dependencies = [
 
 [[package]]
 name = "maxminddb"
-version = "0.24.0"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6087e5d8ea14861bb7c7f573afbc7be3798d3ef0fae87ec4fd9a4de9a127c3c"
+checksum = "76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192"
 dependencies = [
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "log",
  "memchr",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2575,9 +2582,9 @@ dependencies = [
 
 [[package]]
 name = "notify-rust"
-version = "4.15.0"
+version = "4.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8146c105ae33d744e2d645f684d063b01176a99daf5986556266777b428816"
+checksum = "5e551a9f0db223eaf3eb156906f99f46897fd951ee66dd1cb0be14db4d36d2fa"
 dependencies = [
  "futures-lite",
  "log",
@@ -3066,9 +3073,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "open"
-version = "5.3.3"
+version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
 dependencies = [
  "is-wsl",
  "libc",
@@ -3083,9 +3090,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59aed3b33578edcfa1bc96a321d590d31832b6ad55a26f0313362ce687e9abd6"
+checksum = "12c6933ddbbd16539a7672e697bb8d41ac3a4e99ac43eeb40c07236bd7fcb2dd"
 dependencies = [
  "libc",
  "libredox",
@@ -3444,9 +3451,9 @@ checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-error"
@@ -3495,9 +3502,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core",
 ]
@@ -4073,6 +4080,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4294,9 +4307,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -4418,11 +4431,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
@@ -4644,9 +4658,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "js-sys",
  "serde_core",
@@ -4713,7 +4727,7 @@ dependencies = [
  "glib",
  "gtk",
  "image",
- "ipnetwork",
+ "ipnetwork 0.20.0",
  "libappindicator",
  "libc",
  "maxminddb",
@@ -4753,11 +4767,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -4766,7 +4780,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -5015,9 +5029,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
  "core-foundation 0.10.1",
  "jni",
@@ -5031,9 +5045,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5743,6 +5757,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2183,6 +2183,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ksni"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ca513d0be42df5edb485af9f44a12b2cb85af773d91c27dc796d1c58b78edc"
+dependencies = [
+ "futures-util",
+ "once_cell",
+ "pastey",
+ "serde",
+ "zbus",
+]
+
+[[package]]
 name = "kurbo"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3176,6 +3189,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pathdiff"
@@ -4724,11 +4743,9 @@ dependencies = [
  "eframe",
  "egui",
  "egui_extras",
- "glib",
- "gtk",
  "image",
  "ipnetwork 0.20.0",
- "libappindicator",
+ "ksni",
  "libc",
  "maxminddb",
  "notify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,12 +109,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,12 +336,6 @@ dependencies = [
  "object",
  "thiserror 1.0.69",
 ]
-
-[[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
@@ -609,12 +597,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,12 +722,6 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
-
-[[package]]
-name = "data-url"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "deranged"
@@ -958,23 +934,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "egui_extras"
-version = "0.34.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bfc6870c68d3f254e33aca8200095d422e09edacb0f365f79fe23a5ba10963"
-dependencies = [
- "ahash",
- "egui",
- "ehttp",
- "enum-map",
- "image",
- "log",
- "mime_guess2",
- "profiling",
- "resvg",
-]
-
-[[package]]
 name = "egui_glow"
 version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,20 +951,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ehttp"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f1b93eb2e039aaff63ce07cca59bd1dca02f2ce30075a17b619d2c42f56efc"
-dependencies = [
- "document-features",
- "js-sys",
- "ureq",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "emath"
 version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,26 +965,6 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
-
-[[package]]
-name = "enum-map"
-version = "2.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
-dependencies = [
- "enum-map-derive",
-]
-
-[[package]]
-name = "enum-map-derive"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "enumflags2"
@@ -1234,12 +1159,6 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
-
-[[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
 name = "foldhash"
@@ -1485,16 +1404,6 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
-]
-
-[[package]]
-name = "gif"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
-dependencies = [
- "color_quant",
- "weezl",
 ]
 
 [[package]]
@@ -1812,22 +1721,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
-dependencies = [
- "bytes",
- "itoa",
-]
-
-[[package]]
-name = "httparse"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,30 +1861,11 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
- "color_quant",
- "gif",
- "image-webp",
  "moxcms",
  "num-traits",
  "png 0.18.1",
  "tiff",
 ]
-
-[[package]]
-name = "image-webp"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
-dependencies = [
- "byteorder-lite",
- "quick-error",
-]
-
-[[package]]
-name = "imagesize"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "indexmap"
@@ -2193,17 +2067,6 @@ dependencies = [
  "pastey",
  "serde",
  "zbus",
-]
-
-[[package]]
-name = "kurbo"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
-dependencies = [
- "arrayvec",
- "euclid",
- "smallvec",
 ]
 
 [[package]]
@@ -2417,24 +2280,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess2"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1706dc14a2e140dec0a7a07109d9a3d5890b81e85bd6c60b906b249a77adf0ca"
-dependencies = [
- "mime",
- "phf",
- "phf_shared",
- "unicase",
 ]
 
 [[package]]
@@ -3210,7 +3055,7 @@ checksum = "9a2b6aadb221872732e87d465213e9be5af2849b0e8cc5300a8ba98fffa2e00a"
 dependencies = [
  "bytemuck",
  "color",
- "kurbo 0.13.0",
+ "kurbo",
  "linebender_resource_handle",
  "smallvec",
 ]
@@ -3220,56 +3065,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "unicase",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
- "unicase",
-]
-
-[[package]]
-name = "pico-args"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -3520,21 +3315,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3612,43 +3392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
-name = "resvg"
-version = "0.45.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
-dependencies = [
- "log",
- "pico-args",
- "rgb",
- "svgtypes",
- "tiny-skia",
- "usvg",
-]
-
-[[package]]
-name = "rgb"
-version = "0.8.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "ron"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3661,12 +3404,6 @@ dependencies = [
  "typeid",
  "unicode-ident",
 ]
-
-[[package]]
-name = "roxmltree"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rustc-hash"
@@ -3713,41 +3450,6 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
-dependencies = [
- "log",
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -3919,21 +3621,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
-name = "simplecss"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "siphasher"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
-
-[[package]]
 name = "skrifa"
 version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4072,31 +3759,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strict-num"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
-dependencies = [
- "float-cmp",
-]
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "svgtypes"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
-dependencies = [
- "kurbo 0.11.3",
- "siphasher",
-]
 
 [[package]]
 name = "symlink"
@@ -4286,32 +3948,6 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-skia"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
-dependencies = [
- "arrayref",
- "arrayvec",
- "bytemuck",
- "cfg-if",
- "log",
- "png 0.17.16",
- "tiny-skia-path",
-]
-
-[[package]]
-name = "tiny-skia-path"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
-dependencies = [
- "arrayref",
- "bytemuck",
- "strict-num",
 ]
 
 [[package]]
@@ -4559,12 +4195,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4595,41 +4225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
-dependencies = [
- "base64",
- "flate2",
- "log",
- "percent-encoding",
- "rustls",
- "rustls-pki-types",
- "ureq-proto",
- "utf8-zero",
- "webpki-roots",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
-dependencies = [
- "base64",
- "http",
- "httparse",
- "log",
-]
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4640,34 +4235,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "usvg"
-version = "0.45.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
-dependencies = [
- "base64",
- "data-url",
- "flate2",
- "imagesize",
- "kurbo 0.11.3",
- "log",
- "pico-args",
- "roxmltree",
- "simplecss",
- "siphasher",
- "strict-num",
- "svgtypes",
- "tiny-skia-path",
- "xmlwriter",
-]
-
-[[package]]
-name = "utf8-zero"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -4742,7 +4309,6 @@ dependencies = [
  "dns-lookup",
  "eframe",
  "egui",
- "egui_extras",
  "image",
  "ipnetwork 0.20.0",
  "ksni",
@@ -5058,15 +4624,6 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -5940,12 +5497,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
-name = "xmlwriter"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
-
-[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6069,12 +5620,6 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/main.rs"
 tokio = { version = "1", features = ["full"] }
 egui        = "0.34"
 eframe      = { version = "0.34", default-features = false, features = ["default_fonts", "glow", "persistence"] }
-egui_extras = { version = "0.34", features = ["all_loaders"] }
 notify-rust = "4"
 image = { version = "0.25", default-features = false, features = ["bmp", "ico", "png"] }
 sysinfo = "0.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ chrono = { version = "0.4", features = ["serde"] }
 open = "5"
 dashmap = "5"
 auto-launch = "0.6.0"
-maxminddb = "0.24"
+maxminddb = "0.27"
 notify = "6"
 dns-lookup = "2"
 ipnetwork = "0.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ tokio = { version = "1", features = ["full"] }
 egui        = "0.34"
 eframe      = { version = "0.34", default-features = false, features = ["default_fonts", "glow", "persistence"] }
 egui_extras = { version = "0.34", features = ["all_loaders"] }
-tray-icon = "0.22"
 notify-rust = "4"
 image = { version = "0.25", default-features = false, features = ["bmp", "ico", "png"] }
 sysinfo = "0.38"
@@ -55,14 +54,15 @@ windows = { version = "0.62", features = [
 ] }
 winreg = "0.56"
 
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+tray-icon = "0.22"
+
 [target.'cfg(target_os = "linux")'.dependencies]
 eframe = { version = "0.34", default-features = false, features = ["default_fonts", "glow", "persistence", "wayland", "x11"] }
 aya = "0.13"
 bytes = "1"
 libc = "0.2"
-gtk = "0.18"
-glib = "0.18"
-libappindicator = "0.9"
+ksni = { version = "0.3", default-features = false, features = ["blocking"] }
 
 [target.'cfg(target_os = "linux")'.build-dependencies]
 

--- a/src/geoip.rs
+++ b/src/geoip.rs
@@ -67,17 +67,18 @@ impl GeoEngine {
         let mut info = GeoInfo::default();
 
         if let Some(r) = &self.city {
-            if let Ok(rec) = r.lookup::<geoip2::City>(addr) {
-                info.country = rec
-                    .country
-                    .and_then(|c| c.iso_code)
-                    .map(|s| s.to_uppercase());
+            if let Ok(res) = r.lookup(addr) {
+                if let Ok(Some(rec)) = res.decode::<geoip2::City>() {
+                    info.country = rec.country.iso_code.map(|s| s.to_uppercase());
+                }
             }
         }
         if let Some(r) = &self.asn {
-            if let Ok(rec) = r.lookup::<geoip2::Asn>(addr) {
-                info.asn = rec.autonomous_system_number;
-                info.asn_org = rec.autonomous_system_organization.map(|s| s.to_string());
+            if let Ok(res) = r.lookup(addr) {
+                if let Ok(Some(rec)) = res.decode::<geoip2::Asn>() {
+                    info.asn = rec.autonomous_system_number;
+                    info.asn_org = rec.autonomous_system_organization.map(|s| s.to_string());
+                }
             }
         }
         info

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -2,9 +2,9 @@
 //!
 //! # Threading
 //! `run()` is designed to be called on a **dedicated OS thread** (not the
-//! tokio runtime thread).  On Windows it drives a Win32 message pump; the
-//! tray-icon crate requires that the message pump runs on the same thread
-//! that created the `TrayIcon`.
+//! tokio runtime thread). On Windows/macOS it drives the `tray-icon` crate's
+//! event loop. On Linux it uses `ksni` (a pure-Rust StatusNotifierItem client
+//! over zbus) to avoid pulling in the unmaintained gtk3 stack.
 //!
 //! # Commands
 //! The caller forwards `TrayCmd` values over a `std::sync::mpsc` channel:
@@ -20,12 +20,8 @@
 
 use crate::types::ConnInfo;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::{mpsc::Receiver, Arc, Mutex, OnceLock};
-use tray_icon::{
-    menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem},
-    MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent,
-};
 
 /// Commands sent from the monitor / UI to the tray thread.
 #[allow(clippy::large_enum_variant)]
@@ -38,259 +34,13 @@ pub enum TrayCmd {
     SetLockdown(bool),
 }
 
-// ── Icon generation ───────────────────────────────────────────────────────────
+// ── Embedded icon bytes (shared across platforms) ────────────────────────────
 
 const TRAY_GREEN_ICO: &[u8] = include_bytes!("../assets/vigil_tray_green.ico");
 const TRAY_ORANGE_ICO: &[u8] = include_bytes!("../assets/vigil_tray_orange.ico");
 const TRAY_RED_ICO: &[u8] = include_bytes!("../assets/vigil_tray_red.ico");
 
-fn make_circle_icon(r: u8, g: u8, b: u8) -> tray_icon::Icon {
-    const SIZE: u32 = 32;
-    const CENTER: f32 = 15.5;
-    const RADIUS: f32 = 13.0;
-    const INNER: f32 = 11.0;
-
-    let mut rgba = vec![0u8; (SIZE * SIZE * 4) as usize];
-    for y in 0..SIZE {
-        for x in 0..SIZE {
-            let dx = x as f32 - CENTER;
-            let dy = y as f32 - CENTER;
-            let d = (dx * dx + dy * dy).sqrt();
-            let idx = ((y * SIZE + x) * 4) as usize;
-            if d <= RADIUS {
-                let boost = if d <= INNER { 40u8 } else { 0u8 };
-                rgba[idx] = r.saturating_add(boost);
-                rgba[idx + 1] = g.saturating_add(boost);
-                rgba[idx + 2] = b.saturating_add(boost);
-                rgba[idx + 3] = 255;
-            }
-        }
-    }
-    tray_icon::Icon::from_rgba(rgba, SIZE, SIZE).expect("hardcoded icon dimensions are valid")
-}
-
-fn icon_from_embedded_ico(label: &str, bytes: &[u8]) -> Option<tray_icon::Icon> {
-    let image = match image::load_from_memory_with_format(bytes, image::ImageFormat::Ico) {
-        Ok(image) => image,
-        Err(err) => {
-            tracing::warn!("failed to decode embedded tray icon {label}: {err}");
-            return None;
-        }
-    };
-    let image = image.into_rgba8();
-    let (w, h) = (image.width(), image.height());
-    match tray_icon::Icon::from_rgba(image.into_raw(), w, h) {
-        Ok(icon) => Some(icon),
-        Err(err) => {
-            tracing::warn!("failed to build tray icon {label} from decoded bitmap: {err}");
-            None
-        }
-    }
-}
-
-fn load_tray_icons() -> TrayIcons {
-    TrayIcons {
-        ok: icon_from_embedded_ico("green", TRAY_GREEN_ICO)
-            .unwrap_or_else(|| make_circle_icon(0x22, 0xC5, 0x5E)),
-        alert: icon_from_embedded_ico("orange", TRAY_ORANGE_ICO)
-            .unwrap_or_else(|| make_circle_icon(0xF5, 0x9E, 0x0B)),
-        lockdown: icon_from_embedded_ico("red", TRAY_RED_ICO)
-            .unwrap_or_else(|| make_circle_icon(0xEF, 0x44, 0x44)),
-    }
-}
-
-fn apply_tray_visual_state(tray: &TrayIcon, icons: &TrayIcons, in_alert: bool, in_lockdown: bool) {
-    if in_lockdown {
-        let _ = tray.set_icon(Some(icons.lockdown.clone()));
-        let _ = tray.set_tooltip(Some("Vigil — Lockdown active"));
-    } else if in_alert {
-        let _ = tray.set_icon(Some(icons.alert.clone()));
-        let _ = tray.set_tooltip(Some("Vigil — ⚠ Threat detected"));
-    } else {
-        let _ = tray.set_icon(Some(icons.ok.clone()));
-        let _ = tray.set_tooltip(Some("Vigil — Monitoring"));
-    }
-}
-
-// ── Linux themed icon helpers ─────────────────────────────────────────────────
-
-#[cfg(target_os = "linux")]
-fn linux_icon_dir() -> PathBuf {
-    std::env::var_os("HOME")
-        .map(|h| PathBuf::from(h))
-        .unwrap_or_default()
-        .join(".local/share/icons/hicolor/32x32/apps")
-}
-
-/// Decode embedded ICO assets and write PNG files to the themed icon directory
-/// so AppIndicator can find them by name.
-#[cfg(target_os = "linux")]
-fn ensure_themed_icons() {
-    let dir = linux_icon_dir();
-    if let Err(e) = std::fs::create_dir_all(&dir) {
-        tracing::warn!("tray: cannot create icon dir {:?}: {e}", dir);
-        return;
-    }
-
-    let icons: &[(&str, &[u8])] = &[
-        ("vigil-tray-green.png", TRAY_GREEN_ICO),
-        ("vigil-tray-orange.png", TRAY_ORANGE_ICO),
-        ("vigil-tray-red.png", TRAY_RED_ICO),
-    ];
-
-    for &(name, ico_bytes) in icons {
-        let path = dir.join(name);
-        if path.exists() {
-            continue;
-        }
-        match image::load_from_memory_with_format(ico_bytes, image::ImageFormat::Ico) {
-            Ok(img) => {
-                let img = img.resize_exact(32, 32, image::imageops::FilterType::Lanczos3);
-                if let Err(e) = img.save(&path) {
-                    tracing::warn!("tray: failed to write {:?}: {e}", path);
-                }
-            }
-            Err(e) => {
-                tracing::warn!("tray: failed to decode icon {name}: {e}");
-            }
-        }
-    }
-}
-
-/// Switch the AppIndicator themed icon by name (e.g. "vigil-tray-orange").
-#[cfg(target_os = "linux")]
-fn set_linux_tray_icon(tray: &TrayIcon, name: &str) {
-    unsafe {
-        let ai = tray.app_indicator() as *mut libappindicator::AppIndicator;
-        if !ai.is_null() {
-            (*ai).set_icon_full(name, "");
-        }
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn linux_tray_icon_name(in_alert: bool, in_lockdown: bool) -> &'static str {
-    if in_lockdown {
-        "vigil-tray-red"
-    } else if in_alert {
-        "vigil-tray-orange"
-    } else {
-        "vigil-tray-green"
-    }
-}
-
-// ── Public entry point ────────────────────────────────────────────────────────
-
-struct TrayIcons {
-    ok: tray_icon::Icon,
-    alert: tray_icon::Icon,
-    lockdown: tray_icon::Icon,
-}
-
-/// Build the tray icon and run the event loop.
-///
-/// - `cmd_rx`      — receives `TrayCmd` messages from the UI/monitor
-/// - `show_window` — set to `true` when "Open Vigil" is clicked (menu or
-///   notification click); cleared by the UI each frame
-/// - `log_dir`     — path opened when "Open Logs Folder" is clicked
-/// - `pending_nav` — filled with the clicked `ConnInfo` so the UI can navigate
-pub fn run(
-    cmd_rx: Receiver<TrayCmd>,
-    show_window: Arc<AtomicBool>,
-    log_dir: PathBuf,
-    pending_nav: Arc<Mutex<Option<ConnInfo>>>,
-    egui_ctx: Arc<OnceLock<egui::Context>>,
-) {
-    let icons = load_tray_icons();
-
-    #[cfg(target_os = "linux")]
-    ensure_themed_icons();
-
-    // On non-Windows, the tray-icon crate uses GTK which requires a working
-    // display. Running under sudo or without a desktop session means GTK
-    // can't connect. Skip the entire GTK init to avoid panics and C-level
-    // warning spam on stderr.
-    #[cfg(not(windows))]
-    {
-        let has_display = std::env::var("DISPLAY").is_ok()
-            || std::env::var("WAYLAND_DISPLAY").is_ok();
-        let is_root = unsafe { libc::geteuid() == 0 };
-        if !has_display || is_root {
-            tracing::info!("system tray skipped ({}{})", if is_root { "running as root" } else { "no display" }, if !has_display { "" } else { " — display auth may fail" });
-            notification_only_loop(cmd_rx, show_window, pending_nav);
-            return;
-        }
-    }
-    let init_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        // GTK must be initialized before any GTK operations (menu, tray icon).
-        // The tray-icon crate on Linux uses libappindicator which depends on GTK.
-        #[cfg(not(windows))]
-        {
-            if gtk::init().is_err() {
-                return Err("GTK init failed — tray icon unavailable".into());
-            }
-        }
-
-        // ── Context menu ──────────────────────────────────────────────────
-        let menu = Menu::new();
-        let open_item = MenuItem::new("Open Vigil", true, None);
-        let logs_item = MenuItem::new("Open Logs Folder", true, None);
-        let quit_item = MenuItem::new("Quit", true, None);
-        let _ = menu.append_items(&[
-            &open_item,
-            &logs_item,
-            &PredefinedMenuItem::separator(),
-            &quit_item,
-        ]);
-        let open_id = open_item.id().clone();
-        let logs_id = logs_item.id().clone();
-        let quit_id = quit_item.id().clone();
-
-        let tray = TrayIconBuilder::new()
-            .with_tooltip("Vigil — Network Monitor  ●")
-            .with_icon(icons.ok.clone())
-            .with_menu(Box::new(menu))
-            .with_menu_on_left_click(false)
-            .build().map_err(|e| e.to_string())?;
-
-        // On Linux, override the icon with a themed name so GNOME's
-        // AppIndicator extension can render it (raw pixel paths don't work).
-        #[cfg(target_os = "linux")]
-        unsafe {
-            let ai = tray.app_indicator() as *mut libappindicator::AppIndicator;
-            if !ai.is_null() {
-                let icon_dir = linux_icon_dir();
-                if icon_dir.exists() {
-                    (*ai).set_icon_theme_path(icon_dir.to_str().unwrap_or(""));
-                    (*ai).set_icon_full("vigil-tray-green", "");
-                }
-            }
-        }
-
-        Ok::<_, String>((tray, quit_id, open_id, logs_id))
-    }));
-
-    match init_result {
-        Ok(Ok((tray, quit_id, open_id, logs_id))) => {
-            event_loop(
-                tray,
-                icons,
-                cmd_rx,
-                quit_id,
-                open_id,
-                logs_id,
-                log_dir,
-                show_window,
-                pending_nav,
-                egui_ctx,
-            );
-        }
-        _ => {
-            tracing::warn!("tray init failed — running without tray icon");
-            notification_only_loop(cmd_rx, show_window, pending_nav);
-        }
-    }
-}
+// ── Shared fallback loop for environments without a usable tray ──────────────
 
 fn notification_only_loop(
     cmd_rx: Receiver<TrayCmd>,
@@ -314,185 +64,567 @@ fn notification_only_loop(
     }
 }
 
-// ── Platform event loops ──────────────────────────────────────────────────────
+// ═════════════════════════════════════════════════════════════════════════════
+// Windows + macOS: tray-icon crate
+// ═════════════════════════════════════════════════════════════════════════════
 
-#[cfg(windows)]
-#[allow(clippy::too_many_arguments)]
-fn event_loop(
-    tray: TrayIcon,
-    icons: TrayIcons,
-    cmd_rx: Receiver<TrayCmd>,
-    quit_id: tray_icon::menu::MenuId,
-    open_id: tray_icon::menu::MenuId,
-    logs_id: tray_icon::menu::MenuId,
-    log_dir: PathBuf,
-    show_window: Arc<AtomicBool>,
-    pending_nav: Arc<Mutex<Option<ConnInfo>>>,
-    _egui_ctx: Arc<OnceLock<egui::Context>>,
-) {
-    use windows::Win32::UI::WindowsAndMessaging::{
-        DispatchMessageW, PeekMessageW, TranslateMessage, MSG, PM_REMOVE,
+#[cfg(not(target_os = "linux"))]
+mod imp {
+    use super::*;
+    use std::sync::atomic::Ordering;
+    use tray_icon::{
+        menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem},
+        MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent,
     };
 
-    let mut msg = MSG::default();
-    let mut in_alert = false;
-    let mut in_lockdown = false;
-
-    loop {
-        // Drain Win32 messages without blocking.
-        unsafe {
-            while PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).as_bool() {
-                if msg.message == 0x0012 {
-                    return;
-                } // WM_QUIT
-                let _ = TranslateMessage(&msg);
-                DispatchMessageW(&msg);
-            }
-        }
-
-        // ── Tray icon click events ────────────────────────────────────────────
-        // Left-click → open window directly (menu_on_left_click is false).
-        while let Ok(ev) = TrayIconEvent::receiver().try_recv() {
-            if let TrayIconEvent::Click {
-                button: MouseButton::Left,
-                button_state: MouseButtonState::Up,
-                ..
-            } = ev
-            {
-                show_window.store(true, Ordering::Relaxed);
-            }
-        }
-
-        // ── Menu events ───────────────────────────────────────────────────────
-        while let Ok(ev) = MenuEvent::receiver().try_recv() {
-            if ev.id == quit_id {
-                std::process::exit(0);
-            } else if ev.id == open_id {
-                show_window.store(true, Ordering::Relaxed);
-            } else if ev.id == logs_id {
-                let _ = open::that(&log_dir);
-            }
-        }
-
-        // ── Commands from UI / monitor ────────────────────────────────────────
-        while let Ok(cmd) = cmd_rx.try_recv() {
-            match cmd {
-                TrayCmd::Alert(info) => {
-                    crate::notifier::send_alert(&info, show_window.clone(), pending_nav.clone());
-                    in_alert = true;
-                    apply_tray_visual_state(&tray, &icons, in_alert, in_lockdown);
-                }
-                TrayCmd::ResetOk => {
-                    in_alert = false;
-                    apply_tray_visual_state(&tray, &icons, in_alert, in_lockdown);
-                }
-                TrayCmd::SetLockdown(active) => {
-                    in_lockdown = active;
-                    apply_tray_visual_state(&tray, &icons, in_alert, in_lockdown);
-                }
-            }
-        }
-
-        std::thread::sleep(std::time::Duration::from_millis(50));
+    struct TrayIcons {
+        ok: tray_icon::Icon,
+        alert: tray_icon::Icon,
+        lockdown: tray_icon::Icon,
     }
-}
 
-#[cfg(not(windows))]
-#[allow(clippy::too_many_arguments)]
-fn event_loop(
-    tray: TrayIcon,
-    _icons: TrayIcons,
-    cmd_rx: Receiver<TrayCmd>,
-    quit_id: tray_icon::menu::MenuId,
-    open_id: tray_icon::menu::MenuId,
-    logs_id: tray_icon::menu::MenuId,
-    log_dir: PathBuf,
-    show_window: Arc<AtomicBool>,
-    pending_nav: Arc<Mutex<Option<ConnInfo>>>,
-    egui_ctx: Arc<OnceLock<egui::Context>>,
-) {
-    let _tray = tray;
-    let ctx = glib::MainContext::default();
-    let mut in_alert = false;
-    let mut in_lockdown = false;
-    let mut alert_since: Option<std::time::Instant> = None;
-    const ALERT_HOLD: std::time::Duration = std::time::Duration::from_secs(5);
+    fn make_circle_icon(r: u8, g: u8, b: u8) -> tray_icon::Icon {
+        const SIZE: u32 = 32;
+        const CENTER: f32 = 15.5;
+        const RADIUS: f32 = 13.0;
+        const INNER: f32 = 11.0;
 
-    loop {
-        // Process pending GLib events (required for AppIndicator D-Bus).
-        while ctx.iteration(false) {}
-
-        // ── Tray icon click events ────────────────────────────────────────
-        while let Ok(ev) = TrayIconEvent::receiver().try_recv() {
-            if let TrayIconEvent::Click {
-                button: MouseButton::Left,
-                button_state: MouseButtonState::Up,
-                ..
-            } = ev
-            {
-                show_window.store(true, Ordering::Relaxed);
-                if let Some(ec) = egui_ctx.get() {
-                    ec.request_repaint();
+        let mut rgba = vec![0u8; (SIZE * SIZE * 4) as usize];
+        for y in 0..SIZE {
+            for x in 0..SIZE {
+                let dx = x as f32 - CENTER;
+                let dy = y as f32 - CENTER;
+                let d = (dx * dx + dy * dy).sqrt();
+                let idx = ((y * SIZE + x) * 4) as usize;
+                if d <= RADIUS {
+                    let boost = if d <= INNER { 40u8 } else { 0u8 };
+                    rgba[idx] = r.saturating_add(boost);
+                    rgba[idx + 1] = g.saturating_add(boost);
+                    rgba[idx + 2] = b.saturating_add(boost);
+                    rgba[idx + 3] = 255;
                 }
             }
         }
+        tray_icon::Icon::from_rgba(rgba, SIZE, SIZE).expect("hardcoded icon dimensions are valid")
+    }
 
-        // ── Menu events ───────────────────────────────────────────────────
-        while let Ok(ev) = MenuEvent::receiver().try_recv() {
-            if ev.id == quit_id {
-                std::process::exit(0);
-            } else if ev.id == open_id {
-                show_window.store(true, Ordering::Relaxed);
-                if let Some(ec) = egui_ctx.get() {
-                    ec.request_repaint();
-                }
-            } else if ev.id == logs_id {
-                let _ = open::that(&log_dir);
+    fn icon_from_embedded_ico(label: &str, bytes: &[u8]) -> Option<tray_icon::Icon> {
+        let image = match image::load_from_memory_with_format(bytes, image::ImageFormat::Ico) {
+            Ok(image) => image,
+            Err(err) => {
+                tracing::warn!("failed to decode embedded tray icon {label}: {err}");
+                return None;
+            }
+        };
+        let image = image.into_rgba8();
+        let (w, h) = (image.width(), image.height());
+        match tray_icon::Icon::from_rgba(image.into_raw(), w, h) {
+            Ok(icon) => Some(icon),
+            Err(err) => {
+                tracing::warn!("failed to build tray icon {label} from decoded bitmap: {err}");
+                None
             }
         }
+    }
 
-        // ── Commands from UI / monitor ────────────────────────────────────
-        while let Ok(cmd) = cmd_rx.try_recv() {
-            match cmd {
-                TrayCmd::Alert(info) => {
-                    crate::notifier::send_alert(&info, show_window.clone(), pending_nav.clone());
-                    in_alert = true;
-                    alert_since = Some(std::time::Instant::now());
-                    #[cfg(target_os = "linux")]
-                    set_linux_tray_icon(&_tray, linux_tray_icon_name(in_alert, in_lockdown));
+    fn load_tray_icons() -> TrayIcons {
+        TrayIcons {
+            ok: icon_from_embedded_ico("green", TRAY_GREEN_ICO)
+                .unwrap_or_else(|| make_circle_icon(0x22, 0xC5, 0x5E)),
+            alert: icon_from_embedded_ico("orange", TRAY_ORANGE_ICO)
+                .unwrap_or_else(|| make_circle_icon(0xF5, 0x9E, 0x0B)),
+            lockdown: icon_from_embedded_ico("red", TRAY_RED_ICO)
+                .unwrap_or_else(|| make_circle_icon(0xEF, 0x44, 0x44)),
+        }
+    }
+
+    fn apply_tray_visual_state(
+        tray: &TrayIcon,
+        icons: &TrayIcons,
+        in_alert: bool,
+        in_lockdown: bool,
+    ) {
+        if in_lockdown {
+            let _ = tray.set_icon(Some(icons.lockdown.clone()));
+            let _ = tray.set_tooltip(Some("Vigil — Lockdown active"));
+        } else if in_alert {
+            let _ = tray.set_icon(Some(icons.alert.clone()));
+            let _ = tray.set_tooltip(Some("Vigil — ⚠ Threat detected"));
+        } else {
+            let _ = tray.set_icon(Some(icons.ok.clone()));
+            let _ = tray.set_tooltip(Some("Vigil — Monitoring"));
+        }
+    }
+
+    pub fn run(
+        cmd_rx: Receiver<TrayCmd>,
+        show_window: Arc<AtomicBool>,
+        log_dir: PathBuf,
+        pending_nav: Arc<Mutex<Option<ConnInfo>>>,
+        egui_ctx: Arc<OnceLock<egui::Context>>,
+    ) {
+        let icons = load_tray_icons();
+
+        let init_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let menu = Menu::new();
+            let open_item = MenuItem::new("Open Vigil", true, None);
+            let logs_item = MenuItem::new("Open Logs Folder", true, None);
+            let quit_item = MenuItem::new("Quit", true, None);
+            let _ = menu.append_items(&[
+                &open_item,
+                &logs_item,
+                &PredefinedMenuItem::separator(),
+                &quit_item,
+            ]);
+            let open_id = open_item.id().clone();
+            let logs_id = logs_item.id().clone();
+            let quit_id = quit_item.id().clone();
+
+            let tray = TrayIconBuilder::new()
+                .with_tooltip("Vigil — Network Monitor  ●")
+                .with_icon(icons.ok.clone())
+                .with_menu(Box::new(menu))
+                .with_menu_on_left_click(false)
+                .build()
+                .map_err(|e| e.to_string())?;
+
+            Ok::<_, String>((tray, quit_id, open_id, logs_id))
+        }));
+
+        match init_result {
+            Ok(Ok((tray, quit_id, open_id, logs_id))) => {
+                event_loop(
+                    tray,
+                    icons,
+                    cmd_rx,
+                    quit_id,
+                    open_id,
+                    logs_id,
+                    log_dir,
+                    show_window,
+                    pending_nav,
+                    egui_ctx,
+                );
+            }
+            _ => {
+                tracing::warn!("tray init failed — running without tray icon");
+                notification_only_loop(cmd_rx, show_window, pending_nav);
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    #[allow(clippy::too_many_arguments)]
+    fn event_loop(
+        tray: TrayIcon,
+        icons: TrayIcons,
+        cmd_rx: Receiver<TrayCmd>,
+        quit_id: tray_icon::menu::MenuId,
+        open_id: tray_icon::menu::MenuId,
+        logs_id: tray_icon::menu::MenuId,
+        log_dir: PathBuf,
+        show_window: Arc<AtomicBool>,
+        pending_nav: Arc<Mutex<Option<ConnInfo>>>,
+        _egui_ctx: Arc<OnceLock<egui::Context>>,
+    ) {
+        use windows::Win32::UI::WindowsAndMessaging::{
+            DispatchMessageW, PeekMessageW, TranslateMessage, MSG, PM_REMOVE,
+        };
+
+        let mut msg = MSG::default();
+        let mut in_alert = false;
+        let mut in_lockdown = false;
+
+        loop {
+            unsafe {
+                while PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).as_bool() {
+                    if msg.message == 0x0012 {
+                        return;
+                    }
+                    let _ = TranslateMessage(&msg);
+                    DispatchMessageW(&msg);
                 }
-                TrayCmd::ResetOk => {
-                    // On Linux/AppIndicator, hold the alert icon for at
-                    // least ALERT_HOLD so the user can see the state change
-                    // (otherwise ResetOk arrives on the same frame and the
-                    // icon flashes too fast to notice).
-                    if alert_since.map_or(true, |t| t.elapsed() >= ALERT_HOLD) {
+            }
+
+            while let Ok(ev) = TrayIconEvent::receiver().try_recv() {
+                if let TrayIconEvent::Click {
+                    button: MouseButton::Left,
+                    button_state: MouseButtonState::Up,
+                    ..
+                } = ev
+                {
+                    show_window.store(true, Ordering::Relaxed);
+                }
+            }
+
+            while let Ok(ev) = MenuEvent::receiver().try_recv() {
+                if ev.id == quit_id {
+                    std::process::exit(0);
+                } else if ev.id == open_id {
+                    show_window.store(true, Ordering::Relaxed);
+                } else if ev.id == logs_id {
+                    let _ = open::that(&log_dir);
+                }
+            }
+
+            while let Ok(cmd) = cmd_rx.try_recv() {
+                match cmd {
+                    TrayCmd::Alert(info) => {
+                        crate::notifier::send_alert(
+                            &info,
+                            show_window.clone(),
+                            pending_nav.clone(),
+                        );
+                        in_alert = true;
+                        apply_tray_visual_state(&tray, &icons, in_alert, in_lockdown);
+                    }
+                    TrayCmd::ResetOk => {
                         in_alert = false;
-                        alert_since = None;
-                        #[cfg(target_os = "linux")]
-                        set_linux_tray_icon(&_tray, linux_tray_icon_name(in_alert, in_lockdown));
+                        apply_tray_visual_state(&tray, &icons, in_alert, in_lockdown);
+                    }
+                    TrayCmd::SetLockdown(active) => {
+                        in_lockdown = active;
+                        apply_tray_visual_state(&tray, &icons, in_alert, in_lockdown);
                     }
                 }
-                TrayCmd::SetLockdown(active) => {
-                    in_lockdown = active;
-                    #[cfg(target_os = "linux")]
-                    set_linux_tray_icon(&_tray, linux_tray_icon_name(in_alert, in_lockdown));
+            }
+
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    }
+
+    // macOS: tray-icon crate runs its event loop via the AppKit run loop
+    // driven by the process's main thread. Since the tray thread here is
+    // a dedicated std::thread, we just poll commands and let tray-icon's
+    // internal handlers process events on their own.
+    #[cfg(target_os = "macos")]
+    #[allow(clippy::too_many_arguments)]
+    fn event_loop(
+        tray: TrayIcon,
+        icons: TrayIcons,
+        cmd_rx: Receiver<TrayCmd>,
+        quit_id: tray_icon::menu::MenuId,
+        open_id: tray_icon::menu::MenuId,
+        logs_id: tray_icon::menu::MenuId,
+        log_dir: PathBuf,
+        show_window: Arc<AtomicBool>,
+        pending_nav: Arc<Mutex<Option<ConnInfo>>>,
+        _egui_ctx: Arc<OnceLock<egui::Context>>,
+    ) {
+        let mut in_alert = false;
+        let mut in_lockdown = false;
+
+        loop {
+            while let Ok(ev) = TrayIconEvent::receiver().try_recv() {
+                if let TrayIconEvent::Click {
+                    button: MouseButton::Left,
+                    button_state: MouseButtonState::Up,
+                    ..
+                } = ev
+                {
+                    show_window.store(true, Ordering::Relaxed);
                 }
+            }
+
+            while let Ok(ev) = MenuEvent::receiver().try_recv() {
+                if ev.id == quit_id {
+                    std::process::exit(0);
+                } else if ev.id == open_id {
+                    show_window.store(true, Ordering::Relaxed);
+                } else if ev.id == logs_id {
+                    let _ = open::that(&log_dir);
+                }
+            }
+
+            while let Ok(cmd) = cmd_rx.try_recv() {
+                match cmd {
+                    TrayCmd::Alert(info) => {
+                        crate::notifier::send_alert(
+                            &info,
+                            show_window.clone(),
+                            pending_nav.clone(),
+                        );
+                        in_alert = true;
+                        apply_tray_visual_state(&tray, &icons, in_alert, in_lockdown);
+                    }
+                    TrayCmd::ResetOk => {
+                        in_alert = false;
+                        apply_tray_visual_state(&tray, &icons, in_alert, in_lockdown);
+                    }
+                    TrayCmd::SetLockdown(active) => {
+                        in_lockdown = active;
+                        apply_tray_visual_state(&tray, &icons, in_alert, in_lockdown);
+                    }
+                }
+            }
+
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn embedded_tray_icons_decode() {
+            assert!(icon_from_embedded_ico("green-test", TRAY_GREEN_ICO).is_some());
+            assert!(icon_from_embedded_ico("orange-test", TRAY_ORANGE_ICO).is_some());
+            assert!(icon_from_embedded_ico("red-test", TRAY_RED_ICO).is_some());
+        }
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Linux: ksni (pure-Rust StatusNotifierItem, no gtk3)
+// ═════════════════════════════════════════════════════════════════════════════
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use super::*;
+    use ksni::blocking::TrayMethods;
+    use ksni::menu::{MenuItem as KsniMenuItem, StandardItem};
+    use ksni::{Handle, Tray};
+    use std::sync::atomic::Ordering;
+
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    enum IconState {
+        Ok,
+        Alert,
+        Lockdown,
+    }
+
+    impl IconState {
+        fn icon_name(self) -> &'static str {
+            match self {
+                IconState::Ok => "vigil-tray-green",
+                IconState::Alert => "vigil-tray-orange",
+                IconState::Lockdown => "vigil-tray-red",
             }
         }
 
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        fn tooltip(self) -> &'static str {
+            match self {
+                IconState::Ok => "Vigil — Monitoring",
+                IconState::Alert => "Vigil — ⚠ Threat detected",
+                IconState::Lockdown => "Vigil — Lockdown active",
+            }
+        }
+    }
+
+    /// Tray state owned by ksni's background task. Menu activation
+    /// callbacks run here and mutate the `Arc<AtomicBool>` / open the
+    /// logs folder directly — no cross-thread channel needed for them.
+    struct VigilTray {
+        state: IconState,
+        show_window: Arc<AtomicBool>,
+        log_dir: PathBuf,
+        egui_ctx: Arc<OnceLock<egui::Context>>,
+    }
+
+    impl VigilTray {
+        fn wake_ui(&self) {
+            self.show_window.store(true, Ordering::Relaxed);
+            if let Some(ec) = self.egui_ctx.get() {
+                ec.request_repaint();
+            }
+        }
+    }
+
+    impl Tray for VigilTray {
+        fn id(&self) -> String {
+            "vigil".into()
+        }
+
+        fn title(&self) -> String {
+            "Vigil".into()
+        }
+
+        fn icon_name(&self) -> String {
+            self.state.icon_name().into()
+        }
+
+        fn icon_theme_path(&self) -> String {
+            linux_icon_dir()
+                .to_str()
+                .unwrap_or("")
+                .to_string()
+        }
+
+        fn tool_tip(&self) -> ksni::ToolTip {
+            ksni::ToolTip {
+                title: self.state.tooltip().into(),
+                ..Default::default()
+            }
+        }
+
+        fn activate(&mut self, _x: i32, _y: i32) {
+            // Left-click on the icon itself.
+            self.wake_ui();
+        }
+
+        fn menu(&self) -> Vec<KsniMenuItem<Self>> {
+            vec![
+                StandardItem {
+                    label: "Open Vigil".into(),
+                    activate: Box::new(|this: &mut Self| this.wake_ui()),
+                    ..Default::default()
+                }
+                .into(),
+                StandardItem {
+                    label: "Open Logs Folder".into(),
+                    activate: Box::new(|this: &mut Self| {
+                        let _ = open::that(&this.log_dir);
+                    }),
+                    ..Default::default()
+                }
+                .into(),
+                KsniMenuItem::Separator,
+                StandardItem {
+                    label: "Quit".into(),
+                    icon_name: "application-exit".into(),
+                    activate: Box::new(|_this: &mut Self| std::process::exit(0)),
+                    ..Default::default()
+                }
+                .into(),
+            ]
+        }
+    }
+
+    fn linux_icon_dir() -> PathBuf {
+        std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_default()
+            .join(".local/share/icons/hicolor/32x32/apps")
+    }
+
+    /// Write embedded ICOs as PNGs to the user's hicolor theme dir so SNI
+    /// hosts (GNOME AppIndicator, KDE tray, etc.) can render them by name.
+    fn ensure_themed_icons() {
+        let dir = linux_icon_dir();
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            tracing::warn!("tray: cannot create icon dir {:?}: {e}", dir);
+            return;
+        }
+
+        let icons: &[(&str, &[u8])] = &[
+            ("vigil-tray-green.png", TRAY_GREEN_ICO),
+            ("vigil-tray-orange.png", TRAY_ORANGE_ICO),
+            ("vigil-tray-red.png", TRAY_RED_ICO),
+        ];
+
+        for &(name, ico_bytes) in icons {
+            let path = dir.join(name);
+            if path.exists() {
+                continue;
+            }
+            match image::load_from_memory_with_format(ico_bytes, image::ImageFormat::Ico) {
+                Ok(img) => {
+                    let img = img.resize_exact(32, 32, image::imageops::FilterType::Lanczos3);
+                    if let Err(e) = img.save(&path) {
+                        tracing::warn!("tray: failed to write {:?}: {e}", path);
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("tray: failed to decode icon {name}: {e}");
+                }
+            }
+        }
+    }
+
+    pub fn run(
+        cmd_rx: Receiver<TrayCmd>,
+        show_window: Arc<AtomicBool>,
+        log_dir: PathBuf,
+        pending_nav: Arc<Mutex<Option<ConnInfo>>>,
+        egui_ctx: Arc<OnceLock<egui::Context>>,
+    ) {
+        // No display → no SNI host. Skip the tray, still deliver notifications.
+        let has_display = std::env::var("DISPLAY").is_ok()
+            || std::env::var("WAYLAND_DISPLAY").is_ok();
+        let is_root = unsafe { libc::geteuid() == 0 };
+        if !has_display || is_root {
+            tracing::info!(
+                "system tray skipped ({})",
+                if is_root { "running as root" } else { "no display" }
+            );
+            notification_only_loop(cmd_rx, show_window, pending_nav);
+            return;
+        }
+
+        ensure_themed_icons();
+
+        let tray = VigilTray {
+            state: IconState::Ok,
+            show_window: show_window.clone(),
+            log_dir,
+            egui_ctx,
+        };
+
+        let handle: Handle<VigilTray> = match tray.spawn() {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::warn!("ksni tray init failed ({e}) — notifications only");
+                notification_only_loop(cmd_rx, show_window, pending_nav);
+                return;
+            }
+        };
+
+        let mut in_alert = false;
+        let mut in_lockdown = false;
+        let mut alert_since: Option<std::time::Instant> = None;
+        const ALERT_HOLD: std::time::Duration = std::time::Duration::from_secs(5);
+
+        let apply = |handle: &Handle<VigilTray>, in_alert: bool, in_lockdown: bool| {
+            let state = if in_lockdown {
+                IconState::Lockdown
+            } else if in_alert {
+                IconState::Alert
+            } else {
+                IconState::Ok
+            };
+            handle.update(move |t: &mut VigilTray| {
+                t.state = state;
+            });
+        };
+
+        loop {
+            while let Ok(cmd) = cmd_rx.try_recv() {
+                match cmd {
+                    TrayCmd::Alert(info) => {
+                        crate::notifier::send_alert(&info, show_window.clone(), pending_nav.clone());
+                        in_alert = true;
+                        alert_since = Some(std::time::Instant::now());
+                        apply(&handle, in_alert, in_lockdown);
+                    }
+                    TrayCmd::ResetOk => {
+                        // Hold the alert icon for ALERT_HOLD so the colour
+                        // change is noticeable.
+                        if alert_since.map_or(true, |t| t.elapsed() >= ALERT_HOLD) {
+                            in_alert = false;
+                            alert_since = None;
+                            apply(&handle, in_alert, in_lockdown);
+                        }
+                    }
+                    TrayCmd::SetLockdown(active) => {
+                        in_lockdown = active;
+                        apply(&handle, in_alert, in_lockdown);
+                    }
+                }
+            }
+
+            // Deferred ResetOk (holding period expired).
+            if let Some(t) = alert_since {
+                if t.elapsed() >= ALERT_HOLD && in_alert {
+                    in_alert = false;
+                    alert_since = None;
+                    apply(&handle, in_alert, in_lockdown);
+                }
+            }
+
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn embedded_tray_icons_decode() {
-        assert!(icon_from_embedded_ico("green-test", TRAY_GREEN_ICO).is_some());
-        assert!(icon_from_embedded_ico("orange-test", TRAY_ORANGE_ICO).is_some());
-        assert!(icon_from_embedded_ico("red-test", TRAY_RED_ICO).is_some());
-    }
-}
+pub use imp::run;


### PR DESCRIPTION
## Summary
- **Alert #1 (glib < 0.20)** — Replaced the Linux tray's `libappindicator`/gtk3 stack with [`ksni`](https://crates.io/crates/ksni), a pure-Rust StatusNotifierItem client over zbus. gtk3 is upstream-unmaintained and pinned glib to 0.18, so there was no path forward on that stack. ksni implements the same D-Bus spec (same tray host, same pixels rendered), using themed icon names `vigil-tray-{green,orange,red}` already written to `~/.local/share/icons/hicolor/32x32/apps/`.
- **Alert #2 (maxminddb < 0.27)** — Bumped to 0.27 and adapted `geoip.rs` to the new `Reader::lookup` → `LookupResult::decode::<T>()` API. `geoip2::City.country` is now a direct value (no `Option`).
- **Alert #3 (rand < 0.9.3)** — `egui_extras` was declared in `Cargo.toml` but never imported anywhere in `src/`. Removing it killed the whole `egui_extras → mime_guess2 → phf_macros → phf_generator → rand` build-time chain. All six of those crates are gone from `Cargo.lock`.

No dismissals needed — every vulnerable crate is fully out of the tree.

## Test plan
- [x] `cargo check` on Windows — clean
- [x] `cargo test --bin vigil` — 57 passed
- [x] `cargo tree --target x86_64-unknown-linux-gnu` — no gtk, glib, libappindicator, rand, phf*, mime_guess2, egui_extras
- [ ] Verify on a real Linux box: `cargo check` + launch tray, confirm ksni icon shows in GNOME/KDE tray host, menu items work (Open Vigil / Open Logs Folder / Quit), alert/lockdown icon transitions look right (cross-compile from the Windows host used for this PR needs a `x86_64-linux-gnu-gcc`, which wasn't available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)