### PR TITLE
[codex] Add fuzzing scaffold for Scorecard

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,4 +1,5 @@
 FROM gcr.io/oss-fuzz-base/base-builder-rust@sha256:3c12963ef23680ef20a9347eb3e1efbd57cd7aa9ddf885ae59dc117fc481edf0
 
 COPY . $SRC/vigil
+COPY .clusterfuzzlite/build.sh /src/build.sh
 WORKDIR $SRC/vigil

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/oss-fuzz-base/base-builder-rust
+FROM gcr.io/oss-fuzz-base/base-builder-rust@sha256:3c12963ef23680ef20a9347eb3e1efbd57cd7aa9ddf885ae59dc117fc481edf0
 
 COPY . $SRC/vigil
 WORKDIR $SRC/vigil

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,4 @@
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+
+COPY . $SRC/vigil
+WORKDIR $SRC/vigil

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euxo pipefail
+
+cd "$SRC/vigil"
+cargo fuzz build -O parse_client_hello
+cp "fuzz/target/x86_64-unknown-linux-gnu/release/parse_client_hello" "$OUT/"

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: rust

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -2,7 +2,6 @@ name: ClusterFuzzLite PR fuzzing
 
 on:
   pull_request:
-    branches: [master]
 
 permissions: read-all
 

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -18,6 +18,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Build fuzzers
+        uses: google/clusterfuzzlite/actions/build_fuzzers@82652fb49e77bc29c35da1167bb286e93c6bcc05 # v1
+        with:
+          language: rust
+          sanitizer: address
+
       - name: Run ClusterFuzzLite fuzzers
         uses: google/clusterfuzzlite/actions/run_fuzzers@82652fb49e77bc29c35da1167bb286e93c6bcc05 # v1
         with:

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,28 @@
+name: ClusterFuzzLite PR fuzzing
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions: read-all
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run ClusterFuzzLite fuzzers
+        uses: google/clusterfuzzlite/actions/run_fuzzers@82652fb49e77bc29c35da1167bb286e93c6bcc05 # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 300
+          mode: code-change
+          sanitizer: address
+          language: rust

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,8 @@ report bugs, propose features, and submit pull requests.
 5. [Pull request process](#pull-request-process)
 6. [Coding style](#coding-style)
 7. [Testing requirements](#testing-requirements)
-8. [Platform notes](#platform-notes)
+8. [Fuzzing](#fuzzing)
+9. [Platform notes](#platform-notes)
 
 ---
 
@@ -149,6 +150,21 @@ Run the full suite with:
 ```sh
 cargo test
 ```
+
+## Fuzzing
+
+Vigil keeps a small continuous fuzzing setup for parser-style code paths.
+The current fuzz target exercises the TLS ClientHello parser used by the
+monitoring stack.
+
+To run it locally:
+
+```sh
+cd fuzz
+cargo fuzz run parse_client_hello
+```
+
+Pull requests are fuzzed in CI through ClusterFuzzLite.
 
 ---
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euxo pipefail
+
+exec "$(dirname "$0")/.clusterfuzzlite/build.sh"

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euxo pipefail
 
-exec "$(dirname "$0")/.clusterfuzzlite/build.sh"
+exec /src/vigil/.clusterfuzzlite/build.sh

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 [package.metadata]
 cargo-fuzz = true
 
+[workspace]
+
 [dependencies]
 libfuzzer-sys = "0.4"
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "vigil-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[[bin]]
+name = "parse_client_hello"
+path = "fuzz_targets/parse_client_hello.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/parse_client_hello.rs
+++ b/fuzz/fuzz_targets/parse_client_hello.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+#[path = "../../src/tls.rs"]
+mod tls;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = tls::parse_client_hello(data);
+});


### PR DESCRIPTION
Adds a minimal ClusterFuzzLite setup and a Rust libFuzzer target for the TLS ClientHello parser so the repo has real fuzzing coverage and can move the OpenSSF Scorecard Fuzzing check.

Scope:
- .github/workflows/cflite_pr.yml
- .clusterfuzzlite/{project.yaml,Dockerfile,build.sh}
- fuzz/ cargo-fuzz target for src/tls.rs
- CONTRIBUTING.md local fuzzing instructions
- .gitattributes for LF shell scripts