### PR TITLE
Harden non-Windows command execution against PATH hijacking

### DIFF
--- a/src/active_response.rs
+++ b/src/active_response.rs
@@ -2344,6 +2344,7 @@ mod platform {
 #[cfg(not(windows))]
 mod platform {
     use super::*;
+    use std::path::Path;
     use std::process::Stdio;
     pub struct AutorunRevertResult {
         pub removed_additions: usize,
@@ -2389,11 +2390,12 @@ mod platform {
         if pid == 0 {
             return false;
         }
-        Command::new("kill")
-            .args(["-0", &pid.to_string()])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
+        command_base("kill", &["-0", &pid.to_string()])
+            .and_then(|mut cmd| {
+                cmd.stdout(Stdio::null()).stderr(Stdio::null());
+                cmd.status()
+                    .map_err(|e| format!("failed to spawn kill: {e}"))
+            })
             .map(|status| status.success())
             .unwrap_or(false)
     }
@@ -2925,8 +2927,7 @@ mod platform {
     // ── Command helpers ────────────────────────────────────────────────────
 
     fn command_stdout(program: &str, args: &[&str]) -> Result<String, String> {
-        let output = Command::new(program)
-            .args(args)
+        let output = command_base(program, args)?
             .output()
             .map_err(|e| format!("failed to spawn {program}: {e}"))?;
         if output.status.success() {
@@ -2939,8 +2940,7 @@ mod platform {
         }
     }
     fn command_status(program: &str, args: &[&str]) -> Result<(), String> {
-        let status = Command::new(program)
-            .args(args)
+        let status = command_base(program, args)?
             .status()
             .map_err(|e| format!("failed to spawn {program}: {e}"))?;
         if status.success() {
@@ -2948,6 +2948,29 @@ mod platform {
         } else {
             Err(format!("{program} failed with status {status}"))
         }
+    }
+    fn command_base(program: &str, args: &[&str]) -> Result<Command, String> {
+        let resolved = resolve_program_path(program)?;
+        let mut cmd = Command::new(resolved);
+        cmd.args(args);
+        Ok(cmd)
+    }
+    fn resolve_program_path(program: &str) -> Result<&'static str, String> {
+        let candidates: &[&str] = match program {
+            "kill" => &["/bin/kill", "/usr/bin/kill"],
+            #[cfg(target_os = "linux")]
+            "iptables" => &["/usr/sbin/iptables", "/sbin/iptables"],
+            #[cfg(target_os = "linux")]
+            "ip" => &["/usr/sbin/ip", "/sbin/ip"],
+            #[cfg(target_os = "macos")]
+            "ifconfig" => &["/sbin/ifconfig"],
+            _ => &[],
+        };
+        candidates
+            .iter()
+            .copied()
+            .find(|path| Path::new(path).exists())
+            .ok_or_else(|| format!("required system binary for {program} not found"))
     }
 
     #[cfg(target_os = "linux")]

--- a/src/break_glass.rs
+++ b/src/break_glass.rs
@@ -356,6 +356,7 @@ mod platform {
     #[cfg(target_os = "linux")]
     mod imp {
         use std::io::Write;
+        use std::path::Path;
         use std::process::{Command, Stdio};
         const CRON_MARKER: &str = "# Vigil Break Glass Recovery";
         pub fn task_exists() -> bool {
@@ -389,7 +390,7 @@ mod platform {
             ))
         }
         fn read_crontab() -> Result<String, String> {
-            let output = Command::new("crontab")
+            let output = Command::new(crontab_path()?)
                 .arg("-l")
                 .output()
                 .map_err(|e| format!("failed to spawn crontab -l: {e}"))?;
@@ -405,7 +406,7 @@ mod platform {
             }
         }
         fn write_crontab(content: &str) -> Result<(), String> {
-            let mut child = Command::new("crontab")
+            let mut child = Command::new(crontab_path()?)
                 .arg("-")
                 .stdin(Stdio::piped())
                 .stdout(Stdio::null())
@@ -434,6 +435,12 @@ mod platform {
                 ))
             }
         }
+        fn crontab_path() -> Result<&'static str, String> {
+            ["/usr/bin/crontab", "/bin/crontab"]
+                .into_iter()
+                .find(|path| Path::new(path).exists())
+                .ok_or_else(|| "required system binary for crontab not found".to_string())
+        }
     }
     #[cfg(target_os = "macos")]
     mod imp {
@@ -449,10 +456,10 @@ mod platform {
             let plist = format!("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n  <key>Label</key>\n  <string>{PLIST_LABEL}</string>\n  <key>ProgramArguments</key>\n  <array>\n    <string>{}</string>\n    <string>--break-glass-recover</string>\n  </array>\n  <key>RunAtLoad</key>\n  <true/>\n  <key>StartInterval</key>\n  <integer>60</integer>\n</dict>\n</plist>\n", xml_escape(&exe.display().to_string()));
             std::fs::write(plist_path(), plist)
                 .map_err(|e| format!("failed to write launchd plist: {e}"))?;
-            let _ = Command::new("launchctl")
+            let _ = Command::new("/bin/launchctl")
                 .args(["bootout", "system", plist_path().to_string_lossy().as_ref()])
                 .status();
-            let status = Command::new("launchctl")
+            let status = Command::new("/bin/launchctl")
                 .args([
                     "bootstrap",
                     "system",
@@ -467,7 +474,7 @@ mod platform {
             }
         }
         pub fn delete_recovery_task() -> Result<(), String> {
-            let _ = Command::new("launchctl")
+            let _ = Command::new("/bin/launchctl")
                 .args(["bootout", "system", plist_path().to_string_lossy().as_ref()])
                 .status();
             if plist_path().exists() {


### PR DESCRIPTION
### Motivation
- Close a PATH-hijack privilege-escalation vector where non-Windows isolation and break-glass flows executed system tools by bare name (e.g., `kill`, `ip`, `ifconfig`, `crontab`, `launchctl`) and thus relied on the inherited `PATH` when running elevated.
- Ensure privileged operations spawn trusted system binaries to prevent a local attacker from placing malicious binaries earlier in `PATH` and obtaining elevated execution.

### Description
- Centralised command spawning on non-Windows into `command_base` / `resolve_program_path` in `src/active_response.rs` and updated helpers (`command_stdout`, `command_status`, `process_exists`) to use resolved absolute paths instead of `Command::new(program)`.
- The resolver maps known tools to explicit system locations (examples: `kill` -> `/bin/kill`, `ip` -> `/usr/sbin/ip` or `/sbin/ip`, `iptables` -> `/usr/sbin/iptables` or `/sbin/iptables`, `ifconfig` -> `/sbin/ifconfig`) and verifies the candidate exists before spawning.
- Linux break-glass cron management now resolves `crontab` via a `crontab_path()` lookup (`/usr/bin/crontab`, `/bin/crontab`) instead of invoking the bare `crontab` name, and macOS break-glass now invokes `/bin/launchctl` explicitly.
- Minor formatting/whitespace cleanups around the modified call sites.

### Testing
- Ran `cargo fmt` successfully to normalise formatting.
- Attempted `cargo check` but it failed in this environment due to network/crates.io access errors (HTTP 403 while fetching dependencies), so full build/type-check could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e67a042a84832897054048309b04db)