### PR TITLE
Harden break-glass task creation for untrusted executable paths

### DIFF
--- a/src/break_glass.rs
+++ b/src/break_glass.rs
@@ -223,12 +223,10 @@ mod platform {
                 format!("failed to create recovery task as SYSTEM and as current user: {err}")
             })
         } else {
-            create_user_task(name, &command, &start).map_err(|err| {
-                format!(
-                    "refusing SYSTEM task for untrusted executable path ({}); failed to create current-user recovery task: {err}",
-                    exe.display()
-                )
-            })
+            Err(format!(
+                "refusing recovery task creation for untrusted executable path ({})",
+                exe.display()
+            ))
         }
     }
     fn create_system_task(name: &str, command: &str, start: &str) -> Result<(), String> {


### PR DESCRIPTION
### Motivation
- Prevent local privilege escalation introduced by scheduling a current-user recovery task that runs an executable from untrusted, user-writable locations.

### Description
- Changed `create_recovery_task` in `src/break_glass.rs` to return an error for untrusted executable paths instead of falling back to calling `create_user_task`.
- Preserved the existing trusted-path behavior where a SYSTEM task is preferred via `create_system_task` and a current-user task is only attempted if SYSTEM creation fails.
- Updated the error message to clearly indicate refusal to create recovery tasks for untrusted executable paths.

### Testing
- Ran `cargo fmt --all`, which completed successfully.
- Ran `cargo test`, which failed to build in this Linux environment due to upstream/platform build issues in the `winit` dependency unrelated to this change (platform unsupported errors), so no test failures attributable to this patch were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e4acfe842483289fdb6033223e78e5)