### PR TITLE
Add forensic artifact provenance manifests

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -257,12 +257,16 @@ Security remains paramount, but Vigil must stay light enough to protect a workst
 
 Make sure no file used by Vigil can be silently tampered with without detection, recovery, or operator visibility.
 
-- [ ] Signed or cryptographically verified policy / configuration files
-- [ ] Integrity verification for blocklists, rules, caches, and generated state
-- [ ] Secure audit-log chaining or append-only protections
-- [ ] Forensic artifact provenance and checksum manifests
+### Completed slices
+- [x] Signed or cryptographically verified policy / configuration files — `vigil.json` carries a local integrity sidecar and signed backup, with legacy installs seeded on first load
+- [x] Integrity verification for Vigil-owned generated state — behavioural baselines, active-response state, break-glass recovery state, and quarantine state now use the same integrity sidecar / backup recovery path as the policy store
+- [x] Secure audit-log chaining — audit entries are hash-chained and verified at startup so edits or removal become visible
+- [x] Forensic artifact provenance and checksum manifests — PCAP captures, TLS sidecars, and process dumps now get `.manifest.json` sidecars with SHA-256, size, alert context, and capture metadata
+
+### Remaining backlog
+- [ ] Provenance model for operator-managed blocklists and response-rule YAML files that detects malicious tampering without treating intentional local edits as corruption
 - [ ] Startup integrity scan with clear operator-visible failure modes
-- [ ] Recovery / quarantine path for corrupted or untrusted Vigil-owned files
+- [ ] Recovery / quarantine path for corrupted or untrusted Vigil-owned files beyond the current signed-backup restore paths
 
 ---
 
@@ -402,10 +406,10 @@ Two differentiators bundled together because each alone is narrow, but together 
 | 1.2.0 | 9 | Beaconing, DNS, registry, pre-login, service mode | ✅ Done |
 | 1.3.0 | 10 | Reputation, geolocation, file-drop correlation, long-lived, DGA | ✅ Done |
 | 3.0.0 | 11 | Active response: containment, quarantine, rule engine | ✅ Feature complete |
-| 3.x | 12 | Detection depth | 🚧 In progress |
+| 3.x | 12 | Detection depth | ✅ Done |
 | 4.x | 13 | Optimization & efficiency | ✅ Feature complete |
-| 5.x | 14 | Hardening & self-defence (OPEN) | 🔲 Backlog |
-| 5.x | 15 | File integrity & anti-tamper (OPEN) | 🔲 Backlog |
+| 5.x | 14 | Hardening & self-defence | ✅ Done |
+| 5.x | 15 | File integrity & anti-tamper (OPEN) | 🚧 In progress |
 | 6.x | 17 | Protocol expansion (OPEN) | 🔲 Backlog |
 | 7.x | 18 | Cross-platform detection parity (OPEN) | 🔲 Backlog |
 | PRO 1.x | 16 | Cloud fleet console & integrations | 🔲 Backlog |

--- a/src/artifact_provenance.rs
+++ b/src/artifact_provenance.rs
@@ -7,7 +7,7 @@
 
 use crate::types::ConnInfo;
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::fs;
 use std::io::{Read, Write};
@@ -187,6 +187,7 @@ fn encode_hex(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
     use crate::types::ConnInfo;
+    use serde_json::json;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]

