### PR TITLE
Preserve Linux tray and admin relaunch follow-ups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ installer/windows/logs/
 # Generated icon assets (produced by build.rs from programmatic code)
 assets/vigil.ico
 assets/vigil.png
+installer/linux/output/
+installer/windows/output/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ eframe = { version = "0.34", default-features = false, features = ["default_font
 aya = "0.13"
 bytes = "1"
 libc = "0.2"
-ksni = { version = "0.3", default-features = false, features = ["blocking"] }
+ksni = { version = "0.3", features = ["blocking"] }
 
 [target.'cfg(target_os = "linux")'.build-dependencies]
 

--- a/src/autostart.rs
+++ b/src/autostart.rs
@@ -237,7 +237,14 @@ mod platform {
     }
 
     pub fn is_elevated() -> bool {
-        false
+        #[cfg(target_os = "linux")]
+        unsafe {
+            libc::geteuid() == 0
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            false
+        }
     }
 
     pub fn relaunch_as_admin() -> Result<(), String> {

--- a/src/autostart.rs
+++ b/src/autostart.rs
@@ -248,6 +248,53 @@ mod platform {
     }
 
     pub fn relaunch_as_admin() -> Result<(), String> {
-        Err("Elevation is only supported on Windows.".into())
+        #[cfg(target_os = "linux")]
+        {
+            use std::process::Command;
+
+            let exe = std::env::current_exe()
+                .map_err(|e| format!("failed to locate Vigil: {e}"))?;
+
+            // pkexec ships with polkit on every mainstream desktop Linux and
+            // produces a GUI authentication dialog. Without preserving the
+            // display/session env vars the elevated child can't reach the
+            // compositor, so we pass them explicitly via `env`.
+            let mut keep: Vec<String> = Vec::new();
+            for var in [
+                "DISPLAY",
+                "WAYLAND_DISPLAY",
+                "XAUTHORITY",
+                "XDG_RUNTIME_DIR",
+                "XDG_SESSION_TYPE",
+                "DBUS_SESSION_BUS_ADDRESS",
+                "HOME",
+            ] {
+                if let Some(val) = std::env::var_os(var) {
+                    keep.push(format!("{}={}", var, val.to_string_lossy()));
+                }
+            }
+
+            let args: Vec<std::ffi::OsString> = std::env::args_os().skip(1).collect();
+
+            let spawned = Command::new("pkexec")
+                .arg("env")
+                .args(&keep)
+                .arg(&exe)
+                .args(&args)
+                .spawn();
+
+            match spawned {
+                Ok(_) => Ok(()),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(
+                    "pkexec not found — install policykit-1 / polkit to relaunch as admin."
+                        .into(),
+                ),
+                Err(e) => Err(format!("pkexec failed to start: {e}")),
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            Err("Elevation is only supported on Windows and Linux.".into())
+        }
     }
 }

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -384,7 +384,8 @@ mod imp {
     use super::*;
     use ksni::blocking::TrayMethods;
     use ksni::menu::{MenuItem as KsniMenuItem, StandardItem};
-    use ksni::{Handle, Tray};
+    use ksni::blocking::Handle;
+    use ksni::Tray;
     use std::sync::atomic::Ordering;
 
     #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -427,6 +427,19 @@ mod imp {
         fn wake_ui(&self) {
             self.show_window.store(true, Ordering::Relaxed);
             if let Some(ec) = self.egui_ctx.get() {
+                // Send the viewport commands from *this* thread so they land
+                // in winit's event queue even while the window is minimized —
+                // a plain request_repaint() on an iconified window on
+                // Wayland/GNOME doesn't wake the render loop.
+                ec.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
+                ec.send_viewport_cmd(egui::ViewportCommand::Visible(true));
+                ec.send_viewport_cmd(egui::ViewportCommand::Focus);
+                ec.send_viewport_cmd(egui::ViewportCommand::WindowLevel(
+                    egui::WindowLevel::AlwaysOnTop,
+                ));
+                ec.send_viewport_cmd(egui::ViewportCommand::WindowLevel(
+                    egui::WindowLevel::Normal,
+                ));
                 ec.request_repaint();
             }
         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -765,7 +765,7 @@ impl VigilApp {
 
                 if admin {
                     admin_chip(ui);
-                } else if cfg!(windows) {
+                } else {
                     let relaunch = ui
                         .add(admin_btn("Run as Admin"))
                         .on_hover_cursor(egui::CursorIcon::PointingHand)

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -765,7 +765,7 @@ impl VigilApp {
 
                 if admin {
                     admin_chip(ui);
-                } else {
+                } else if cfg!(windows) {
                     let relaunch = ui
                         .add(admin_btn("Run as Admin"))
                         .on_hover_cursor(egui::CursorIcon::PointingHand)
@@ -916,6 +916,19 @@ impl eframe::App for VigilApp {
             ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
             ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
             ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
+            // Linux winit often ignores plain Focus on hidden/iconified windows
+            // under Wayland/GNOME; forcing an outer-position nudge and a repaint
+            // reliably brings the surface back in front.
+            #[cfg(target_os = "linux")]
+            {
+                ctx.send_viewport_cmd(egui::ViewportCommand::WindowLevel(
+                    egui::WindowLevel::AlwaysOnTop,
+                ));
+                ctx.send_viewport_cmd(egui::ViewportCommand::WindowLevel(
+                    egui::WindowLevel::Normal,
+                ));
+                ctx.request_repaint();
+            }
         }
         if let Some(nav) = self.pending_nav.lock().unwrap().take() {
             ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
@@ -937,6 +950,12 @@ impl eframe::App for VigilApp {
             );
         }
         if ctx.input(|i| i.viewport().close_requested()) && !self.exit_requested {
+            // On Linux, `Visible(false)` is unreliable under Wayland/GNOME —
+            // the window stays on screen and the close appears to do nothing.
+            // Minimizing to the tray is the robust equivalent.
+            #[cfg(target_os = "linux")]
+            ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(true));
+            #[cfg(not(target_os = "linux"))]
             ctx.send_viewport_cmd(egui::ViewportCommand::Visible(false));
             ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose);
         }


### PR DESCRIPTION
## Why
This branch still contains Linux-specific desktop follow-up work that is not currently represented by an open pull request.

## Included
- support Linux admin relaunch through `pkexec`
- improve Linux tray/window restore behavior under Wayland/GNOME
- align `ksni` usage with the blocking handle API
- ignore local installer output directories

## Preservation note
This draft PR is being opened to preserve the remaining branch-only work during branch cleanup review. It has not been freshly validated in this maintenance pass.