### PR TITLE
Fix CI secret-exfiltration risk in Snyk workflow

### DIFF
--- a/.github/workflows/snyk-open-source.yml
+++ b/.github/workflows/snyk-open-source.yml
@@ -5,8 +5,6 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
-  pull_request_review:
-    types: [submitted]
   schedule:
     - cron: '0 4 * * 1'
   workflow_dispatch:
@@ -16,7 +14,7 @@ permissions:
 
 jobs:
   sbom-scan:
-    if: (github.event_name != 'pull_request_review' || github.event.review.state == 'approved') && secrets.SNYK_TOKEN != ''
+    if: secrets.SNYK_TOKEN != ''
     name: Snyk OSS SBOM scan
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
### Motivation
- Prevent a secrets-enabled job from running on reviewer-submitted PR content by removing the `pull_request_review` trigger that allowed approved PRs to execute repository-controlled code with `SNYK_TOKEN` access.

### Description
- Removed the `pull_request_review` event from `.github/workflows/snyk-open-source.yml` and simplified the job `if` condition to `secrets.SNYK_TOKEN != ''`, preserving scans on `push`, `pull_request`, `schedule`, and `workflow_dispatch` while eliminating the review-triggered secret-exposure path.

### Testing
- Verified the modified workflow parses with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/snyk-open-source.yml'); puts 'ok'"`, reviewed the `git diff`, and committed the change; these commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e663fe30b88328a4aaac35b89694c7)