### PR TITLE
[codex] Align Phase 15 docs with implemented integrity features

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,12 @@ Drop plain-text blocklists anywhere and list them:
 
 Format: one IP or CIDR per line, `#` starts a comment. Hits add **+3**
 and the Alerts row gets a red `REP` badge naming the source list.
+If you place `<blocklist>.sha256` beside the file in normal `sha256sum`
+format, Vigil verifies the list before loading it and refuses mismatched
+content. Even without a sidecar, Vigil still records first-seen and changed
+hashes for configured blocklists and response-rule files in its protected
+local provenance registry so silent edits show up in the audit trail instead
+of being mistaken for normal application state.
 
 ### File-drop correlation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -253,7 +253,7 @@ Security remains paramount, but Vigil must stay light enough to protect a workst
 
 ---
 
-## Phase 15 — File Integrity & Anti-Tamper (OPEN backlog)
+## Phase 15 — File Integrity & Anti-Tamper ✅ COMPLETE
 
 Make sure no file used by Vigil can be silently tampered with without detection, recovery, or operator visibility.
 
@@ -263,10 +263,10 @@ Make sure no file used by Vigil can be silently tampered with without detection,
 - [x] Secure audit-log chaining — audit entries are hash-chained and verified at startup so edits or removal become visible
 - [x] Forensic artifact provenance and checksum manifests — PCAP captures, TLS sidecars, and process dumps now get `.manifest.json` sidecars with SHA-256, size, alert context, and capture metadata
 
-### Remaining backlog
-- [ ] Provenance model for operator-managed blocklists and response-rule YAML files that detects malicious tampering without treating intentional local edits as corruption
-- [ ] Startup integrity scan with clear operator-visible failure modes
-- [ ] Recovery / quarantine path for corrupted or untrusted Vigil-owned files beyond the current signed-backup restore paths
+### Completed in this branch
+- [x] Provenance model for operator-managed blocklists and response-rule YAML files that detects malicious tampering without treating intentional local edits as corruption
+- [x] Startup integrity scan with clear operator-visible failure modes
+- [x] Recovery / quarantine path for corrupted or untrusted Vigil-owned files beyond the current signed-backup restore paths
 
 ---
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -77,6 +77,10 @@ The Settings tab stores changes automatically. Common settings include:
 - uninstall confirmation flow
 
 Policy-sensitive settings require Admin Mode when protected policy editing is enabled.
+Configured blocklists and response-rule YAML stay operator-managed: Vigil can
+verify optional `.sha256` sidecars when you provide them, and it also records
+first-seen and changed hashes in its protected local provenance registry so
+later edits are visible without treating every intentional update as corruption.
 
 ### Help
 
@@ -141,6 +145,11 @@ Generated artifacts are stored under the Vigil data directory unless a custom pa
 Vigil writes rolling logs and an audit stream under the per-user Vigil data directory. The tray menu includes an **Open Logs Folder** shortcut.
 
 Audit events include active response actions, integrity scan summaries, uninstall attempts, and other security-relevant state changes.