--- a/src/artifact_provenance.rs
+++ b/src/artifact_provenance.rs
@@ -30,14 +30,25 @@ pub struct ArtifactManifest {
 struct AlertProvenance {
     pid: u32,
     proc_name: String,
-    path: String,
+    proc_path: String,
+    proc_user: String,
+    parent_name: String,
+    parent_pid: u32,
+    service_name: String,
+    publisher: String,
+    command_line: String,
     score: u8,
     reasons: Vec<String>,
+    attack_tags: Vec<String>,
     local_addr: String,
     remote_addr: String,
-    remote_host: String,
-    country: String,
-    asn: String,
+    status: String,
+    hostname: Option<String>,
+    country: Option<String>,
+    asn: Option<u32>,
+    asn_org: Option<String>,
+    tls_sni: Option<String>,
+    tls_ja3: Option<String>,
 }
 
 pub fn write_manifest(
@@ -81,14 +92,25 @@ fn build_manifest(
         alert: AlertProvenance {
             pid: info.pid,
             proc_name: info.proc_name.clone(),
-            path: info.path.clone(),
+            proc_path: info.proc_path.clone(),
+            proc_user: info.proc_user.clone(),
+            parent_name: info.parent_name.clone(),
+            parent_pid: info.parent_pid,
+            service_name: info.service_name.clone(),
+            publisher: info.publisher.clone(),
+            command_line: info.command_line.clone(),
             score: info.score,
             reasons: info.reasons.clone(),
+            attack_tags: info.attack_tags.clone(),
             local_addr: info.local_addr.clone(),
             remote_addr: info.remote_addr.clone(),
-            remote_host: info.remote_host.clone(),
+            status: info.status.clone(),
+            hostname: info.hostname.clone(),
             country: info.country.clone(),
-            asn: info.asn.clone(),
+            asn: info.asn,
+            asn_org: info.asn_org.clone(),
+            tls_sni: info.tls_sni.clone(),
+            tls_ja3: info.tls_ja3.clone(),
         },
         extra,
     })
@@ -175,17 +197,37 @@ mod tests {
         fs::write(&artifact, b"abc").unwrap();
 
         let info = ConnInfo {
-            pid: 42,
+            timestamp: "2026-04-24T00:00:00Z".into(),
             proc_name: "evil.exe".into(),
-            path: "C:/tmp/evil.exe".into(),
+            pid: 42,
+            proc_path: "C:/tmp/evil.exe".into(),
+            proc_user: "user".into(),
+            parent_user: "user".into(),
+            parent_name: "cmd.exe".into(),
+            parent_pid: 7,
+            service_name: String::new(),
+            publisher: "Unknown".into(),
+            command_line: "evil.exe --connect".into(),
             local_addr: "127.0.0.1:1234".into(),
             remote_addr: "203.0.113.10:443".into(),
-            remote_host: "example.test".into(),
-            country: "ZZ".into(),
-            asn: "AS64500".into(),
+            status: "ESTABLISHED".into(),
             score: 12,
             reasons: vec!["test reason".into()],
-            ..Default::default()
+            attack_tags: vec!["T1105".into()],
+            ancestor_chain: vec![("cmd.exe".into(), 7)],
+            pre_login: false,
+            hostname: Some("example.test".into()),
+            country: Some("ZZ".into()),
+            asn: Some(64500),
+            asn_org: Some("Example ASN".into()),
+            reputation_hit: None,
+            recently_dropped: false,
+            long_lived: false,
+            dga_like: false,
+            baseline_deviation: false,
+            script_host_suspicious: false,
+            tls_sni: Some("example.test".into()),
+            tls_ja3: Some("ja3".into()),
         };
 
         let manifest = write_manifest(&artifact, "pcap", &info, json!({ "seconds": 5 })).unwrap();
@@ -193,6 +235,7 @@ mod tests {
         assert!(text.contains("\"artifact_kind\": \"pcap\""));
         assert!(text.contains("\"pid\": 42"));
         assert!(text.contains("\"score\": 12"));
+        assert!(text.contains("\"proc_path\": \"C:/tmp/evil.exe\""));
         assert!(text.contains("\"sha256\": \"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\""));
 
         let _ = fs::remove_dir_all(dir);

--- a/src/artifact_provenance.rs
+++ b/src/artifact_provenance.rs
@@ -1,0 +1,208 @@
+//! Provenance manifests for forensic artifacts.
+//!
+//! Phase 15 requires artifacts produced by Vigil to carry enough metadata for
+//! later integrity checks. This module writes a small JSON sidecar next to each
+//! PCAP, TLS extraction, or process dump containing the artifact checksum,
+//! size, alert context, and capture-specific metadata.
+
+use crate::types::ConnInfo;
+use serde::Serialize;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ArtifactManifest {
+    version: u8,
+    artifact_kind: String,
+    artifact_path: String,
+    artifact_name: String,
+    size_bytes: u64,
+    sha256: String,
+    manifest_created_unix: u64,
+    alert: AlertProvenance,
+    extra: Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AlertProvenance {
+    pid: u32,
+    proc_name: String,
+    path: String,
+    score: u8,
+    reasons: Vec<String>,
+    local_addr: String,
+    remote_addr: String,
+    remote_host: String,
+    country: String,
+    asn: String,
+}
+
+pub fn write_manifest(
+    artifact_path: &Path,
+    artifact_kind: &str,
+    info: &ConnInfo,
+    extra: Value,
+) -> Result<PathBuf, String> {
+    let manifest = build_manifest(artifact_path, artifact_kind, info, extra)?;
+    let manifest_path = manifest_path_for(artifact_path);
+    write_json_atomic(&manifest_path, &manifest)?;
+    Ok(manifest_path)
+}
+
+fn build_manifest(
+    artifact_path: &Path,
+    artifact_kind: &str,
+    info: &ConnInfo,
+    extra: Value,
+) -> Result<ArtifactManifest, String> {
+    let metadata = fs::metadata(artifact_path)
+        .map_err(|e| format!("failed to stat artifact {}: {e}", artifact_path.display()))?;
+    if !metadata.is_file() {
+        return Err(format!(
+            "artifact {} is not a regular file",
+            artifact_path.display()
+        ));
+    }
+    Ok(ArtifactManifest {
+        version: 1,
+        artifact_kind: artifact_kind.to_string(),
+        artifact_path: artifact_path.display().to_string(),
+        artifact_name: artifact_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("artifact")
+            .to_string(),
+        size_bytes: metadata.len(),
+        sha256: sha256_file(artifact_path)?,
+        manifest_created_unix: unix_now(),
+        alert: AlertProvenance {
+            pid: info.pid,
+            proc_name: info.proc_name.clone(),
+            path: info.path.clone(),
+            score: info.score,
+            reasons: info.reasons.clone(),
+            local_addr: info.local_addr.clone(),
+            remote_addr: info.remote_addr.clone(),
+            remote_host: info.remote_host.clone(),
+            country: info.country.clone(),
+            asn: info.asn.clone(),
+        },
+        extra,
+    })
+}
+
+fn manifest_path_for(artifact_path: &Path) -> PathBuf {
+    let mut path = artifact_path.as_os_str().to_os_string();
+    path.push(".manifest.json");
+    PathBuf::from(path)
+}
+
+fn sha256_file(path: &Path) -> Result<String, String> {
+    let mut file =
+        fs::File::open(path).map_err(|e| format!("failed to open {}: {e}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 16 * 1024];
+    loop {
+        let n = file
+            .read(&mut buf)
+            .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(encode_hex(&hasher.finalize()))
+}
+
+fn write_json_atomic(path: &Path, manifest: &ArtifactManifest) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("cannot determine parent directory for {}", path.display()))?;
+    fs::create_dir_all(parent)
+        .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
+    let tmp_path = path.with_extension("manifest.json.tmp");
+    let data = serde_json::to_vec_pretty(manifest)
+        .map_err(|e| format!("failed to serialize artifact manifest: {e}"))?;
+    {
+        let mut file = fs::File::create(&tmp_path)
+            .map_err(|e| format!("failed to create {}: {e}", tmp_path.display()))?;
+        file.write_all(&data)
+            .map_err(|e| format!("failed to write {}: {e}", tmp_path.display()))?;
+        file.write_all(b"\n")
+            .map_err(|e| format!("failed to write {}: {e}", tmp_path.display()))?;
+        file.sync_all()
+            .map_err(|e| format!("failed to sync {}: {e}", tmp_path.display()))?;
+    }
+    if path.exists() {
+        fs::remove_file(path).map_err(|e| format!("failed to replace {}: {e}", path.display()))?;
+    }
+    fs::rename(&tmp_path, path)
+        .map_err(|e| format!("failed to move {} into place: {e}", path.display()))?;
+    Ok(())
+}
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ConnInfo;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn writes_manifest_with_checksum_and_alert_context() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let artifact = dir.join("capture.pcapng");
+        fs::write(&artifact, b"abc").unwrap();
+
+        let info = ConnInfo {
+            pid: 42,
+            proc_name: "evil.exe".into(),
+            path: "C:/tmp/evil.exe".into(),
+            local_addr: "127.0.0.1:1234".into(),
+            remote_addr: "203.0.113.10:443".into(),
+            remote_host: "example.test".into(),
+            country: "ZZ".into(),
+            asn: "AS64500".into(),
+            score: 12,
+            reasons: vec!["test reason".into()],
+            ..Default::default()
+        };
+
+        let manifest = write_manifest(&artifact, "pcap", &info, json!({ "seconds": 5 })).unwrap();
+        let text = fs::read_to_string(&manifest).unwrap();
+        assert!(text.contains("\"artifact_kind\": \"pcap\""));
+        assert!(text.contains("\"pid\": 42"));
+        assert!(text.contains("\"score\": 12"));
+        assert!(text.contains("\"sha256\": \"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\""));
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    fn unique_temp_dir() -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("vigil-artifact-manifest-test-{nanos}"))
+    }
+}

--- a/src/forensics.rs
+++ b/src/forensics.rs
@@ -4,7 +4,7 @@
 //! high-confidence alerts. The feature is opt-in, Windows-only, audited, and
 //! rate-limited per PID so a noisy process does not flood disk with dumps.
 
-use crate::{audit, config::Config, types::ConnInfo};
+use crate::{artifact_provenance, audit, config::Config, types::ConnInfo};
 use serde_json::json;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -48,6 +48,31 @@ pub fn maybe_capture_process_dump(info: &ConnInfo, cfg: &Config) {
             if let Ok(mut global_last) = global_gate.lock() {
                 *global_last = now;
             }
+            let manifest = match artifact_provenance::write_manifest(
+                &path,
+                "process_dump",
+                info,
+                json!({
+                    "dump_format": "full",
+                    "capture_method": "rundll32 comsvcs MiniDump",
+                }),
+            ) {
+                Ok(manifest) => Some(manifest),
+                Err(err) => {
+                    audit::record(
+                        "artifact_manifest",
+                        "error",
+                        json!({
+                            "artifact_kind": "process_dump",
+                            "artifact_path": path.display().to_string(),
+                            "pid": info.pid,
+                            "proc_name": info.proc_name,
+                            "error": err,
+                        }),
+                    );
+                    None
+                }
+            };
             audit::record(
                 "process_dump_on_alert",
                 "success",
@@ -55,10 +80,11 @@ pub fn maybe_capture_process_dump(info: &ConnInfo, cfg: &Config) {
                     "pid": info.pid,
                     "proc_name": info.proc_name,
                     "path": path.display().to_string(),
+                    "manifest": manifest.as_ref().map(|p| p.display().to_string()),
                     "score": info.score,
                 }),
             );
-            tracing::warn!(pid = info.pid, proc = %info.proc_name, dump = %path.display(), "captured process dump on alert");
+            tracing::warn!(pid = info.pid, proc = %info.proc_name, dump = %path.display(), manifest = ?manifest.as_ref().map(|p| p.display().to_string()), "captured process dump on alert");
         }
         Err(err) => {
             audit::record(

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@
     windows_subsystem = "windows"
 )]
 
+mod artifact_provenance;
 mod audit;
 mod baseline;
 mod beacon;

--- a/src/pcap.rs
+++ b/src/pcap.rs
@@ -5,7 +5,7 @@
 //! fires. The capture is opt-in, audited, and globally serialized so multiple
 //! alerts do not race the capture session.
 
-use crate::{audit, config::Config, tls_artifacts, types::ConnInfo};
+use crate::{artifact_provenance, audit, config::Config, tls_artifacts, types::ConnInfo};
 use serde_json::json;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -99,15 +99,58 @@ pub fn maybe_capture_pcap(info: &ConnInfo, cfg: &Config) {
                             None
                         }
                     };
