### PR TITLE
Fix private SLSA release provenance

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,32 @@
+name: Publish Crate
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish crate to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+
+      - name: Verify registry token
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          if [ -z "$CARGO_REGISTRY_TOKEN" ]; then
+            echo "CARGO_REGISTRY_TOKEN is not configured."
+            exit 1
+          fi
+
+      - name: Publish crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked --token "$CARGO_REGISTRY_TOKEN"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,7 +268,8 @@ jobs:
       actions: read
       contents: write
       id-token: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ needs.publish.outputs.hashes }}
       upload-assets: true
+      private-repository: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3836,7 +3836,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vigil"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "auto-launch",
  "aya",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3836,7 +3836,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vigil"
-version = "1.3.3"
+version = "1.3.4"
 dependencies = [
  "auto-launch",
  "aya",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "vigil"
-version     = "1.3.3"
+version     = "1.3.4"
 edition     = "2021"
 description = "Real-time network threat monitor"
 license     = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "vigil"
-version     = "1.3.4"
+version     = "1.3.5"
 edition     = "2021"
 description = "Real-time network threat monitor"
 license     = "MIT"


### PR DESCRIPTION
- switch the SLSA reusable workflow to the documented tagged release
- enable private repository mode so provenance generation doesn't halt on the repo privacy check

This is intended to unblock the release job so the signed release/provenance step can complete.