+At startup, Vigil also checks configured operator-managed inputs and Vigil-owned
+forensic artifact manifests. Changed blocklists or response-rule files are
+recorded as provenance events, while unreadable or tampered Vigil-owned
+artifacts are logged as integrity failures and may be moved into the integrity
+quarantine under the data directory.
 
 ## Boot-time service mode
 

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -84,11 +84,26 @@ pub fn show(ui: &mut egui::Ui) {
                     });
 
                     card(ui, "Integrity and provenance", |ui| {
-                        body(ui, "Vigil treats operator-managed inputs differently from its own generated state. Blocklists and response-rule YAML may change on purpose, so Vigil records first-seen and changed hashes in a protected local provenance registry instead of treating every edit as corruption.");
+                        body(
+                            ui,
+                            "Vigil treats operator-managed inputs differently from its own generated state. Blocklists and response-rule YAML may change on purpose, so Vigil records first-seen and changed hashes in a protected local provenance registry instead of treating every edit as corruption.",
+                        );
                         ui.add_space(6.0);
-                        bullet(ui, "Optional sidecars", "Place <filename>.sha256 beside a blocklist or rules file in normal sha256sum format to require an exact hash match before Vigil loads it.");
-                        bullet(ui, "Startup scan", "Each launch records integrity scan results in the audit trail so missing, unreadable, changed, or newly seen inputs are visible to the operator.");
-                        bullet(ui, "Artifact quarantine", "If a Vigil-owned forensic artifact no longer matches its manifest, Vigil logs the failure and moves the manifest and related files into the integrity quarantine instead of leaving them beside trusted evidence.");
+                        bullet(
+                            ui,
+                            "Optional sidecars",
+                            "Place <filename>.sha256 beside a blocklist or rules file in normal sha256sum format to require an exact hash match before Vigil loads it.",
+                        );
+                        bullet(
+                            ui,
+                            "Startup scan",
+                            "Each launch records integrity scan results in the audit trail so missing, unreadable, changed, or newly seen inputs are visible to the operator.",
+                        );
+                        bullet(
+                            ui,
+                            "Artifact quarantine",
+                            "If a Vigil-owned forensic artifact no longer matches its manifest, Vigil logs the failure and moves the manifest and related files into the integrity quarantine instead of leaving them beside trusted evidence.",
+                        );
                     });
 
                     card(ui, "Forensics and honeypots", |ui| {
@@ -154,7 +169,12 @@ pub fn show(ui: &mut egui::Ui) {
             card(ui, "Detection depth", |ui| { body(ui, "Phase 12 adds behavioural baselines, script-host inspection, TLS ClientHello enrichment, parent/token anomaly heuristics, and ATT&CK-style mappings while keeping the output explainable in the inspector."); });
             card(ui, "Auto response and allowlisting", |ui| { body(ui, "Auto response is optional and can dry-run. Allowlist-only mode can force containment for traffic from processes outside the trusted list, explicit allowlist, and current Microsoft-signed system processes."); });
             card(ui, "User-defined response rules", |ui| { body(ui, "Operator-supplied YAML rules can dry-run or execute kill_connection, block_remote, block_process, and quarantine actions. See response-rules.example.yaml."); });
-            card(ui, "Integrity and provenance", |ui| { body(ui, "Optional .sha256 sidecars can hard-verify blocklists and response-rule files. Vigil also records first-seen and changed hashes for those operator-managed inputs, logs startup integrity results, and quarantines corrupted forensic artifacts when their manifests no longer match."); });
+            card(ui, "Integrity and provenance", |ui| {
+                body(
+                    ui,
+                    "Optional .sha256 sidecars can hard-verify blocklists and response-rule files. Vigil also records first-seen and changed hashes for those operator-managed inputs, logs startup integrity results, and quarantines corrupted forensic artifacts when their manifests no longer match.",
+                );
+            });
             card(ui, "Forensics and honeypots", |ui| { body(ui, "Process dumps, PCAP capture, TLS sidecar extraction, and decoy-file touches are optional and configurable in Settings."); });
             card(ui, "Secure updates", |ui| { body(ui, "Each release ships a signed update manifest and signature. Vigil can verify the manifest offline against the embedded trust anchor before you trust a downloaded asset."); });
             card(ui, "Break-glass recovery", |ui| { body(ui, "Watchdog-based recovery can restore networking after an isolation lockout if Vigil dies and the heartbeat goes stale."); });

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -83,6 +83,14 @@ pub fn show(ui: &mut egui::Ui) {
                         bullet(ui, "Example file", "See response-rules.example.yaml in the repository root for a starting point.");
                     });
 
+                    card(ui, "Integrity and provenance", |ui| {
+                        body(ui, "Vigil treats operator-managed inputs differently from its own generated state. Blocklists and response-rule YAML may change on purpose, so Vigil records first-seen and changed hashes in a protected local provenance registry instead of treating every edit as corruption.");
+                        ui.add_space(6.0);
+                        bullet(ui, "Optional sidecars", "Place <filename>.sha256 beside a blocklist or rules file in normal sha256sum format to require an exact hash match before Vigil loads it.");
+                        bullet(ui, "Startup scan", "Each launch records integrity scan results in the audit trail so missing, unreadable, changed, or newly seen inputs are visible to the operator.");
+                        bullet(ui, "Artifact quarantine", "If a Vigil-owned forensic artifact no longer matches its manifest, Vigil logs the failure and moves the manifest and related files into the integrity quarantine instead of leaving them beside trusted evidence.");
+                    });
+
                     card(ui, "Forensics and honeypots", |ui| {
                         body(ui, "Optional forensic capture is available in Settings. Vigil can write a full user-mode process dump and a short host-wide packet window on high-score alerts, both rate-limited and logged to the audit trail. Honeypot decoys can plant lure files into common user folders and raise synthetic alerts when touched.");
                         ui.add_space(6.0);
@@ -146,6 +154,7 @@ pub fn show(ui: &mut egui::Ui) {
             card(ui, "Detection depth", |ui| { body(ui, "Phase 12 adds behavioural baselines, script-host inspection, TLS ClientHello enrichment, parent/token anomaly heuristics, and ATT&CK-style mappings while keeping the output explainable in the inspector."); });
             card(ui, "Auto response and allowlisting", |ui| { body(ui, "Auto response is optional and can dry-run. Allowlist-only mode can force containment for traffic from processes outside the trusted list, explicit allowlist, and current Microsoft-signed system processes."); });
             card(ui, "User-defined response rules", |ui| { body(ui, "Operator-supplied YAML rules can dry-run or execute kill_connection, block_remote, block_process, and quarantine actions. See response-rules.example.yaml."); });
+            card(ui, "Integrity and provenance", |ui| { body(ui, "Optional .sha256 sidecars can hard-verify blocklists and response-rule files. Vigil also records first-seen and changed hashes for those operator-managed inputs, logs startup integrity results, and quarantines corrupted forensic artifacts when their manifests no longer match."); });
             card(ui, "Forensics and honeypots", |ui| { body(ui, "Process dumps, PCAP capture, TLS sidecar extraction, and decoy-file touches are optional and configurable in Settings."); });
             card(ui, "Secure updates", |ui| { body(ui, "Each release ships a signed update manifest and signature. Vigil can verify the manifest offline against the embedded trust anchor before you trust a downloaded asset."); });
             card(ui, "Break-glass recovery", |ui| { body(ui, "Watchdog-based recovery can restore networking after an isolation lockout if Vigil dies and the heartbeat goes stale."); });


### PR DESCRIPTION
## What changed
- mark Phase 15 complete in the roadmap now that the provenance model, startup integrity scan, and artifact quarantine path are already implemented in code
- document optional `.sha256` sidecars and the protected provenance registry for operator-managed blocklists and response-rule files
- add Help text in the app for integrity/provenance, startup scan results, and artifact quarantine behavior

## Why
The roadmap and operator-facing docs had drifted behind the implementation. That made the repo’s own next-task signal misleading and hid already-shipped integrity behavior from operators.

## Impact
- roadmap sequencing now reflects the current codebase
- operators get clearer guidance on how Phase 15 integrity features behave
- the in-app Help view now exposes integrity/provenance behavior without requiring log spelunking

## Validation
- `cargo check --locked --offline`
- used the uploaded Rust 1.95 x86_64 toolchain and vendored crate bundle to run that check offline