### PR TITLE
Pin OSSF Scorecard workflow actions to immutable SHAs

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -29,18 +29,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload SARIF to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
### Motivation
- The OSSF Scorecard workflow ` .github/workflows/ossf-scorecard.yml` used mutable action tags while the job granted `id-token: write` and `security-events: write`, creating a supply-chain risk if a tag is retargeted.

### Description
- Replaced mutable action tags in ` .github/workflows/ossf-scorecard.yml` with immutable commit SHAs for `actions/checkout` (`08c6903cd8c0fde910a37f88322edcfb5dd907a8`), `ossf/scorecard-action` (`4eaacf0543bb3f2c246792bd56e8cdeffafb205a`), and `github/codeql-action/upload-sarif` (`ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a`), preserving the original tag/version as a comment.
- This is a minimal change that preserves the workflow’s behavior while removing mutable-tag trust from a job with elevated permissions.

### Testing
- Ran a whitespace/format check on the modified workflow file and it reported no issues (success).
- Verified the workflow file was updated to reference the specified SHAs and includes the version comments (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e664b2f07c83288553cc58ba185a10)