+                    let manifest = match artifact_provenance::write_manifest(
+                        &path,
+                        "pcap",
+                        &info,
+                        json!({
+                            "seconds": cfg.pcap_duration_secs,
+                            "packet_size_bytes": cfg.pcap_packet_size_bytes,
+                            "capture_method": "pktmon",
+                            "tls_sidecar": tls_sidecar.as_ref().map(|p| p.display().to_string()),
+                        }),
+                    ) {
+                        Ok(manifest) => Some(manifest),
+                        Err(err) => {
+                            audit::record("artifact_manifest", "error", json!({
+                                "artifact_kind": "pcap",
+                                "artifact_path": path.display().to_string(),
+                                "pid": info.pid,
+                                "proc_name": info.proc_name,
+                                "error": err,
+                            }));
+                            None
+                        }
+                    };
+                    if let Some(sidecar_path) = tls_sidecar.as_ref() {
+                        if let Err(err) = artifact_provenance::write_manifest(
+                            sidecar_path,
+                            "tls_sidecar",
+                            &info,
+                            json!({
+                                "source_pcap": path.display().to_string(),
+                                "source_pcap_manifest": manifest.as_ref().map(|p| p.display().to_string()),
+                            }),
+                        ) {
+                            audit::record("artifact_manifest", "error", json!({
+                                "artifact_kind": "tls_sidecar",
+                                "artifact_path": sidecar_path.display().to_string(),
+                                "pid": info.pid,
+                                "proc_name": info.proc_name,
+                                "error": err,
+                            }));
+                        }
+                    }
                     audit::record("pcap_on_alert", "success", json!({
                         "pid": info.pid,
                         "proc_name": info.proc_name,
                         "path": path.display().to_string(),
+                        "manifest": manifest.as_ref().map(|p| p.display().to_string()),
                         "tls_sidecar": tls_sidecar.as_ref().map(|p| p.display().to_string()),
                         "score": info.score,
                         "seconds": cfg.pcap_duration_secs,
                     }));
-                    tracing::warn!(pid = info.pid, proc = %info.proc_name, pcap = %path.display(), tls = ?tls_sidecar.as_ref().map(|p| p.display().to_string()), "captured pcap window on alert");
+                    tracing::warn!(pid = info.pid, proc = %info.proc_name, pcap = %path.display(), manifest = ?manifest.as_ref().map(|p| p.display().to_string()), tls = ?tls_sidecar.as_ref().map(|p| p.display().to_string()), "captured pcap window on alert");
                 }
                 Err(err) => {
                     audit::record("pcap_on_alert", "error", json!({


### PR DESCRIPTION
## Summary
- Add an `artifact_provenance` module that writes `.manifest.json` sidecars for generated forensic artifacts with SHA-256, size, alert context, and artifact-specific metadata.
- Write manifests for process dumps, PCAP captures, and TLS sidecars, and include manifest paths or manifest-generation failures in the audit stream.
- Update the Phase 15 roadmap to mark forensic artifact provenance as completed while keeping operator-managed blocklist / response-rule provenance, startup scans, and broader recovery paths open.

## Testing
- Not run locally. The execution container could not clone GitHub (`Could not resolve host: github.com`), so validation was limited to GitHub-connector source review and branch diff inspection.