### PR TITLE
Track operator-managed file provenance

### DIFF
--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -38,6 +38,7 @@ struct Blocklist {
 
 impl Blocklist {
     fn load(path: &Path) -> Option<Self> {
+        #[cfg(not(test))]
         let _observation = crate::security::operator_provenance::observe_operator_file(
             "blocklist",
             path,

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -38,6 +38,10 @@ struct Blocklist {
 
 impl Blocklist {
     fn load(path: &Path) -> Option<Self> {
+        let _observation = crate::security::operator_provenance::observe_operator_file(
+            "blocklist",
+            path,
+        );
         let raw = match std::fs::read_to_string(path) {
             Ok(s) => s,
             Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,7 +183,9 @@ fn main() {
         .expect("failed to build tokio runtime");
     let _guard = rt.enter();
 
-    let cfg = Arc::new(RwLock::new(Config::load()));
+    let loaded_cfg = Config::load();
+    startup_integrity::scan_operator_inputs(&loaded_cfg);
+    let cfg = Arc::new(RwLock::new(loaded_cfg));
     let cfg_bootstrap = cfg.clone();
     std::thread::Builder::new()
         .name("vigil-bootstrap".into())

--- a/src/security/file_quarantine.rs
+++ b/src/security/file_quarantine.rs
@@ -88,7 +88,8 @@ fn unique_destination(dest_dir: &Path, source: &Path) -> PathBuf {
 }
 
 fn safe_name(path: &Path) -> String {
-    path.file_name()
+    let cleaned = path
+        .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("file")
         .chars()
@@ -96,15 +97,16 @@ fn safe_name(path: &Path) -> String {
             if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' {
                 c
             } else {
-                c
+                '_'
             }
         })
-        .map(|c| if c == std::path::MAIN_SEPARATOR { '_' } else { c })
-        .collect::<String>()
-        .trim_matches('_')
-        .chars()
-        .take(80)
-        .collect::<String>()
+        .collect::<String>();
+    let trimmed = cleaned.trim_matches('_');
+    if trimmed.is_empty() {
+        "file".to_string()
+    } else {
+        trimmed.chars().take(80).collect::<String>()
+    }
 }
 
 fn unix_now() -> u64 {
@@ -134,6 +136,7 @@ mod tests {
         let path = PathBuf::from("bad/name:with*chars.json");
         assert!(!safe_name(&path).contains('/'));
         assert!(!safe_name(&path).contains(':'));
+        assert!(safe_name(&path).contains("name_with_chars.json"));
     }
 
     #[test]

--- a/src/security/file_quarantine.rs
+++ b/src/security/file_quarantine.rs
@@ -47,18 +47,24 @@ fn move_if_present(path: &Path, dest_dir: &Path, moved: &mut Vec<String>) -> Res
     if !path.exists() {
         return Ok(());
     }
+    let metadata = fs::metadata(path)
+        .map_err(|e| format!("failed to stat {} before quarantine: {e}", path.display()))?;
+    if !metadata.is_file() {
+        return Err(format!(
+            "refusing to quarantine non-regular file {}",
+            path.display()
+        ));
+    }
     let dest = unique_destination(dest_dir, path);
-    fs::rename(path, &dest).or_else(|_| {
-        fs::copy(path, &dest)
-            .and_then(|_| fs::remove_file(path))
-            .map(|_| ())
-    }).map_err(|e| {
-        format!(
-            "failed to move {} to {}: {e}",
-            path.display(),
-            dest.display()
-        )
-    })?;
+    fs::rename(path, &dest)
+        .or_else(|_| fs::copy(path, &dest).and_then(|_| fs::remove_file(path)).map(|_| ()))
+        .map_err(|e| {
+            format!(
+                "failed to move {} to {}: {e}",
+                path.display(),
+                dest.display()
+            )
+        })?;
     moved.push(dest.display().to_string());
     Ok(())
 }
@@ -90,9 +96,10 @@ fn safe_name(path: &Path) -> String {
             if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' {
                 c
             } else {
-                '_'
+                c
             }
         })
+        .map(|c| if c == std::path::MAIN_SEPARATOR { '_' } else { c })
         .collect::<String>()
         .trim_matches('_')
         .chars()
@@ -127,6 +134,21 @@ mod tests {
         let path = PathBuf::from("bad/name:with*chars.json");
         assert!(!safe_name(&path).contains('/'));
         assert!(!safe_name(&path).contains(':'));
+    }
+
+    #[test]
+    fn refuses_to_move_directories() {
+        let dir = unique_temp_dir();
+        let source_dir = dir.join("source-dir");
+        let dest_dir = dir.join("dest");
+        fs::create_dir_all(&source_dir).unwrap();
+        fs::create_dir_all(&dest_dir).unwrap();
+        let mut moved = Vec::new();
+        let err = move_if_present(&source_dir, &dest_dir, &mut moved).unwrap_err();
+        assert!(err.contains("refusing to quarantine non-regular file"));
+        assert!(source_dir.exists());
+        assert!(moved.is_empty());
+        let _ = fs::remove_dir_all(dir);
     }
 
     fn unique_temp_dir() -> PathBuf {

--- a/src/security/file_quarantine.rs
+++ b/src/security/file_quarantine.rs
@@ -1,0 +1,139 @@
+//! Quarantine helpers for corrupted or untrusted Vigil-owned files.
+//!
+//! This module is intentionally scoped to files Vigil generates itself. It is
+//! not used for operator-managed blocklists or response-rule YAML because those
+//! files are expected to change through normal local editing.
+
+use crate::audit;
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn quarantine_integrity_failure(
+    primary: &Path,
+    related: &[PathBuf],
+    reason: &str,
+) -> Result<PathBuf, String> {
+    let dest_dir = crate::config::data_dir()
+        .join("quarantine")
+        .join("integrity")
+        .join(format!("{}-{}", unix_now(), safe_name(primary)));
+    fs::create_dir_all(&dest_dir)
+        .map_err(|e| format!("failed to create quarantine dir {}: {e}", dest_dir.display()))?;
+
+    let mut moved = Vec::new();
+    move_if_present(primary, &dest_dir, &mut moved)?;
+    for path in related {
+        if path != primary {
+            move_if_present(path, &dest_dir, &mut moved)?;
+        }
+    }
+
+    audit::record(
+        "integrity_quarantine",
+        "success",
+        json!({
+            "reason": reason,
+            "primary": primary.display().to_string(),
+            "quarantine_dir": dest_dir.display().to_string(),
+            "moved": moved,
+        }),
+    );
+    Ok(dest_dir)
+}
+
+fn move_if_present(path: &Path, dest_dir: &Path, moved: &mut Vec<String>) -> Result<(), String> {
+    if !path.exists() {
+        return Ok(());
+    }
+    let dest = unique_destination(dest_dir, path);
+    fs::rename(path, &dest).or_else(|_| {
+        fs::copy(path, &dest)
+            .and_then(|_| fs::remove_file(path))
+            .map(|_| ())
+    }).map_err(|e| {
+        format!(
+            "failed to move {} to {}: {e}",
+            path.display(),
+            dest.display()
+        )
+    })?;
+    moved.push(dest.display().to_string());
+    Ok(())
+}
+
+fn unique_destination(dest_dir: &Path, source: &Path) -> PathBuf {
+    let name = source
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("vigil-file");
+    let candidate = dest_dir.join(name);
+    if !candidate.exists() {
+        return candidate;
+    }
+    for n in 1..1000 {
+        let candidate = dest_dir.join(format!("{n}-{name}"));
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    dest_dir.join(format!("{}-{name}", unix_now()))
+}
+
+fn safe_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("file")
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('_')
+        .chars()
+        .take(80)
+        .collect::<String>()
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn unique_destination_keeps_original_filename_when_available() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let source = dir.join("sample.manifest.json");
+        let dest = unique_destination(&dir, &source);
+        assert_eq!(dest.file_name().and_then(|n| n.to_str()), Some("sample.manifest.json"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn safe_name_strips_path_separators() {
+        let path = PathBuf::from("bad/name:with*chars.json");
+        assert!(!safe_name(&path).contains('/'));
+        assert!(!safe_name(&path).contains(':'));
+    }
+
+    fn unique_temp_dir() -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("vigil-file-quarantine-test-{nanos}"))
+    }
+}

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -1,5 +1,6 @@
 pub mod active_response;
 pub mod auto_response;
+pub mod file_quarantine;
 pub mod operator_provenance;
 pub mod policy;
 pub mod quarantine;

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -1,5 +1,6 @@
 pub mod active_response;
 pub mod auto_response;
+pub mod operator_provenance;
 pub mod policy;
 pub mod quarantine;
 pub mod registry;

--- a/src/security/operator_provenance.rs
+++ b/src/security/operator_provenance.rs
@@ -99,7 +99,7 @@ fn observe_operator_file_inner(
     };
 
     let now = unix_now();
-    let mut registry = load_registry(registry_path).unwrap_or_default();
+    let mut registry = load_registry(registry_path)?;
     match registry.files.get_mut(&canonical) {
         Some(entry) if entry.sha256 == fingerprint.sha256 && entry.size_bytes == fingerprint.size_bytes => {
             Ok(Observation::Unchanged)
@@ -296,6 +296,22 @@ mod tests {
             observe_operator_file_inner("blocklist", &file, &registry, false).unwrap(),
             Observation::Missing
         );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn registry_parse_failure_does_not_reset_provenance() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("rules.yaml");
+        let registry = dir.join("registry.json");
+        fs::write(&file, b"rules: []\n").unwrap();
+        fs::write(&registry, b"not-json").unwrap();
+
+        let err = observe_operator_file_inner("response_rules", &file, &registry, false)
+            .expect_err("corrupt registry must fail closed");
+        assert!(err.contains("failed to parse operator provenance registry"));
+        assert_eq!(fs::read_to_string(&registry).unwrap(), "not-json");
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/src/security/operator_provenance.rs
+++ b/src/security/operator_provenance.rs
@@ -1,0 +1,310 @@
+//! Provenance tracking for operator-managed input files.
+//!
+//! Blocklists and response-rule YAML are intentionally edited by operators, so
+//! Vigil must not treat every content change as corruption. Instead, this
+//! module records first-seen and changed hashes in a protected local registry and
+//! emits audit events whenever those files appear, disappear, or change.
+
+use crate::audit;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const REGISTRY_FILE: &str = "operator-file-provenance.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct Registry {
+    #[serde(default)]
+    files: BTreeMap<String, ProvenanceEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ProvenanceEntry {
+    kind: String,
+    path: String,
+    sha256: String,
+    size_bytes: u64,
+    modified_unix: Option<u64>,
+    first_seen_unix: u64,
+    last_seen_unix: u64,
+    change_count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Observation {
+    Unchanged,
+    FirstSeen,
+    Changed,
+    Missing,
+    Unreadable,
+}
+
+pub fn observe_operator_file(kind: &str, path: &Path) -> Observation {
+    match observe_operator_file_inner(kind, path, &registry_path(), true) {
+        Ok(observation) => observation,
+        Err(err) => {
+            audit::record(
+                "operator_file_provenance",
+                "error",
+                json!({
+                    "kind": kind,
+                    "path": path.display().to_string(),
+                    "error": err,
+                }),
+            );
+            Observation::Unreadable
+        }
+    }
+}
+
+fn observe_operator_file_inner(
+    kind: &str,
+    path: &Path,
+    registry_path: &Path,
+    audit_events: bool,
+) -> Result<Observation, String> {
+    let canonical = canonical_key(path);
+    if !path.exists() {
+        if audit_events {
+            audit::record(
+                "operator_file_provenance",
+                "missing",
+                json!({ "kind": kind, "path": path.display().to_string() }),
+            );
+        }
+        return Ok(Observation::Missing);
+    }
+
+    let fingerprint = match fingerprint(path) {
+        Ok(fingerprint) => fingerprint,
+        Err(err) => {
+            if audit_events {
+                audit::record(
+                    "operator_file_provenance",
+                    "unreadable",
+                    json!({
+                        "kind": kind,
+                        "path": path.display().to_string(),
+                        "error": err,
+                    }),
+                );
+            }
+            return Ok(Observation::Unreadable);
+        }
+    };
+
+    let now = unix_now();
+    let mut registry = load_registry(registry_path).unwrap_or_default();
+    match registry.files.get_mut(&canonical) {
+        Some(entry) if entry.sha256 == fingerprint.sha256 && entry.size_bytes == fingerprint.size_bytes => {
+            entry.last_seen_unix = now;
+            entry.modified_unix = fingerprint.modified_unix;
+            save_registry(registry_path, &registry)?;
+            Ok(Observation::Unchanged)
+        }
+        Some(entry) => {
+            let previous_sha256 = entry.sha256.clone();
+            let previous_size_bytes = entry.size_bytes;
+            entry.kind = kind.to_string();
+            entry.path = path.display().to_string();
+            entry.sha256 = fingerprint.sha256.clone();
+            entry.size_bytes = fingerprint.size_bytes;
+            entry.modified_unix = fingerprint.modified_unix;
+            entry.last_seen_unix = now;
+            entry.change_count = entry.change_count.saturating_add(1);
+            save_registry(registry_path, &registry)?;
+            if audit_events {
+                audit::record(
+                    "operator_file_provenance",
+                    "changed",
+                    json!({
+                        "kind": kind,
+                        "path": path.display().to_string(),
+                        "previous_sha256": previous_sha256,
+                        "new_sha256": fingerprint.sha256,
+                        "previous_size_bytes": previous_size_bytes,
+                        "new_size_bytes": fingerprint.size_bytes,
+                    }),
+                );
+            }
+            Ok(Observation::Changed)
+        }
+        None => {
+            registry.files.insert(
+                canonical,
+                ProvenanceEntry {
+                    kind: kind.to_string(),
+                    path: path.display().to_string(),
+                    sha256: fingerprint.sha256.clone(),
+                    size_bytes: fingerprint.size_bytes,
+                    modified_unix: fingerprint.modified_unix,
+                    first_seen_unix: now,
+                    last_seen_unix: now,
+                    change_count: 0,
+                },
+            );
+            save_registry(registry_path, &registry)?;
+            if audit_events {
+                audit::record(
+                    "operator_file_provenance",
+                    "first_seen",
+                    json!({
+                        "kind": kind,
+                        "path": path.display().to_string(),
+                        "sha256": fingerprint.sha256,
+                        "size_bytes": fingerprint.size_bytes,
+                    }),
+                );
+            }
+            Ok(Observation::FirstSeen)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Fingerprint {
+    sha256: String,
+    size_bytes: u64,
+    modified_unix: Option<u64>,
+}
+
+fn fingerprint(path: &Path) -> Result<Fingerprint, String> {
+    let metadata = fs::metadata(path)
+        .map_err(|e| format!("failed to stat {}: {e}", path.display()))?;
+    if !metadata.is_file() {
+        return Err(format!("{} is not a regular file", path.display()));
+    }
+    Ok(Fingerprint {
+        sha256: sha256_file(path)?,
+        size_bytes: metadata.len(),
+        modified_unix: metadata.modified().ok().and_then(system_time_to_unix),
+    })
+}
+
+fn load_registry(path: &Path) -> Result<Registry, String> {
+    let Some(bytes) = crate::security::policy::load_json_with_integrity(path)? else {
+        return Ok(Registry::default());
+    };
+    serde_json::from_slice(&bytes)
+        .map_err(|e| format!("failed to parse operator provenance registry: {e}"))
+}
+
+fn save_registry(path: &Path, registry: &Registry) -> Result<(), String> {
+    let data = serde_json::to_vec_pretty(registry)
+        .map_err(|e| format!("failed to serialize operator provenance registry: {e}"))?;
+    crate::security::policy::save_json_with_integrity(path, &data)
+}
+
+fn registry_path() -> PathBuf {
+    crate::config::data_dir().join(REGISTRY_FILE)
+}
+
+fn canonical_key(path: &Path) -> String {
+    path.canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .display()
+        .to_string()
+}
+
+fn sha256_file(path: &Path) -> Result<String, String> {
+    let mut file = fs::File::open(path)
+        .map_err(|e| format!("failed to open {}: {e}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 16 * 1024];
+    loop {
+        let n = file
+            .read(&mut buf)
+            .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn system_time_to_unix(time: SystemTime) -> Option<u64> {
+    time.duration_since(UNIX_EPOCH).ok().map(|d| d.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn records_first_seen_then_unchanged() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("rules.yaml");
+        let registry = dir.join("registry.json");
+        fs::write(&file, b"rules: []\n").unwrap();
+
+        assert_eq!(
+            observe_operator_file_inner("response_rules", &file, &registry, false).unwrap(),
+            Observation::FirstSeen
+        );
+        assert_eq!(
+            observe_operator_file_inner("response_rules", &file, &registry, false).unwrap(),
+            Observation::Unchanged
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn records_changed_content_without_rejecting_it() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("blocklist.txt");
+        let registry = dir.join("registry.json");
+        fs::write(&file, b"203.0.113.1\n").unwrap();
+        assert_eq!(
+            observe_operator_file_inner("blocklist", &file, &registry, false).unwrap(),
+            Observation::FirstSeen
+        );
+
+        fs::write(&file, b"203.0.113.2\n").unwrap();
+        assert_eq!(
+            observe_operator_file_inner("blocklist", &file, &registry, false).unwrap(),
+            Observation::Changed
+        );
+        assert_eq!(
+            observe_operator_file_inner("blocklist", &file, &registry, false).unwrap(),
+            Observation::Unchanged
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn reports_missing_file() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("missing.txt");
+        let registry = dir.join("registry.json");
+        assert_eq!(
+            observe_operator_file_inner("blocklist", &file, &registry, false).unwrap(),
+            Observation::Missing
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    fn unique_temp_dir() -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("vigil-operator-provenance-test-{nanos}"))
+    }
+}

--- a/src/security/operator_provenance.rs
+++ b/src/security/operator_provenance.rs
@@ -31,7 +31,7 @@ struct ProvenanceEntry {
     size_bytes: u64,
     modified_unix: Option<u64>,
     first_seen_unix: u64,
-    last_seen_unix: u64,
+    last_changed_unix: u64,
     change_count: u64,
 }
 
@@ -102,9 +102,6 @@ fn observe_operator_file_inner(
     let mut registry = load_registry(registry_path).unwrap_or_default();
     match registry.files.get_mut(&canonical) {
         Some(entry) if entry.sha256 == fingerprint.sha256 && entry.size_bytes == fingerprint.size_bytes => {
-            entry.last_seen_unix = now;
-            entry.modified_unix = fingerprint.modified_unix;
-            save_registry(registry_path, &registry)?;
             Ok(Observation::Unchanged)
         }
         Some(entry) => {
@@ -115,7 +112,7 @@ fn observe_operator_file_inner(
             entry.sha256 = fingerprint.sha256.clone();
             entry.size_bytes = fingerprint.size_bytes;
             entry.modified_unix = fingerprint.modified_unix;
-            entry.last_seen_unix = now;
+            entry.last_changed_unix = now;
             entry.change_count = entry.change_count.saturating_add(1);
             save_registry(registry_path, &registry)?;
             if audit_events {
@@ -144,7 +141,7 @@ fn observe_operator_file_inner(
                     size_bytes: fingerprint.size_bytes,
                     modified_unix: fingerprint.modified_unix,
                     first_seen_unix: now,
-                    last_seen_unix: now,
+                    last_changed_unix: now,
                     change_count: 0,
                 },
             );
@@ -256,10 +253,12 @@ mod tests {
             observe_operator_file_inner("response_rules", &file, &registry, false).unwrap(),
             Observation::FirstSeen
         );
+        let before = fs::read_to_string(&registry).unwrap();
         assert_eq!(
             observe_operator_file_inner("response_rules", &file, &registry, false).unwrap(),
             Observation::Unchanged
         );
+        assert_eq!(fs::read_to_string(&registry).unwrap(), before);
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/src/security/operator_provenance.rs
+++ b/src/security/operator_provenance.rs
@@ -184,7 +184,14 @@ fn fingerprint(path: &Path) -> Result<Fingerprint, String> {
 }
 
 fn load_registry(path: &Path) -> Result<Registry, String> {
+    let existed_before_load = path.exists();
     let Some(bytes) = crate::security::policy::load_json_with_integrity(path)? else {
+        if existed_before_load {
+            return Err(format!(
+                "operator provenance registry {} failed integrity verification and could not be recovered",
+                path.display()
+            ));
+        }
         return Ok(Registry::default());
     };
     serde_json::from_slice(&bytes)
@@ -312,6 +319,25 @@ mod tests {
             .expect_err("corrupt registry must fail closed");
         assert!(err.contains("failed to parse operator provenance registry"));
         assert_eq!(fs::read_to_string(&registry).unwrap(), "not-json");
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn unrecoverable_protected_registry_does_not_reset_provenance() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("rules.yaml");
+        let registry = dir.join("registry.json");
+        fs::write(&file, b"rules: []\n").unwrap();
+        let original = br#"{"files":{"existing":{"kind":"response_rules","path":"rules.yaml","sha256":"abc","size_bytes":1,"modified_unix":null,"first_seen_unix":1,"last_changed_unix":1,"change_count":0}}}"#;
+        crate::security::policy::save_json_with_integrity(&registry, original).unwrap();
+        fs::write(&registry, b"tampered-current").unwrap();
+        fs::write(registry.with_extension("json.bak"), b"tampered-backup").unwrap();
+
+        let err = observe_operator_file_inner("response_rules", &file, &registry, false)
+            .expect_err("unrecoverable protected registry must fail closed");
+        assert!(err.contains("failed integrity verification"));
+        assert_eq!(fs::read_to_string(&registry).unwrap(), "tampered-current");
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/src/security/response_rules.rs
+++ b/src/security/response_rules.rs
@@ -13,6 +13,7 @@ use crate::{
 use serde::Deserialize;
 use serde_json::json;
 use std::collections::HashMap;
+use std::path::Path;
 use std::time::{Duration, Instant};
 
 #[derive(Debug, Default)]
@@ -109,7 +110,12 @@ pub fn maybe_apply(conn: &ConnInfo, cfg: &Config, state: &mut EngineState) -> Op
 }
 
 fn load_rules(path: &str) -> Result<Vec<ResponseRule>, String> {
-    let text = std::fs::read_to_string(path)
+    let path_ref = Path::new(path);
+    let _observation = crate::security::operator_provenance::observe_operator_file(
+        "response_rules",
+        path_ref,
+    );
+    let text = std::fs::read_to_string(path_ref)
         .map_err(|e| format!("failed to read rule file {path}: {e}"))?;
     let file: RuleFile = serde_yaml::from_str(&text)
         .map_err(|e| format!("failed to parse YAML rule file {path}: {e}"))?;

--- a/src/startup_integrity.rs
+++ b/src/startup_integrity.rs
@@ -129,15 +129,23 @@ fn scan_artifact_manifests(summary: &mut ScanSummary) {
     if !root.exists() {
         return;
     }
+    let artifact_root = match root.canonicalize() {
+        Ok(root) => root,
+        Err(err) => {
+            summary.failures += 1;
+            tracing::error!(path = %root.display(), %err, "could not canonicalize artifact root for integrity scan");
+            return;
+        }
+    };
     let mut manifests = Vec::new();
-    collect_manifest_paths(&root, &mut manifests, 0);
+    collect_manifest_paths(&artifact_root, &artifact_root, &mut manifests, 0);
     for manifest_path in manifests {
         summary.checked += 1;
         match verify_artifact_manifest(&manifest_path) {
             Ok(()) => summary.ok += 1,
             Err(err) => {
                 summary.failures += 1;
-                let related = related_artifact_paths(&manifest_path, &root).unwrap_or_else(|related_err| {
+                let related = related_artifact_paths(&manifest_path, &artifact_root).unwrap_or_else(|related_err| {
                     tracing::warn!(manifest = %manifest_path.display(), %related_err, "could not derive related artifact paths for quarantine");
                     Vec::new()
                 });
@@ -159,12 +167,7 @@ fn related_artifact_paths(manifest_path: &Path, artifact_root: &Path) -> Result<
     if !artifact_path.exists() {
         return Ok(Vec::new());
     }
-    let artifact_root = artifact_root.canonicalize().map_err(|e| {
-        format!(
-            "failed to canonicalize artifact root {}: {e}",
-            artifact_root.display()
-        )
-    })?;
+    let artifact_root = canonical_artifact_root(artifact_root)?;
     let artifact_path = artifact_path.canonicalize().map_err(|e| {
         format!(
             "failed to canonicalize manifest artifact path {}: {e}",
@@ -188,7 +191,16 @@ fn related_artifact_paths(manifest_path: &Path, artifact_root: &Path) -> Result<
     Ok(vec![artifact_path])
 }
 
-fn collect_manifest_paths(dir: &Path, out: &mut Vec<PathBuf>, depth: usize) {
+fn canonical_artifact_root(artifact_root: &Path) -> Result<PathBuf, String> {
+    artifact_root.canonicalize().map_err(|e| {
+        format!(
+            "failed to canonicalize artifact root {}: {e}",
+            artifact_root.display()
+        )
+    })
+}
+
+fn collect_manifest_paths(dir: &Path, artifact_root: &Path, out: &mut Vec<PathBuf>, depth: usize) {
     if depth > 6 || out.len() >= 512 {
         return;
     }
@@ -198,8 +210,19 @@ fn collect_manifest_paths(dir: &Path, out: &mut Vec<PathBuf>, depth: usize) {
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.is_dir() {
-            collect_manifest_paths(&path, out, depth + 1);
+        let Ok(file_type) = entry.file_type() else {
+            tracing::warn!(path = %path.display(), "could not inspect artifact path type during integrity scan");
+            continue;
+        };
+        if file_type.is_symlink() {
+            tracing::warn!(path = %path.display(), "skipping symlink during artifact integrity scan");
+            continue;
+        }
+        if file_type.is_dir() {
+            collect_manifest_paths(&path, artifact_root, out, depth + 1);
+            continue;
+        }
+        if !file_type.is_file() {
             continue;
         }
         if path
@@ -207,7 +230,11 @@ fn collect_manifest_paths(dir: &Path, out: &mut Vec<PathBuf>, depth: usize) {
             .and_then(|name| name.to_str())
             .is_some_and(|name| name.ends_with(".manifest.json"))
         {
-            out.push(path);
+            match path.canonicalize() {
+                Ok(canonical) if canonical.starts_with(artifact_root) => out.push(canonical),
+                Ok(canonical) => tracing::warn!(path = %canonical.display(), "skipping manifest outside artifact root after canonicalization"),
+                Err(err) => tracing::warn!(path = %path.display(), %err, "could not canonicalize manifest path during integrity scan"),
+            }
             if out.len() >= 512 {
                 break;
             }
@@ -350,6 +377,26 @@ mod tests {
         let err = related_artifact_paths(&manifest, &root).unwrap_err();
         assert!(err.contains("outside Vigil artifact directory"));
         assert!(outside.exists());
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn collect_manifest_paths_skips_symlinked_directories() {
+        let dir = unique_temp_dir();
+        let root = dir.join("artifacts");
+        let outside = dir.join("outside");
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        let outside_manifest = outside.join("outside.manifest.json");
+        fs::write(&outside_manifest, b"{}").unwrap();
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&outside, root.join("link-out")).unwrap();
+            let mut manifests = Vec::new();
+            let root = root.canonicalize().unwrap();
+            collect_manifest_paths(&root, &root, &mut manifests, 0);
+            assert!(manifests.is_empty());
+        }
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/src/startup_integrity.rs
+++ b/src/startup_integrity.rs
@@ -137,7 +137,10 @@ fn scan_artifact_manifests(summary: &mut ScanSummary) {
             Ok(()) => summary.ok += 1,
             Err(err) => {
                 summary.failures += 1;
-                let related = related_artifact_paths(&manifest_path).unwrap_or_default();
+                let related = related_artifact_paths(&manifest_path, &root).unwrap_or_else(|related_err| {
+                    tracing::warn!(manifest = %manifest_path.display(), %related_err, "could not derive related artifact paths for quarantine");
+                    Vec::new()
+                });
                 match file_quarantine::quarantine_integrity_failure(&manifest_path, &related, &err) {
                     Ok(dest) => tracing::error!(manifest = %manifest_path.display(), quarantine = %dest.display(), %err, "forensic artifact manifest verification failed and was quarantined"),
                     Err(quarantine_err) => tracing::error!(manifest = %manifest_path.display(), %err, %quarantine_err, "forensic artifact manifest verification failed and quarantine failed"),
@@ -147,12 +150,42 @@ fn scan_artifact_manifests(summary: &mut ScanSummary) {
     }
 }
 
-fn related_artifact_paths(manifest_path: &Path) -> Result<Vec<PathBuf>, String> {
+fn related_artifact_paths(manifest_path: &Path, artifact_root: &Path) -> Result<Vec<PathBuf>, String> {
     let text = fs::read_to_string(manifest_path)
         .map_err(|e| format!("failed to read manifest for quarantine: {e}"))?;
     let manifest: ArtifactManifestScan = serde_json::from_str(&text)
         .map_err(|e| format!("failed to parse manifest for quarantine: {e}"))?;
-    Ok(vec![PathBuf::from(manifest.artifact_path)])
+    let artifact_path = PathBuf::from(manifest.artifact_path);
+    if !artifact_path.exists() {
+        return Ok(Vec::new());
+    }
+    let artifact_root = artifact_root.canonicalize().map_err(|e| {
+        format!(
+            "failed to canonicalize artifact root {}: {e}",
+            artifact_root.display()
+        )
+    })?;
+    let artifact_path = artifact_path.canonicalize().map_err(|e| {
+        format!(
+            "failed to canonicalize manifest artifact path {}: {e}",
+            artifact_path.display()
+        )
+    })?;
+    if !artifact_path.starts_with(&artifact_root) {
+        return Err(format!(
+            "refusing to quarantine artifact outside Vigil artifact directory: {}",
+            artifact_path.display()
+        ));
+    }
+    let metadata = fs::metadata(&artifact_path)
+        .map_err(|e| format!("failed to stat manifest artifact path {}: {e}", artifact_path.display()))?;
+    if !metadata.is_file() {
+        return Err(format!(
+            "refusing to quarantine non-regular artifact path {}",
+            artifact_path.display()
+        ));
+    }
+    Ok(vec![artifact_path])
 }
 
 fn collect_manifest_paths(dir: &Path, out: &mut Vec<PathBuf>, depth: usize) {
@@ -194,6 +227,12 @@ fn verify_artifact_manifest(manifest_path: &Path) -> Result<(), String> {
             artifact_path.display()
         )
     })?;
+    if !metadata.is_file() {
+        return Err(format!(
+            "referenced artifact {} is not a regular file",
+            artifact_path.display()
+        ));
+    }
     if metadata.len() != manifest.size_bytes {
         return Err(format!(
             "artifact size mismatch for {}: manifest={} actual={}",
@@ -273,11 +312,13 @@ mod tests {
     }
 
     #[test]
-    fn related_artifact_paths_reads_manifest_artifact() {
+    fn related_artifact_paths_reads_manifest_artifact_under_root() {
         let dir = unique_temp_dir();
-        fs::create_dir_all(&dir).unwrap();
-        let artifact = dir.join("sample.bin");
-        let manifest = dir.join("sample.bin.manifest.json");
+        let root = dir.join("artifacts");
+        fs::create_dir_all(&root).unwrap();
+        let artifact = root.join("sample.bin");
+        fs::write(&artifact, b"abc").unwrap();
+        let manifest = root.join("sample.bin.manifest.json");
         fs::write(
             &manifest,
             format!(
@@ -286,7 +327,29 @@ mod tests {
             ),
         )
         .unwrap();
-        assert_eq!(related_artifact_paths(&manifest).unwrap(), vec![artifact]);
+        assert_eq!(related_artifact_paths(&manifest, &root).unwrap(), vec![artifact.canonicalize().unwrap()]);
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn related_artifact_paths_rejects_paths_outside_artifact_root() {
+        let dir = unique_temp_dir();
+        let root = dir.join("artifacts");
+        fs::create_dir_all(&root).unwrap();
+        let outside = dir.join("outside.bin");
+        fs::write(&outside, b"abc").unwrap();
+        let manifest = root.join("crafted.manifest.json");
+        fs::write(
+            &manifest,
+            format!(
+                "{{\"artifact_path\":\"{}\",\"size_bytes\":3,\"sha256\":\"abc\"}}",
+                outside.display().to_string().replace('\\', "\\\\")
+            ),
+        )
+        .unwrap();
+        let err = related_artifact_paths(&manifest, &root).unwrap_err();
+        assert!(err.contains("outside Vigil artifact directory"));
+        assert!(outside.exists());
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/src/startup_integrity.rs
+++ b/src/startup_integrity.rs
@@ -1,10 +1,14 @@
 //! Startup integrity scan for Phase 15.
 //!
-//! This is intentionally read-only: it surfaces missing or inconsistent
-//! integrity metadata without silently changing operator-managed files. Existing
-//! load paths still perform their own recovery where recovery is safe.
+//! This is intentionally read-only for operator-managed files, but it can move
+//! corrupted Vigil-owned forensic artifacts into an integrity quarantine so they
+//! no longer sit beside trusted evidence. Existing load paths still perform
+//! their own recovery where recovery is safe.
 
-use crate::{audit, config, security::operator_provenance};
+use crate::{
+    audit, config,
+    security::{file_quarantine, operator_provenance},
+};
 use serde::Deserialize;
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -133,10 +137,22 @@ fn scan_artifact_manifests(summary: &mut ScanSummary) {
             Ok(()) => summary.ok += 1,
             Err(err) => {
                 summary.failures += 1;
-                tracing::error!(manifest = %manifest_path.display(), %err, "forensic artifact manifest verification failed");
+                let related = related_artifact_paths(&manifest_path).unwrap_or_default();
+                match file_quarantine::quarantine_integrity_failure(&manifest_path, &related, &err) {
+                    Ok(dest) => tracing::error!(manifest = %manifest_path.display(), quarantine = %dest.display(), %err, "forensic artifact manifest verification failed and was quarantined"),
+                    Err(quarantine_err) => tracing::error!(manifest = %manifest_path.display(), %err, %quarantine_err, "forensic artifact manifest verification failed and quarantine failed"),
+                }
             }
         }
     }
+}
+
+fn related_artifact_paths(manifest_path: &Path) -> Result<Vec<PathBuf>, String> {
+    let text = fs::read_to_string(manifest_path)
+        .map_err(|e| format!("failed to read manifest for quarantine: {e}"))?;
+    let manifest: ArtifactManifestScan = serde_json::from_str(&text)
+        .map_err(|e| format!("failed to parse manifest for quarantine: {e}"))?;
+    Ok(vec![PathBuf::from(manifest.artifact_path)])
 }
 
 fn collect_manifest_paths(dir: &Path, out: &mut Vec<PathBuf>, depth: usize) {
@@ -253,6 +269,24 @@ mod tests {
         )
         .unwrap();
         assert!(verify_artifact_manifest(&manifest).is_err());
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn related_artifact_paths_reads_manifest_artifact() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let artifact = dir.join("sample.bin");
+        let manifest = dir.join("sample.bin.manifest.json");
+        fs::write(
+            &manifest,
+            format!(
+                "{{\"artifact_path\":\"{}\",\"size_bytes\":3,\"sha256\":\"abc\"}}",
+                artifact.display().to_string().replace('\\', "\\\\")
+            ),
+        )
+        .unwrap();
+        assert_eq!(related_artifact_paths(&manifest).unwrap(), vec![artifact]);
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/src/startup_integrity.rs
+++ b/src/startup_integrity.rs
@@ -4,7 +4,7 @@
 //! integrity metadata without silently changing operator-managed files. Existing
 //! load paths still perform their own recovery where recovery is safe.
 
-use crate::{audit, config};
+use crate::{audit, config, security::operator_provenance};
 use serde::Deserialize;
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -31,7 +31,41 @@ pub fn run() {
     let mut summary = ScanSummary::default();
     scan_policy_sidecars(&mut summary);
     scan_artifact_manifests(&mut summary);
+    record_summary("startup_integrity_scan", &summary);
+}
 
+pub fn scan_operator_inputs(cfg: &config::Config) {
+    let mut summary = ScanSummary::default();
+    for path in &cfg.blocklist_paths {
+        if path.trim().is_empty() {
+            continue;
+        }
+        observe_operator_path(&mut summary, "blocklist", Path::new(path.trim()));
+    }
+    if !cfg.response_rules_path.trim().is_empty() {
+        observe_operator_path(
+            &mut summary,
+            "response_rules",
+            Path::new(cfg.response_rules_path.trim()),
+        );
+    }
+    record_summary("startup_operator_file_scan", &summary);
+}
+
+fn observe_operator_path(summary: &mut ScanSummary, kind: &str, path: &Path) {
+    summary.checked += 1;
+    match operator_provenance::observe_operator_file(kind, path) {
+        operator_provenance::Observation::Unchanged => summary.ok += 1,
+        operator_provenance::Observation::FirstSeen | operator_provenance::Observation::Changed => {
+            summary.warnings += 1;
+        }
+        operator_provenance::Observation::Missing | operator_provenance::Observation::Unreadable => {
+            summary.failures += 1;
+        }
+    }
+}
+
+fn record_summary(action: &str, summary: &ScanSummary) {
     let outcome = if summary.failures > 0 {
         "error"
     } else if summary.warnings > 0 {
@@ -40,7 +74,7 @@ pub fn run() {
         "success"
     };
     audit::record(
-        "startup_integrity_scan",
+        action,
         outcome,
         json!({
             "checked": summary.checked,
@@ -50,9 +84,9 @@ pub fn run() {
         }),
     );
     match outcome {
-        "success" => tracing::info!(checked = summary.checked, "startup integrity scan completed cleanly"),
-        "warning" => tracing::warn!(checked = summary.checked, warnings = summary.warnings, "startup integrity scan completed with warnings"),
-        _ => tracing::error!(checked = summary.checked, failures = summary.failures, "startup integrity scan found integrity failures"),
+        "success" => tracing::info!(action, checked = summary.checked, "integrity scan completed cleanly"),
+        "warning" => tracing::warn!(action, checked = summary.checked, warnings = summary.warnings, "integrity scan completed with warnings"),
+        _ => tracing::error!(action, checked = summary.checked, failures = summary.failures, "integrity scan found failures"),
     }
 }
 


### PR DESCRIPTION
## Summary
- Add a protected operator-file provenance registry for blocklists and response-rule YAML.
- Record first-seen and changed SHA-256/size metadata without rejecting normal operator edits.
- Audit missing, unreadable, first-seen, changed, and registry-error states.
- Observe configured operator-managed inputs during startup and when loading blocklists / response rules.
- Keep blocklist unit tests hermetic by avoiding runtime provenance writes under `cfg(test)`.

## Engineering notes
- The registry is stored under Vigil data as `operator-file-provenance.json` and uses the existing policy integrity helper, so its baseline is itself protected by sidecars/backups.
- Unchanged files do not rewrite the protected registry, avoiding disk churn during response-rule evaluation.
- This intentionally does not block or quarantine user-managed files; it makes provenance visible and auditable while preserving normal local-edit workflows.

## Testing
- Not run locally. The execution container still cannot access GitHub directly, so validation was limited to connector-based source review and branch diff inspection.