### PR TITLE
[codex] Improve security policy and dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,15 @@
 # Security Policy
 
-If you believe you have found a security issue in Vigil, please report it privately by opening a security advisory on GitHub or by contacting the maintainers through the repository's private security channel.
+If you believe you have found a security issue in Vigil, please report it privately through GitHub Security Advisories:
+
+https://github.com/YMRYMR/vigil/security/advisories/new
 
 Please include:
 - a clear description of the issue
 - affected version(s)
 - proof of concept or reproduction steps
 - whether the issue affects Windows, Linux, macOS, or all three
+
+We aim to acknowledge reports within 7 days and provide a remediation or disclosure plan within 90 days, unless the issue is already fixed or the reporter agrees to a shorter timeline.
 
 We will treat confirmed vulnerabilities as confidential until a fix is prepared and released.


### PR DESCRIPTION
## Summary

This PR tightens the repository security posture by improving the security policy wording and adding Dependabot for Cargo and GitHub Actions.

## Changes

- Added an explicit private vulnerability reporting link in SECURITY.md.
- Added a 7-day acknowledgement / 90-day remediation target.
- Added Dependabot config for Cargo and GitHub Actions updates.

## Why

These are the remaining repo-side Scorecard items that are actually fixable in-tree.