### PR TITLE
Add Phase 15 integrity sidecars for rules and blocklists

### DIFF
--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -4,13 +4,16 @@
 //! (AbuseIPDB, Shodan, VirusTotal) are deferred — they require API keys and
 //! a network round-trip per check.  A static blocklist is almost as useful:
 //! users can subscribe to community feeds (FireHOL, Emerging Threats,
-//! AbuseIPDB daily dumps) and drop them into `%LOCALAPPDATA%\Vigil\blocklists\`
+//! AbuseIPDB daily dumps) and drop them into `%LOCALAPPDATA%\\Vigil\\blocklists\\`
 //! then list the paths in `blocklist_paths` in `vigil.json`.
 //!
 //! ## File format
 //! - One IP (v4 or v6) or CIDR per line.
 //! - `#` to end-of-line is a comment.
 //! - Blank lines are ignored.
+//! - Optional integrity sidecar: place `<blocklist>.sha256` beside the file,
+//!   containing a SHA-256 digest in standard `sha256sum` format. If present,
+//!   Vigil verifies it before parsing and fails closed on mismatch.
 //!
 //! Example `abuseipdb.txt`:
 //! ```text
@@ -20,6 +23,7 @@
 //! 2001:db8::/32      # Research net
 //! ```
 
+use crate::security::integrity;
 use ipnetwork::IpNetwork;
 use std::net::IpAddr;
 use std::path::Path;
@@ -43,10 +47,24 @@ impl Blocklist {
             "blocklist",
             path,
         );
