### PR TITLE
Quarantine corrupt Vigil-owned forensic files

### DIFF
--- a/src/security/file_quarantine.rs
+++ b/src/security/file_quarantine.rs
@@ -1,0 +1,139 @@
+//! Quarantine helpers for corrupted or untrusted Vigil-owned files.
+//!
+//! This module is intentionally scoped to files Vigil generates itself. It is
+//! not used for operator-managed blocklists or response-rule YAML because those
+//! files are expected to change through normal local editing.
+
+use crate::audit;
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn quarantine_integrity_failure(
+    primary: &Path,
+    related: &[PathBuf],
+    reason: &str,
+) -> Result<PathBuf, String> {
+    let dest_dir = crate::config::data_dir()
+        .join("quarantine")
+        .join("integrity")
+        .join(format!("{}-{}", unix_now(), safe_name(primary)));
+    fs::create_dir_all(&dest_dir)
+        .map_err(|e| format!("failed to create quarantine dir {}: {e}", dest_dir.display()))?;
+
+    let mut moved = Vec::new();
+    move_if_present(primary, &dest_dir, &mut moved)?;
+    for path in related {
+        if path != primary {
+            move_if_present(path, &dest_dir, &mut moved)?;
+        }
+    }
+
+    audit::record(
+        "integrity_quarantine",
+        "success",
+        json!({
+            "reason": reason,
+            "primary": primary.display().to_string(),
+            "quarantine_dir": dest_dir.display().to_string(),
+            "moved": moved,
+        }),
+    );
+    Ok(dest_dir)
+}
+
+fn move_if_present(path: &Path, dest_dir: &Path, moved: &mut Vec<String>) -> Result<(), String> {
+    if !path.exists() {
+        return Ok(());
+    }
+    let dest = unique_destination(dest_dir, path);
+    fs::rename(path, &dest).or_else(|_| {
+        fs::copy(path, &dest)
+            .and_then(|_| fs::remove_file(path))
+            .map(|_| ())
+    }).map_err(|e| {
+        format!(
+            "failed to move {} to {}: {e}",
+            path.display(),
+            dest.display()
+        )
+    })?;
+    moved.push(dest.display().to_string());
+    Ok(())
+}
+
+fn unique_destination(dest_dir: &Path, source: &Path) -> PathBuf {
+    let name = source
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("vigil-file");
+    let candidate = dest_dir.join(name);
+    if !candidate.exists() {
+        return candidate;
+    }
+    for n in 1..1000 {
+        let candidate = dest_dir.join(format!("{n}-{name}"));
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    dest_dir.join(format!("{}-{name}", unix_now()))
+}
+
+fn safe_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("file")
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('_')
+        .chars()
+        .take(80)
+        .collect::<String>()
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn unique_destination_keeps_original_filename_when_available() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let source = dir.join("sample.manifest.json");
+        let dest = unique_destination(&dir, &source);
+        assert_eq!(dest.file_name().and_then(|n| n.to_str()), Some("sample.manifest.json"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn safe_name_strips_path_separators() {
+        let path = PathBuf::from("bad/name:with*chars.json");
+        assert!(!safe_name(&path).contains('/'));
+        assert!(!safe_name(&path).contains(':'));
+    }
+
+    fn unique_temp_dir() -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("vigil-file-quarantine-test-{nanos}"))
+    }
+}

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -1,5 +1,6 @@
 pub mod active_response;
 pub mod auto_response;
+pub mod file_quarantine;
 pub mod operator_provenance;
 pub mod policy;
 pub mod quarantine;

--- a/src/startup_integrity.rs
+++ b/src/startup_integrity.rs
@@ -1,10 +1,14 @@
 //! Startup integrity scan for Phase 15.
 //!
-//! This is intentionally read-only: it surfaces missing or inconsistent
-//! integrity metadata without silently changing operator-managed files. Existing
-//! load paths still perform their own recovery where recovery is safe.
+//! This is intentionally read-only for operator-managed files, but it can move
+//! corrupted Vigil-owned forensic artifacts into an integrity quarantine so they
+//! no longer sit beside trusted evidence. Existing load paths still perform
+//! their own recovery where recovery is safe.
 
-use crate::{audit, config, security::operator_provenance};
+use crate::{
+    audit, config,
+    security::{file_quarantine, operator_provenance},
+};
 use serde::Deserialize;
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -133,10 +137,22 @@ fn scan_artifact_manifests(summary: &mut ScanSummary) {
             Ok(()) => summary.ok += 1,
             Err(err) => {
                 summary.failures += 1;
-                tracing::error!(manifest = %manifest_path.display(), %err, "forensic artifact manifest verification failed");
+                let related = related_artifact_paths(&manifest_path).unwrap_or_default();
+                match file_quarantine::quarantine_integrity_failure(&manifest_path, &related, &err) {
+                    Ok(dest) => tracing::error!(manifest = %manifest_path.display(), quarantine = %dest.display(), %err, "forensic artifact manifest verification failed and was quarantined"),
+                    Err(quarantine_err) => tracing::error!(manifest = %manifest_path.display(), %err, %quarantine_err, "forensic artifact manifest verification failed and quarantine failed"),
+                }
             }
         }
     }
+}
+
+fn related_artifact_paths(manifest_path: &Path) -> Result<Vec<PathBuf>, String> {
+    let text = fs::read_to_string(manifest_path)
+        .map_err(|e| format!("failed to read manifest for quarantine: {e}"))?;
+    let manifest: ArtifactManifestScan = serde_json::from_str(&text)
+        .map_err(|e| format!("failed to parse manifest for quarantine: {e}"))?;
+    Ok(vec![PathBuf::from(manifest.artifact_path)])
 }
 
 fn collect_manifest_paths(dir: &Path, out: &mut Vec<PathBuf>, depth: usize) {
@@ -253,6 +269,24 @@ mod tests {
         )
         .unwrap();
         assert!(verify_artifact_manifest(&manifest).is_err());
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn related_artifact_paths_reads_manifest_artifact() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let artifact = dir.join("sample.bin");
+        let manifest = dir.join("sample.bin.manifest.json");
+        fs::write(
+            &manifest,
+            format!(
+                "{{\"artifact_path\":\"{}\",\"size_bytes\":3,\"sha256\":\"abc\"}}",
+                artifact.display().to_string().replace('\\', "\\\\")
+            ),
+        )
+        .unwrap();
+        assert_eq!(related_artifact_paths(&manifest).unwrap(), vec![artifact]);
         let _ = fs::remove_dir_all(dir);
     }
 


### PR DESCRIPTION
## Summary
- Add a scoped integrity quarantine helper for Vigil-owned generated files.
- When startup forensic manifest verification fails, move the corrupt manifest and referenced artifact into `quarantine/integrity/...`.
- Record `integrity_quarantine` audit events with reason, primary path, destination, and moved files.
- Keep operator-managed blocklists and response-rule YAML observational only; they are not quarantined by this flow.

## Engineering notes
- This PR is stacked on #74 (`phase15-operator-file-provenance`) so Phase 15 remains split into focused review slices.
- The quarantine helper prefers `rename` and falls back to copy+remove for cross-device moves.
- Destination names are sanitized and collision-safe.

## Testing
- Not run locally. The execution container cannot access GitHub directly, so validation was limited to connector-based source review and branch diff inspection.