### PR TITLE
Reposition docs around Vigil's current protection capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ vigil --verify-update-manifest Vigil-latest-update-manifest.json Vigil-latest-up
 
 ### Preserve trust, evidence, and operator control
 
-- **Forensic capture on high-confidence alerts** — short PCAP capture, process
-  memory dump, TLS sidecar metadata, and provenance manifests
+- **Forensic capture on high-confidence alerts (Windows today)** — short PCAP
+  capture, process memory dump, TLS sidecar metadata, and provenance manifests
 - **Tamper-evident local state** — protected policy store, integrity-backed
   generated state, audit-log chaining, and signed update manifests
 - **Daily rolling logs and audit trail** — operator-visible records for alerts,

--- a/README.md
+++ b/README.md
@@ -10,11 +10,16 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/YMRYMR/vigil?label=release)](https://github.com/YMRYMR/vigil/releases/latest)
 
-Real-time network threat monitor for Windows, macOS, and Linux.
+Cross-platform endpoint defense for Windows, macOS, and Linux.
 
-Vigil watches every TCP/UDP connection on your machine, scores each one for
-suspicious behaviour, and alerts you — via a system tray icon, desktop
-notification, and a full GUI — the moment something looks wrong.
+Vigil watches live network and process activity on your machine, scores suspicious
+behaviour, shows you the process and connection context behind each alert, and
+can take reversible containment actions when something needs to be stopped.
+
+It is designed for local machine protection first: detect suspicious outbound
+activity quickly, help the operator understand what is happening, preserve
+evidence when needed, and contain the machine or process without turning every
+high-noise event into a destructive action.
 
 ![Vigil current UI](docs/images/vigil-current.png)
 
@@ -22,7 +27,7 @@ notification, and a full GUI — the moment something looks wrong.
 
 ## Documentation
 
-- [User guide](docs/USER-GUIDE.md) — released functionality and basic operation
+- [User guide](docs/USER-GUIDE.md) — released functionality, operator workflows, and day-to-day use
 - [Security policy](SECURITY.md) — vulnerability reporting and security contacts
 - [OpenSSF Best Practices controls](docs/OPENSSF-BEST-PRACTICES.md) — repository controls and maintainer settings
 - [Codebase inventory](docs/CODEBASES.md) — repositories that are part of Vigil
@@ -67,33 +72,55 @@ vigil --verify-update-manifest Vigil-latest-update-manifest.json Vigil-latest-up
 
 ---
 
-## Features
+## What Vigil Does
+
+### Detect and surface suspicious activity
 
 - **Sub-100 ms detection** on Windows via ETW (Event Tracing for Windows);
   on Linux via eBPF (`sock:inet_sock_set_state` tracepoint); polling fallback
   on macOS and older kernels
-- **Multi-signal threat scoring** (0–10+) across eight detection categories
+- **Multi-signal threat scoring** across behavioural, reputation, persistence,
+  and execution-context signals so alerts stay explainable instead of opaque
+- **Passive persistence and timing signals** including registry autoruns,
+  beaconing behaviour, pre-login activity, long-lived connections, and DGA-like
+  hostnames
+- **Offline enrichment** with local blocklists, geolocation, ASN data, reverse
+  DNS, and file-drop correlation
+
+### Help investigate what is happening
+
 - **Full ancestor process tree** — see exactly which process spawned which,
   up to 8 levels deep
-- **System tray** — amber icon + tooltip on alert; green when all-clear;
-  left-click opens the UI, right-click shows the menu (GNOME AppIndicator
-  on Linux uses themed icon names)
-- **Clickable notifications** — clicking a desktop alert opens Vigil and
-  navigates directly to the triggering connection
-- **Full GUI** — process-grouped Activity and Alerts views, a process-first
-  Inspector, auto-save Settings, persisted grid sort/window state, a
-  polished Help screen, and a header that clearly shows whether Vigil is
-  elevated
-- **Active response** — reversible actions (Windows + Linux) for killing a live TCP
-  connection, suspending or resuming a process during investigation,
+- **Process-first GUI** — Activity and Alerts views are grouped around the local
+  process, with a detailed Inspector for path, parent, publisher, user, remote
+  endpoint, score reasons, badges, and enrichment context
+- **Clickable notifications and tray workflow** — alerts can take you straight
+  into the relevant connection from the desktop or tray icon
+- **Boot-time service mode** — monitor before login so early persistence and
+  pre-user activity are still visible when the operator signs in
+
+### Protect and contain the machine
+
+- **Active response** — reversible actions (Windows + Linux) for killing a live
+  TCP connection, suspending or resuming a process during investigation,
   blocking a remote IP for 1 hour, 24 hours, or permanently, blocking a
-  process by executable path, or isolating the machine, with confirmation
-  prompts, live countdowns for temporary blocks, and one-click unblock
-  buttons
-- **Rolling daily log** at the per-user Vigil data directory under `logs/vigil.YYYY-MM-DD`
-- **Autostart at login** enabled on first run (configurable in Settings);
-  if Vigil is launched elevated on Windows, future autostart uses a
-  highest-privilege scheduled task so it keeps admin visibility
+  process by executable path, or isolating the machine
+- **Containment safety rails** — confirmation prompts for destructive actions,
+  live countdowns for temporary blocks, inline unblock controls, and break-glass
+  recovery for isolation
+- **Policy-driven automation** — user-defined response rules, scheduled
+  lockdown, allowlist-only mode, and threshold-based escalation planning
+
+### Preserve trust, evidence, and operator control
+
+- **Forensic capture on high-confidence alerts** — short PCAP capture, process
+  memory dump, TLS sidecar metadata, and provenance manifests
+- **Tamper-evident local state** — protected policy store, integrity-backed
+  generated state, audit-log chaining, and signed update manifests
+- **Daily rolling logs and audit trail** — operator-visible records for alerts,
+  actions, integrity events, and other security-relevant state changes
+- **Privilege-aware UX** — Vigil makes clear when elevated permissions are
+  required for deeper visibility or containment
 
 ---
 
@@ -123,7 +150,7 @@ score 3 + 3 + 4 + 5 = 15. The alert threshold is configurable (default: 3).
 | +1 | Unusual destination port for an untrusted process |
 
 Trusted processes skip the **+2 unrecognised** and **+2 unsigned** penalties,
-so routine connections from browsers and system services score 0.  High-severity
+so routine connections from browsers and system services score 0. High-severity
 signals (malware ports, LoLBins, pre-login activity) still apply — if a trusted
 app suddenly dials a C2 port, you want to know.
 
@@ -191,7 +218,7 @@ just ci         # fmt-check + lint + test (mirrors CI)
 ### Windows icon embedding
 
 `build.rs` generates a multi-size `.ico` file and embeds it via
-[`winres`](https://crates.io/crates/winres).  This requires the Windows SDK
+[`winres`](https://crates.io/crates/winres). This requires the Windows SDK
 (`rc.exe`) or [`llvm-rc`](https://llvm.org/docs/CommandGuide/llvm-rc.html).
 If neither is present the build still succeeds — it just won't have the
 custom icon in the taskbar.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -2,6 +2,19 @@
 
 This guide covers the basic functionality available in released Vigil builds.
 
+## What Vigil is for
+
+Vigil is a local machine protection tool with a network-first view.
+
+It is built to help you:
+
+- see suspicious network and process activity quickly
+- understand which local process is responsible and why it looks risky
+- contain a process, connection, or machine when you decide the risk is real
+- preserve evidence and an audit trail for follow-up investigation
+
+Vigil is intentionally conservative about action. Scores and advisory context are there to help an operator make better decisions, not to pretend every suspicious connection is a confirmed compromise.
+
 ## Install and launch
 
 ### Windows
@@ -69,9 +82,18 @@ Policy-sensitive settings require Admin Mode when protected policy editing is en
 
 The Help tab summarizes scoring, controls, and safe operating guidance inside the app.
 
-## Active response
+## Common operator workflows
 
-When Vigil has the needed privileges, it can perform reversible response actions:
+### Investigate a suspicious connection
+
+1. Open **Alerts** or **Activity**.
+2. Select the process or connection.
+3. Review the Inspector for the executable path, parent chain, remote endpoint, score reasons, and any enrichment badges.
+4. Decide whether the activity is expected, merely unusual, or worth containing.
+
+### Contain something without losing the thread
+
+When Vigil is elevated and the selected item supports it, you can take reversible action from the Inspector:
 
 - kill a live TCP connection
 - suspend or resume a process
@@ -81,6 +103,27 @@ When Vigil has the needed privileges, it can perform reversible response actions
 - restore networking after isolation
 
 Temporary actions show countdowns and unblock controls. Isolation always arms break-glass recovery so networking can be restored if Vigil crashes.
+
+### Capture evidence on high-confidence alerts
+
+When forensic capture is enabled, Vigil can preserve:
+
+- process memory dumps
+- short PCAP captures
+- TLS sidecar metadata
+- provenance manifests with SHA-256 and alert context
+
+Generated artifacts are stored under the Vigil data directory unless a custom path is configured.
+
+## Privileges and visibility
+
+Vigil does more with elevated privileges, but it is still usable without them.
+
+- On Windows, elevation enables ETW-backed near-real-time visibility and active response actions.
+- On Linux, elevated privileges or the needed capabilities are required for actions such as firewall-based containment and some deeper monitoring paths.
+- On macOS, the app may rely on OS-granted visibility and falls back where deeper system hooks are unavailable.
+
+The header and controls are meant to make that state visible so you can tell when Vigil is observing only, and when it is able to act.
 
 ## Forensics
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -106,7 +106,7 @@ Temporary actions show countdowns and unblock controls. Isolation always arms br
 
 ### Capture evidence on high-confidence alerts
 
-When forensic capture is enabled, Vigil can preserve:
+On Windows today, when forensic capture is enabled, Vigil can preserve:
 
 - process memory dumps
 - short PCAP captures
@@ -127,7 +127,7 @@ The header and controls are meant to make that state visible so you can tell whe
 
 ## Forensics
 
-When enabled, Vigil can capture forensic evidence for high-confidence alerts:
+On Windows today, when enabled, Vigil can capture forensic evidence for high-confidence alerts:
 
 - process memory dumps
 - short PCAP captures

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -11,7 +11,7 @@ It is built to help you:
 - see suspicious network and process activity quickly
 - understand which local process is responsible and why it looks risky
 - contain a process, connection, or machine when you decide the risk is real
-- preserve evidence and an audit trail for follow-up investigation
+- preserve an audit trail for follow-up investigation and, on Windows today, capture forensic artifacts
 
 Vigil is intentionally conservative about action. Scores and advisory context are there to help an operator make better decisions, not to pretend every suspicious connection is a confirmed compromise.
 
@@ -72,7 +72,7 @@ The Settings tab stores changes automatically. Common settings include:
 - user-defined response rules
 - scheduled lockdown
 - break-glass recovery timeout
-- forensic capture options
+- forensic capture options (Windows today)
 - honeypot decoy settings
 - uninstall confirmation flow
 


### PR DESCRIPTION
## Summary
Update the README and user guide so Vigil is described as the tool it already is today: a local machine protection tool with a strong network-first view, not only a passive monitor.

## What changed
- tighten the README headline and opening paragraphs to reflect detection, investigation, containment, and evidence preservation
- reorganize the README capability section around what Vigil actually does today: detect, investigate, protect, and preserve trust
- keep the language precise and avoid promising a larger product category than the shipped feature set supports
- add a `What Vigil is for` section to the user guide
- add workflow-oriented user-guide sections for investigation, containment, evidence capture, and privilege expectations

## Intent
This is a positioning cleanup, not a scope expansion. The goal is to avoid underselling Vigil's released capabilities while still being careful about the limits of scoring, heuristics, and operator-driven action.