-        let raw = match std::fs::read_to_string(path) {
-            Ok(s) => s,
+        let raw = match integrity::read_verified_to_string(path, "blocklist") {
+            Ok((text, integrity::VerificationStatus::Verified { sidecar })) => {
+                tracing::info!(
+                    "verified blocklist {} with sidecar {}",
+                    path.display(),
+                    sidecar.display()
+                );
+                text
+            }
+            Ok((text, integrity::VerificationStatus::Unsigned)) => {
+                tracing::warn!(
+                    "blocklist {} has no SHA-256 sidecar; loading as legacy unsigned input",
+                    path.display()
+                );
+                text
+            }
             Err(e) => {
-                tracing::warn!("failed to read blocklist {}: {e}", path.display());
+                tracing::warn!("refusing blocklist {}: {e}", path.display());
                 return None;
             }
         };
@@ -170,6 +188,7 @@ pub fn stats() -> (usize, usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sha2::{Digest, Sha256};
     use std::io::Write;
 
     fn mktmp(content: &str, name: &str) -> std::path::PathBuf {
@@ -178,6 +197,25 @@ mod tests {
         let mut f = std::fs::File::create(&p).unwrap();
         f.write_all(content.as_bytes()).unwrap();
         p
+    }
+
+    fn write_sidecar(path: &Path, content: &str) {
+        let digest = Sha256::digest(content.as_bytes());
+        std::fs::write(
+            integrity::sidecar_path(path),
+            format!("{}  {}\n", hex(&digest), path.file_name().unwrap().to_string_lossy()),
+        )
+        .unwrap();
+    }
+
+    fn hex(bytes: &[u8]) -> String {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut out = String::with_capacity(bytes.len() * 2);
+        for &byte in bytes {
+            out.push(HEX[(byte >> 4) as usize] as char);
+            out.push(HEX[(byte & 0x0f) as usize] as char);
+        }
+        out
     }
 
     #[test]
@@ -211,5 +249,25 @@ mod tests {
         let hit = eng.lookup("1.2.3.4").unwrap();
         // Stem is something like "vigil_bl_test_<pid>_source"
         assert!(hit.contains("source"));
+    }
+
+    #[test]
+    fn verified_sidecar_is_accepted() {
+        let content = "203.0.113.4\n";
+        let p = mktmp(content, "signed");
+        write_sidecar(&p, content);
+        let eng = BlocklistEngine::load(&[p.to_string_lossy().into_owned()]);
+        assert!(eng.lookup("203.0.113.4").is_some());
+        let _ = std::fs::remove_file(integrity::sidecar_path(&p));
+    }
+
+    #[test]
+    fn bad_sidecar_rejects_blocklist() {
+        let p = mktmp("203.0.113.5\n", "tampered");
+        write_sidecar(&p, "198.51.100.9\n");
+        let eng = BlocklistEngine::load(&[p.to_string_lossy().into_owned()]);
+        assert_eq!(eng.list_count(), 0);
+        assert!(eng.lookup("203.0.113.5").is_none());
+        let _ = std::fs::remove_file(integrity::sidecar_path(&p));
     }
 }

--- a/src/security/integrity.rs
+++ b/src/security/integrity.rs
@@ -1,0 +1,211 @@
+//! File integrity helpers for operator-managed inputs.
+//!
+//! Phase 15 extends Vigil's tamper-evidence beyond `vigil.json` by letting
+//! security-sensitive companion files carry a simple SHA-256 sidecar.  The
+//! sidecar format is intentionally compatible with common `sha256sum` output:
+//!
+//! ```text
+//! <64 hex chars>  optional-filename
+//! ```
+//!
+//! Files without a sidecar are still loaded for backward compatibility, but a
+//! sidecar mismatch is treated as untrusted input and fails closed.
+
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const HASH_HEX_LEN: usize = 64;
+const SIDECAR_SUFFIX: &str = "sha256";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerificationStatus {
+    Verified { sidecar: PathBuf },
+    Unsigned,
+}
+
+/// Read a file and verify it against `<filename>.sha256` when that sidecar is
+/// present. Missing sidecars are allowed so existing deployments keep working;
+/// malformed sidecars or digest mismatches are hard failures.
+pub fn read_verified(path: &Path, purpose: &str) -> Result<(Vec<u8>, VerificationStatus), String> {
+    let data = fs::read(path).map_err(|e| format!("failed to read {purpose} {}: {e}", path.display()))?;
+    let sidecar = sidecar_path(path);
+    match fs::symlink_metadata(&sidecar) {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok((data, VerificationStatus::Unsigned));
+        }
+        Err(e) => {
+            return Err(format!(
+                "failed to access integrity sidecar {}: {e}",
+                sidecar.display()
+            ));
+        }
+    }
+
+    let expected = read_sidecar_hash(&sidecar)?;
+    let actual = sha256_hex(&data);
+    if !actual.eq_ignore_ascii_case(&expected) {
+        return Err(format!(
+            "{purpose} {} failed SHA-256 verification: expected {expected}, got {actual}",
+            path.display()
+        ));
+    }
+
+    Ok((data, VerificationStatus::Verified { sidecar }))
+}
+
+pub fn read_verified_to_string(path: &Path, purpose: &str) -> Result<(String, VerificationStatus), String> {
+    let (data, status) = read_verified(path, purpose)?;
+    let text = String::from_utf8(data)
+        .map_err(|e| format!("failed to decode {purpose} {} as UTF-8: {e}", path.display()))?;
+    Ok((text, status))
+}
+
+pub fn sidecar_path(path: &Path) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("integrity");
+    path.with_file_name(format!("{file_name}.{SIDECAR_SUFFIX}"))
+}
+
+fn read_sidecar_hash(path: &Path) -> Result<String, String> {
+    let metadata = fs::metadata(path)
+        .map_err(|e| format!("failed to stat integrity sidecar {}: {e}", path.display()))?;
+    if !metadata.is_file() {
+        return Err(format!(
+            "integrity sidecar {} is not a regular file",
+            path.display()
+        ));
+    }
+    let text = fs::read_to_string(path)
+        .map_err(|e| format!("failed to read integrity sidecar {}: {e}", path.display()))?;
+    let candidate = text
+        .split_whitespace()
+        .next()
+        .ok_or_else(|| format!("integrity sidecar {} is empty", path.display()))?;
+    if candidate.len() != HASH_HEX_LEN || !candidate.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(format!(
+            "integrity sidecar {} does not start with a 64-character SHA-256 hex digest",
+            path.display()
+        ));
+    }
+    Ok(candidate.to_ascii_lowercase())
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    let digest = Sha256::digest(data);
+    encode_hex(&digest)
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
+
+    #[test]
+    fn verified_sidecar_allows_matching_file() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("rules.yaml");
+        fs::write(&path, b"rules: []\n").unwrap();
+        fs::write(sidecar_path(&path), format!("{}  rules.yaml\n", sha256_hex(b"rules: []\n"))).unwrap();
+
+        let (text, status) = read_verified_to_string(&path, "rules").unwrap();
+        assert_eq!(text, "rules: []\n");
+        assert!(matches!(status, VerificationStatus::Verified { .. }));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn sidecar_mismatch_fails_closed() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("blocklist.txt");
+        fs::write(&path, b"1.2.3.4\n").unwrap();
+        fs::write(sidecar_path(&path), format!("{}  blocklist.txt\n", sha256_hex(b"5.6.7.8\n"))).unwrap();
+
+        let err = read_verified(&path, "blocklist").unwrap_err();
+        assert!(err.contains("failed SHA-256 verification"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn missing_sidecar_is_legacy_unsigned() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("legacy.txt");
+        fs::write(&path, b"legacy\n").unwrap();
+
+        let (_, status) = read_verified(&path, "legacy").unwrap();
+        assert_eq!(status, VerificationStatus::Unsigned);
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sidecar_metadata_errors_fail_closed() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("rules.yaml");
+        let sidecar = sidecar_path(&path);
+        fs::write(&path, b"rules: []\n").unwrap();
+        symlink(&sidecar, &sidecar).unwrap();
+
+        let err = read_verified(&path, "rules").unwrap_err();
+        assert!(err.contains("failed to read integrity sidecar"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dangling_sidecar_symlink_fails_closed() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("rules.yaml");
+        let sidecar = sidecar_path(&path);
+        let missing = dir.join("missing.sha256");
+        fs::write(&path, b"rules: []\n").unwrap();
+        symlink(&missing, &sidecar).unwrap();
+
+        let err = read_verified(&path, "rules").unwrap_err();
+        assert!(err.contains("failed to read integrity sidecar"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn directory_sidecar_fails_closed() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("rules.yaml");
+        let sidecar = sidecar_path(&path);
+        fs::write(&path, b"rules: []\n").unwrap();
+        fs::create_dir(&sidecar).unwrap();
+
+        let err = read_verified(&path, "rules").unwrap_err();
+        assert!(err.contains("is not a regular file"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    fn unique_temp_dir() -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("vigil-integrity-test-{nanos}"))
+    }
+}

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -1,6 +1,7 @@
 pub mod active_response;
 pub mod auto_response;
 pub mod file_quarantine;
+pub mod integrity;
 pub mod operator_provenance;
 pub mod policy;
 pub mod quarantine;

--- a/src/security/response_rules.rs
+++ b/src/security/response_rules.rs
@@ -3,22 +3,27 @@
 //! The rule file is optional and operator-controlled. Rules are evaluated in
 //! order; the first matching rule wins. Current actions intentionally reuse the
 //! existing active-response primitives so every action stays reversible and
-//! audited in the same way as the built-in controls.
+//! audited in the same way as the built-in controls. If `<rules-file>.sha256`
+//! exists beside the YAML file, Vigil verifies the SHA-256 digest before parsing
+//! and refuses tampered rule files.
 
 use crate::{
     active_response, audit,
     config::{normalise_name, Config},
+    security::integrity,
     types::ConnInfo,
 };
 use serde::Deserialize;
 use serde_json::json;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 #[derive(Debug, Default)]
 pub struct EngineState {
     cooldowns: HashMap<String, Instant>,
+    last_rule_load_error: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -71,7 +76,23 @@ pub fn maybe_apply(conn: &ConnInfo, cfg: &Config, state: &mut EngineState) -> Op
     {
         return None;
     }
-    let rules = load_rules(&cfg.response_rules_path).ok()?;
+    let rules = match load_rules(&cfg.response_rules_path) {
+        Ok(rules) => {
+            state.clear_rule_load_error();
+            rules
+        }
+        Err(err) => {
+            if !state.note_rule_load_error(&cfg.response_rules_path, &err) {
+                return None;
+            }
+            audit::record(
+                "response_rule",
+                "integrity_failure",
+                json!({"path": cfg.response_rules_path, "error": err}),
+            );
+            return Some(format!("Response rules unavailable: {err}"));
+        }
+    };
     let rule = rules.into_iter().find(|rule| matches_rule(rule, conn))?;
     let action = plan_action(&rule, conn)?;
     let cooldown = Duration::from_secs(cfg.auto_response_cooldown_secs.max(30));
@@ -111,15 +132,51 @@ pub fn maybe_apply(conn: &ConnInfo, cfg: &Config, state: &mut EngineState) -> Op
 
 fn load_rules(path: &str) -> Result<Vec<ResponseRule>, String> {
     let path_ref = Path::new(path);
+    #[cfg(not(test))]
     let _observation = crate::security::operator_provenance::observe_operator_file(
         "response_rules",
         path_ref,
     );
-    let text = std::fs::read_to_string(path_ref)
-        .map_err(|e| format!("failed to read rule file {path}: {e}"))?;
+    let (text, status) = integrity::read_verified_to_string(path_ref, "response rules")?;
+    match status {
+        integrity::VerificationStatus::Verified { sidecar } => {
+            info_verified_rules_once(path_ref, &sidecar)
+        }
+        integrity::VerificationStatus::Unsigned => warn_unsigned_rules_once(path_ref),
+    }
     let file: RuleFile = serde_yaml::from_str(&text)
         .map_err(|e| format!("failed to parse YAML rule file {path}: {e}"))?;
     Ok(file.rules)
+}
+
+fn info_verified_rules_once(path: &Path, sidecar: &Path) {
+    if note_logged_rule_path(&VERIFIED_RULE_PATHS, path) {
+        tracing::info!(
+            "verified response rules {} with sidecar {}",
+            path.display(),
+            sidecar.display()
+        );
+    }
+}
+
+fn warn_unsigned_rules_once(path: &Path) {
+    if !note_logged_rule_path(&WARNED_UNSIGNED_RULE_PATHS, path) {
+        return;
+    }
+    tracing::warn!("response rules {} loaded without a SHA-256 sidecar", path.display());
+}
+
+static VERIFIED_RULE_PATHS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+static WARNED_UNSIGNED_RULE_PATHS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+fn note_logged_rule_path(paths: &'static OnceLock<Mutex<HashSet<String>>>, path: &Path) -> bool {
+    let paths = paths.get_or_init(|| Mutex::new(HashSet::new()));
+    let Ok(mut paths) = paths.lock() else {
+        tracing::debug!("response rules logging cache unavailable for {}", path.display());
+        return false;
+    };
+    let path = path.display().to_string();
+    paths.insert(path)
 }
 
 fn matches_rule(rule: &ResponseRule, conn: &ConnInfo) -> bool {
@@ -281,5 +338,108 @@ impl EngineState {
         }
         self.cooldowns.insert(key, now);
         true
+    }
+
+    fn note_rule_load_error(&mut self, path: &str, err: &str) -> bool {
+        let key = format!("{path}:{err}");
+        if self.last_rule_load_error.as_deref() == Some(key.as_str()) {
+            return false;
+        }
+        self.last_rule_load_error = Some(key);
+        true
+    }
+
+    fn clear_rule_load_error(&mut self) {
+        self.last_rule_load_error = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha2::{Digest, Sha256};
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn signed_rule_file_loads() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("rules.yaml");
+        let yaml = "rules:\n  - name: high score\n    min_score: 9\n    action: block_remote\n";
+        fs::write(&path, yaml).unwrap();
+        write_sidecar(&path, yaml);
+
+        let rules = load_rules(&path.to_string_lossy()).unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].name, "high score");
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn tampered_signed_rule_file_is_rejected() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("rules.yaml");
+        let original = "rules: []\n";
+        fs::write(&path, original).unwrap();
+        write_sidecar(&path, original);
+        fs::write(&path, "rules:\n  - name: tampered\n").unwrap();
+
+        let err = load_rules(&path.to_string_lossy()).unwrap_err();
+        assert!(err.contains("failed SHA-256 verification"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn repeated_rule_paths_only_log_once() {
+        let path = Path::new("rules.yaml");
+        assert!(note_logged_rule_path(&VERIFIED_RULE_PATHS, path));
+        assert!(!note_logged_rule_path(&VERIFIED_RULE_PATHS, path));
+
+        let other = Path::new("unsigned.yaml");
+        assert!(note_logged_rule_path(&WARNED_UNSIGNED_RULE_PATHS, other));
+        assert!(!note_logged_rule_path(&WARNED_UNSIGNED_RULE_PATHS, other));
+    }
+
+    #[test]
+    fn repeated_rule_load_failures_are_reported_once_until_success() {
+        let mut state = EngineState::default();
+
+        assert!(state.note_rule_load_error("/tmp/rules.yaml", "signature mismatch"));
+        assert!(!state.note_rule_load_error("/tmp/rules.yaml", "signature mismatch"));
+        assert!(state.note_rule_load_error("/tmp/rules.yaml", "yaml parse failed"));
+
+        state.clear_rule_load_error();
+
+        assert!(state.note_rule_load_error("/tmp/rules.yaml", "signature mismatch"));
+    }
+
+    fn write_sidecar(path: &Path, content: &str) {
+        let digest = Sha256::digest(content.as_bytes());
+        fs::write(
+            integrity::sidecar_path(path),
+            format!("{}  {}\n", hex(&digest), path.file_name().unwrap().to_string_lossy()),
+        )
+        .unwrap();
+    }
+
+    fn hex(bytes: &[u8]) -> String {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut out = String::with_capacity(bytes.len() * 2);
+        for &byte in bytes {
+            out.push(HEX[(byte >> 4) as usize] as char);
+            out.push(HEX[(byte & 0x0f) as usize] as char);
+        }
+        out
+    }
+
+    fn unique_temp_dir() -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("vigil-response-rules-test-{nanos}"))
     }
 }


### PR DESCRIPTION
## Summary
- Adds a Phase 15 file-integrity helper that verifies optional `.sha256` sidecars in standard `sha256sum` format.
- Verifies response-rule YAML before parsing when a sidecar is present, failing closed on digest mismatch.
- Verifies blocklist files before parsing when a sidecar is present, refusing tampered reputation inputs while preserving legacy unsigned compatibility.
- Adds unit coverage for verified, unsigned legacy, and tampered sidecar paths.

## Security posture
- Fail-closed for files that provide a sidecar but fail verification.
- Backward-compatible warning-only path for existing unsigned operator-managed files so current deployments do not break unexpectedly.
- No network lookups or dynamic trust bootstrap added.

## Validation
- Inspected the roadmap and current architecture docs.
- Compared the branch against `master`; changed only `src/security/integrity.rs`, `src/security/mod.rs`, `src/blocklist.rs`, and `src/security/response_rules.rs`.
- I could not run the full Rust test suite locally because the execution environment could not clone/fetch GitHub-hosted code, so CI should run `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-targets --all-features` before merge.

## Follow-up
- Add a UI/operator workflow for generating sidecars.
- Extend integrity verification to caches, generated state, and forensic artifact manifests.