### PR TITLE
Protect response rules and blocklists with integrity checks

### DIFF
--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -38,8 +38,21 @@ struct Blocklist {
 
 impl Blocklist {
     fn load(path: &Path) -> Option<Self> {
-        let raw = match std::fs::read_to_string(path) {
-            Ok(s) => s,
+        let raw = match crate::security::policy::load_bytes_with_integrity(path, "blocklist") {
+            Ok(Some(bytes)) => match String::from_utf8(bytes) {
+                Ok(text) => text,
+                Err(e) => {
+                    tracing::warn!("blocklist {} is not valid UTF-8: {e}", path.display());
+                    return None;
+                }
+            },
+            Ok(None) => {
+                tracing::warn!(
+                    "blocklist {} failed integrity verification and no trusted backup was available",
+                    path.display()
+                );
+                return None;
+            }
             Err(e) => {
                 tracing::warn!("failed to read blocklist {}: {e}", path.display());
                 return None;
@@ -182,6 +195,7 @@ mod tests {
         assert!(eng.lookup("1.2.3.4").is_some());
         assert!(eng.lookup("185.220.101.1").is_some());
         assert!(eng.lookup("8.8.8.8").is_none());
+        let _ = cleanup_integrity_files(&p);
     }
 
     #[test]
@@ -190,6 +204,7 @@ mod tests {
         let eng = BlocklistEngine::load(&[p.to_string_lossy().into_owned()]);
         assert!(eng.lookup("10.1.2.3").is_some());
         assert!(eng.lookup("11.1.2.3").is_none());
+        let _ = cleanup_integrity_files(&p);
     }
 
     #[test]
@@ -197,6 +212,7 @@ mod tests {
         let p = mktmp("# comment\n\n 1.1.1.1 # trailing\n", "cmt");
         let eng = BlocklistEngine::load(&[p.to_string_lossy().into_owned()]);
         assert!(eng.lookup("1.1.1.1").is_some());
+        let _ = cleanup_integrity_files(&p);
     }
 
     #[test]
@@ -206,5 +222,38 @@ mod tests {
         let hit = eng.lookup("1.2.3.4").unwrap();
         // Stem is something like "vigil_bl_test_<pid>_source"
         assert!(hit.contains("source"));
+        let _ = cleanup_integrity_files(&p);
+    }
+
+    #[test]
+    fn tampered_blocklist_restores_last_signed_copy() {
+        let p = mktmp("203.0.113.10\n", "integrity");
+        let eng = BlocklistEngine::load(&[p.to_string_lossy().into_owned()]);
+        assert!(eng.lookup("203.0.113.10").is_some());
+
+        std::fs::write(&p, "198.51.100.7\n").unwrap();
+        let eng = BlocklistEngine::load(&[p.to_string_lossy().into_owned()]);
+        assert!(eng.lookup("203.0.113.10").is_some());
+        assert!(eng.lookup("198.51.100.7").is_none());
+
+        let _ = cleanup_integrity_files(&p);
+    }
+
+    fn cleanup_integrity_files(path: &std::path::Path) -> std::io::Result<()> {
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("artifact");
+        for candidate in [
+            path.to_path_buf(),
+            path.with_extension(format!("{ext}.sig")),
+            path.with_extension(format!("{ext}.bak")),
+            path.with_extension(format!("{ext}.bak.sig")),
+            path.parent()
+                .unwrap_or_else(|| std::path::Path::new("."))
+                .join("vigil-policy.key"),
+        ] {
+            if candidate.exists() {
+                std::fs::remove_file(candidate)?;
+            }
+        }
+        Ok(())
     }
 }

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -1,7 +1,7 @@
 //! IP reputation via user-supplied plain-text blocklists.
 //!
 //! This is the "offline reputation" half of Phase 10.  Active online lookups
-//! (AbuseIPDB, Shodan, VirusTotal) are deferred — they require API keys and
+//! (AbuseIPDB, Shodan, VirusTotal) are deferred - they require API keys and
 //! a network round-trip per check.  A static blocklist is almost as useful:
 //! users can subscribe to community feeds (FireHOL, Emerging Threats,
 //! AbuseIPDB daily dumps) and drop them into `%LOCALAPPDATA%\Vigil\blocklists\`
@@ -25,7 +25,7 @@ use std::net::IpAddr;
 use std::path::Path;
 use std::sync::RwLock;
 
-// ── One loaded list ──────────────────────────────────────────────────────────
+// -- One loaded list ---------------------------------------------------------
 
 struct Blocklist {
     /// File stem shown in alerts (e.g. "abuseipdb").
@@ -114,7 +114,7 @@ impl Blocklist {
     }
 }
 
-// ── Engine ───────────────────────────────────────────────────────────────────
+// -- Engine ------------------------------------------------------------------
 
 #[derive(Default)]
 pub struct BlocklistEngine {
@@ -153,7 +153,7 @@ impl BlocklistEngine {
     }
 }
 
-// ── Global singleton ─────────────────────────────────────────────────────────
+// -- Global singleton --------------------------------------------------------
 
 static ENGINE: RwLock<Option<BlocklistEngine>> = RwLock::new(None);
 
@@ -173,16 +173,18 @@ pub fn stats() -> (usize, usize) {
     }
 }
 
-// ── Tests ────────────────────────────────────────────────────────────────────
+// -- Tests -------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::io::Write;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     fn mktmp(content: &str, name: &str) -> std::path::PathBuf {
-        let mut p = std::env::temp_dir();
-        p.push(format!("vigil_bl_test_{}_{}.txt", std::process::id(), name));
+        let dir = unique_temp_dir(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        let p = dir.join(format!("{name}.txt"));
         let mut f = std::fs::File::create(&p).unwrap();
         f.write_all(content.as_bytes()).unwrap();
         p
@@ -195,7 +197,7 @@ mod tests {
         assert!(eng.lookup("1.2.3.4").is_some());
         assert!(eng.lookup("185.220.101.1").is_some());
         assert!(eng.lookup("8.8.8.8").is_none());
-        let _ = cleanup_integrity_files(&p);
+        let _ = cleanup_test_dir(&p);
     }
 
     #[test]
@@ -204,7 +206,7 @@ mod tests {
         let eng = BlocklistEngine::load(&[p.to_string_lossy().into_owned()]);
         assert!(eng.lookup("10.1.2.3").is_some());
         assert!(eng.lookup("11.1.2.3").is_none());
-        let _ = cleanup_integrity_files(&p);
+        let _ = cleanup_test_dir(&p);
     }
 
     #[test]
@@ -212,7 +214,7 @@ mod tests {
         let p = mktmp("# comment\n\n 1.1.1.1 # trailing\n", "cmt");
         let eng = BlocklistEngine::load(&[p.to_string_lossy().into_owned()]);
         assert!(eng.lookup("1.1.1.1").is_some());
-        let _ = cleanup_integrity_files(&p);
+        let _ = cleanup_test_dir(&p);
     }
 
     #[test]
@@ -220,9 +222,8 @@ mod tests {
         let p = mktmp("1.2.3.4\n", "source");
         let eng = BlocklistEngine::load(&[p.to_string_lossy().into_owned()]);
         let hit = eng.lookup("1.2.3.4").unwrap();
-        // Stem is something like "vigil_bl_test_<pid>_source"
         assert!(hit.contains("source"));
-        let _ = cleanup_integrity_files(&p);
+        let _ = cleanup_test_dir(&p);
     }
 
     #[test]
@@ -236,24 +237,23 @@ mod tests {
         assert!(eng.lookup("203.0.113.10").is_some());
         assert!(eng.lookup("198.51.100.7").is_none());
 
-        let _ = cleanup_integrity_files(&p);
+        let _ = cleanup_test_dir(&p);
     }
 
-    fn cleanup_integrity_files(path: &std::path::Path) -> std::io::Result<()> {
-        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("artifact");
-        for candidate in [
-            path.to_path_buf(),
-            path.with_extension(format!("{ext}.sig")),
-            path.with_extension(format!("{ext}.bak")),
-            path.with_extension(format!("{ext}.bak.sig")),
-            path.parent()
-                .unwrap_or_else(|| std::path::Path::new("."))
-                .join("vigil-policy.key"),
-        ] {
-            if candidate.exists() {
-                std::fs::remove_file(candidate)?;
+    fn cleanup_test_dir(path: &std::path::Path) -> std::io::Result<()> {
+        if let Some(dir) = path.parent() {
+            if dir.exists() {
+                std::fs::remove_dir_all(dir)?;
             }
         }
         Ok(())
+    }
+
+    fn unique_temp_dir(name: &str) -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("vigil-bl-test-{}-{nanos}", name))
     }
 }

--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -3,6 +3,12 @@
 //! Vigil keeps the authoritative user policy in `vigil.json`, but the file is
 //! wrapped with an integrity sidecar and a signed backup so casual tampering or
 //! corruption can be detected and repaired on load.
+//!
+//! The same integrity envelope is also used for operator-controlled security
+//! inputs such as response-rule YAML and local blocklists. Those files are
+//! intentionally trust-on-first-use for legacy/manual installs, then verified on
+//! every subsequent load so a local attacker cannot silently rewrite them into a
+//! weaker policy or a poisoned reputation feed.
 
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
@@ -18,6 +24,23 @@ const BACKUP_SUFFIX: &str = "bak";
 const SECRET_LEN: usize = 32;
 
 pub fn load_json_with_integrity(path: &Path) -> Result<Option<Vec<u8>>, String> {
+    load_bytes_with_integrity(path, "policy")
+}
+
+pub fn save_json_with_integrity(path: &Path, data: &[u8]) -> Result<(), String> {
+    save_bytes_with_integrity(path, data)
+}
+
+pub fn load_bytes_with_integrity(path: &Path, artifact_label: &str) -> Result<Option<Vec<u8>>, String> {
+    load_artifact_with_integrity(path, artifact_label)
+}
+
+pub fn save_bytes_with_integrity(path: &Path, data: &[u8]) -> Result<(), String> {
+    let secret = load_or_create_secret(path)?;
+    save_current_and_backup(path, &secret, data)
+}
+
+fn load_artifact_with_integrity(path: &Path, artifact_label: &str) -> Result<Option<Vec<u8>>, String> {
     if !path.exists() {
         return Ok(None);
     }
@@ -31,7 +54,7 @@ pub fn load_json_with_integrity(path: &Path) -> Result<Option<Vec<u8>>, String> 
             return Ok(Some(current));
         }
         tracing::warn!(
-            "policy integrity check failed for {} — attempting backup restore",
+            "{artifact_label} integrity check failed for {} — attempting backup restore",
             path.display()
         );
         if let Some(restored) = restore_from_backup(path, &secret)? {
@@ -42,7 +65,7 @@ pub fn load_json_with_integrity(path: &Path) -> Result<Option<Vec<u8>>, String> 
 
     if had_secret || backup_data_path(path).exists() || backup_sig_path(path).exists() {
         tracing::warn!(
-            "policy signature missing for existing store {}; attempting backup restore",
+            "{artifact_label} signature missing for existing store {}; attempting backup restore",
             path.display()
         );
         if let Some(restored) = restore_from_backup(path, &secret)? {
@@ -51,19 +74,14 @@ pub fn load_json_with_integrity(path: &Path) -> Result<Option<Vec<u8>>, String> 
         return Ok(None);
     }
 
-    // Migration path for existing installs: accept the legacy unsigned config
+    // Migration path for existing installs: accept the legacy unsigned artifact
     // once, then seed the integrity sidecars so future loads are protected.
     tracing::info!(
-        "seeding policy integrity metadata for legacy store {}",
+        "seeding {artifact_label} integrity metadata for legacy artifact {}",
         path.display()
     );
     seed_integrity_artifacts(path, &secret, &current)?;
     Ok(Some(current))
-}
-
-pub fn save_json_with_integrity(path: &Path, data: &[u8]) -> Result<(), String> {
-    let secret = load_or_create_secret(path)?;
-    save_current_and_backup(path, &secret, data)
 }
 
 fn restore_from_backup(path: &Path, secret: &[u8]) -> Result<Option<Vec<u8>>, String> {
@@ -168,15 +186,20 @@ fn protect_secret_file(_path: &Path) -> Result<(), String> {
 }
 
 fn signature_path(path: &Path) -> PathBuf {
-    path.with_extension(format!("json.{SIGNATURE_SUFFIX}"))
+    path.with_extension(format!("{}.{}", path.extension().and_then(|e| e.to_str()).unwrap_or("artifact"), SIGNATURE_SUFFIX))
 }
 
 fn backup_data_path(path: &Path) -> PathBuf {
-    path.with_extension(format!("json.{BACKUP_SUFFIX}"))
+    path.with_extension(format!("{}.{}", path.extension().and_then(|e| e.to_str()).unwrap_or("artifact"), BACKUP_SUFFIX))
 }
 
 fn backup_sig_path(path: &Path) -> PathBuf {
-    path.with_extension(format!("json.{BACKUP_SUFFIX}.{SIGNATURE_SUFFIX}"))
+    path.with_extension(format!(
+        "{}.{}.{}",
+        path.extension().and_then(|e| e.to_str()).unwrap_or("artifact"),
+        BACKUP_SUFFIX,
+        SIGNATURE_SUFFIX
+    ))
 }
 
 fn secret_path(path: &Path) -> PathBuf {
@@ -295,6 +318,22 @@ mod tests {
         assert_eq!(loaded, json);
         assert!(signature_path(&path).exists());
         assert!(backup_data_path(&path).exists());
+        let _ = fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn non_json_artifact_uses_native_extension_sidecars() {
+        let base = unique_temp_dir();
+        fs::create_dir_all(&base).unwrap();
+        let path = base.join("rules.yaml");
+        let yaml = b"rules:\n  - name: dry-run\n";
+        save_bytes_with_integrity(&path, yaml).unwrap();
+
+        assert!(base.join("rules.yaml.sig").exists());
+        assert!(base.join("rules.yaml.bak").exists());
+        assert!(base.join("rules.yaml.bak.sig").exists());
+        assert_eq!(load_bytes_with_integrity(&path, "test").unwrap().unwrap(), yaml);
+
         let _ = fs::remove_dir_all(base);
     }
 

--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -54,7 +54,7 @@ fn load_artifact_with_integrity(path: &Path, artifact_label: &str) -> Result<Opt
             return Ok(Some(current));
         }
         tracing::warn!(
-            "{artifact_label} integrity check failed for {} — attempting backup restore",
+            "{artifact_label} integrity check failed for {} - attempting backup restore",
             path.display()
         );
         if let Some(restored) = restore_from_backup(path, &secret)? {
@@ -63,7 +63,7 @@ fn load_artifact_with_integrity(path: &Path, artifact_label: &str) -> Result<Opt
         return Ok(None);
     }
 
-    if had_secret || backup_data_path(path).exists() || backup_sig_path(path).exists() {
+    if backup_data_path(path).exists() || backup_sig_path(path).exists() {
         tracing::warn!(
             "{artifact_label} signature missing for existing store {}; attempting backup restore",
             path.display()
@@ -74,12 +74,20 @@ fn load_artifact_with_integrity(path: &Path, artifact_label: &str) -> Result<Opt
         return Ok(None);
     }
 
-    // Migration path for existing installs: accept the legacy unsigned artifact
-    // once, then seed the integrity sidecars so future loads are protected.
-    tracing::info!(
-        "seeding {artifact_label} integrity metadata for legacy artifact {}",
-        path.display()
-    );
+    // Migration path for existing installs: accept a legacy unsigned artifact
+    // once, then seed integrity sidecars so future loads are protected. This
+    // remains valid even when a shared directory already has a policy secret.
+    if had_secret {
+        tracing::info!(
+            "seeding {artifact_label} integrity metadata for unsigned artifact {} using existing shared secret",
+            path.display()
+        );
+    } else {
+        tracing::info!(
+            "seeding {artifact_label} integrity metadata for legacy artifact {}",
+            path.display()
+        );
+    }
     seed_integrity_artifacts(path, &secret, &current)?;
     Ok(Some(current))
 }
@@ -186,11 +194,19 @@ fn protect_secret_file(_path: &Path) -> Result<(), String> {
 }
 
 fn signature_path(path: &Path) -> PathBuf {
-    path.with_extension(format!("{}.{}", path.extension().and_then(|e| e.to_str()).unwrap_or("artifact"), SIGNATURE_SUFFIX))
+    path.with_extension(format!(
+        "{}.{}",
+        path.extension().and_then(|e| e.to_str()).unwrap_or("artifact"),
+        SIGNATURE_SUFFIX
+    ))
 }
 
 fn backup_data_path(path: &Path) -> PathBuf {
-    path.with_extension(format!("{}.{}", path.extension().and_then(|e| e.to_str()).unwrap_or("artifact"), BACKUP_SUFFIX))
+    path.with_extension(format!(
+        "{}.{}",
+        path.extension().and_then(|e| e.to_str()).unwrap_or("artifact"),
+        BACKUP_SUFFIX
+    ))
 }
 
 fn backup_sig_path(path: &Path) -> PathBuf {
@@ -318,6 +334,27 @@ mod tests {
         assert_eq!(loaded, json);
         assert!(signature_path(&path).exists());
         assert!(backup_data_path(&path).exists());
+        let _ = fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn unsigned_new_artifact_can_seed_using_existing_shared_secret() {
+        let base = unique_temp_dir();
+        fs::create_dir_all(&base).unwrap();
+
+        let policy_path = base.join("vigil.json");
+        save_json_with_integrity(&policy_path, br#"{"version":1}"#).unwrap();
+
+        let rules_path = base.join("rules.yaml");
+        let yaml = b"rules:\n  - name: dry-run\n";
+        fs::write(&rules_path, yaml).unwrap();
+
+        let loaded = load_bytes_with_integrity(&rules_path, "rules").unwrap().unwrap();
+        assert_eq!(loaded, yaml);
+        assert!(base.join("rules.yaml.sig").exists());
+        assert!(base.join("rules.yaml.bak").exists());
+        assert!(base.join("rules.yaml.bak.sig").exists());
+
         let _ = fs::remove_dir_all(base);
     }
 

--- a/src/security/response_rules.rs
+++ b/src/security/response_rules.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, Instant};
 #[derive(Debug, Default)]
 pub struct EngineState {
     cooldowns: HashMap<String, Instant>,
+    last_rule_load_error: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -71,8 +72,14 @@ pub fn maybe_apply(conn: &ConnInfo, cfg: &Config, state: &mut EngineState) -> Op
         return None;
     }
     let rules = match load_rules(&cfg.response_rules_path) {
-        Ok(rules) => rules,
+        Ok(rules) => {
+            state.clear_rule_load_error();
+            rules
+        }
         Err(err) => {
+            if !state.note_rule_load_error(&cfg.response_rules_path, &err) {
+                return None;
+            }
             audit::record(
                 "response_rule",
                 "integrity_failure",
@@ -291,6 +298,19 @@ impl EngineState {
         self.cooldowns.insert(key, now);
         true
     }
+
+    fn note_rule_load_error(&mut self, path: &str, err: &str) -> bool {
+        let key = format!("{path}:{err}");
+        if self.last_rule_load_error.as_deref() == Some(key.as_str()) {
+            return false;
+        }
+        self.last_rule_load_error = Some(key);
+        true
+    }
+
+    fn clear_rule_load_error(&mut self) {
+        self.last_rule_load_error = None;
+    }
 }
 
 #[cfg(test)]
@@ -316,6 +336,19 @@ mod tests {
         assert_eq!(rules[0].name, "signed");
 
         let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn repeated_rule_load_failures_are_reported_once_until_success() {
+        let mut state = EngineState::default();
+
+        assert!(state.note_rule_load_error("/tmp/rules.yaml", "signature mismatch"));
+        assert!(!state.note_rule_load_error("/tmp/rules.yaml", "signature mismatch"));
+        assert!(state.note_rule_load_error("/tmp/rules.yaml", "yaml parse failed"));
+
+        state.clear_rule_load_error();
+
+        assert!(state.note_rule_load_error("/tmp/rules.yaml", "signature mismatch"));
     }
 
     fn write_file(path: &Path, content: &str) {

--- a/src/security/response_rules.rs
+++ b/src/security/response_rules.rs
@@ -70,7 +70,17 @@ pub fn maybe_apply(conn: &ConnInfo, cfg: &Config, state: &mut EngineState) -> Op
     {
         return None;
     }
-    let rules = load_rules(&cfg.response_rules_path).ok()?;
+    let rules = match load_rules(&cfg.response_rules_path) {
+        Ok(rules) => rules,
+        Err(err) => {
+            audit::record(
+                "response_rule",
+                "integrity_failure",
+                json!({"path": cfg.response_rules_path, "error": err}),
+            );
+            return Some(format!("Response rules unavailable: {err}"));
+        }
+    };
     let rule = rules.into_iter().find(|rule| matches_rule(rule, conn))?;
     let action = plan_action(&rule, conn)?;
     let cooldown = Duration::from_secs(cfg.auto_response_cooldown_secs.max(30));
@@ -109,8 +119,13 @@ pub fn maybe_apply(conn: &ConnInfo, cfg: &Config, state: &mut EngineState) -> Op
 }
 
 fn load_rules(path: &str) -> Result<Vec<ResponseRule>, String> {
-    let text = std::fs::read_to_string(path)
-        .map_err(|e| format!("failed to read rule file {path}: {e}"))?;
+    let bytes = crate::security::policy::load_bytes_with_integrity(
+        std::path::Path::new(path),
+        "response rules",
+    )?
+    .ok_or_else(|| format!("rule file {path} failed integrity verification and no trusted backup was available"))?;
+    let text = String::from_utf8(bytes)
+        .map_err(|e| format!("rule file {path} is not valid UTF-8: {e}"))?;
     let file: RuleFile = serde_yaml::from_str(&text)
         .map_err(|e| format!("failed to parse YAML rule file {path}: {e}"))?;
     Ok(file.rules)
@@ -275,5 +290,44 @@ impl EngineState {
         }
         self.cooldowns.insert(key, now);
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::path::Path;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn tampered_rule_file_restores_signed_backup() {
+        let base = unique_temp_dir();
+        std::fs::create_dir_all(&base).unwrap();
+        let path = base.join("response-rules.yaml");
+        write_file(&path, "rules:\n  - name: signed\n    min_score: 9\n    action: block_remote\n");
+        let rules = load_rules(&path.to_string_lossy()).unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].name, "signed");
+
+        write_file(&path, "rules:\n  - name: tampered\n    min_score: 0\n    action: quarantine\n");
+        let rules = load_rules(&path.to_string_lossy()).unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].name, "signed");
+
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    fn write_file(path: &Path, content: &str) {
+        let mut file = std::fs::File::create(path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+    }
+
+    fn unique_temp_dir() -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("vigil-rules-test-{nanos}"))
     }
 }


### PR DESCRIPTION
## Summary
- extend the existing policy integrity envelope so it can protect arbitrary operator-controlled files, not just JSON config
- verify and restore local blocklists before loading reputation entries
- verify and restore response-rule YAML before applying automated response actions, with audit visibility when rule loading fails
- add regression tests for non-JSON sidecar naming and tamper-restore behavior for both blocklists and response rules

## Why this task
Phase 15 is the next open roadmap phase after completed Phase 14, and its first actionable item is cryptographically verified policy/configuration files. Existing code already protected `vigil.json`, but adjacent security inputs (`response_rules_path` and `blocklist_paths`) were still loaded directly from disk. That made them a narrow, high-value follow-up because they can influence automated containment and reputation scoring.

## Validation
- Static implementation review against existing Rust module patterns
- Compared branch against `master` to confirm only `src/security/policy.rs`, `src/blocklist.rs`, and `src/security/response_rules.rs` changed

I could not run `cargo fmt`, `cargo test`, or `cargo clippy` in this environment because the sandbox cannot resolve `github.com` to clone/build the repository or fetch missing dependencies.