### PR TITLE
[codex] Automate releases after merge

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,6 +6,7 @@ on:
     types: [completed]
 
 permissions:
+  actions: write
   contents: write
   pull-requests: read
 

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -146,17 +146,32 @@ PY
           git add Cargo.toml Cargo.lock
           git commit -m "chore(release): cut v${NEXT_VERSION} after merge of #${PR_NUMBER} [skip ci]"
 
-      - name: Tag and push release
+      - name: Tag and push release ref
         if: steps.tag.outputs.release_ready == 'true'
         env:
           NEXT_VERSION: ${{ steps.version.outputs.next_version }}
         run: |
-          git tag "v${NEXT_VERSION}"
+          git tag -a "v${NEXT_VERSION}" -m "Vigil v${NEXT_VERSION}"
           if [ "${{ steps.version.outputs.needs_commit }}" = "true" ]; then
-            git push origin HEAD:master --follow-tags
+            git push origin HEAD:master "refs/tags/v${NEXT_VERSION}"
           else
             git push origin "refs/tags/v${NEXT_VERSION}"
           fi
+
+      - name: Dispatch release workflow
+        if: steps.tag.outputs.release_ready == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEXT_VERSION: ${{ steps.version.outputs.next_version }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/actions/workflows/release.yml/dispatches" \
+            -f ref="master" \
+            -f inputs[tag]="v${NEXT_VERSION}" \
+            -f inputs[version]="${NEXT_VERSION}" \
+            -f inputs[source_ref]="refs/tags/v${NEXT_VERSION}"
 
       - name: Report skipped release
         if: always() && steps.tag.outputs.release_ready != 'true'

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,168 @@
+name: Auto release after merge
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: auto-release-master
+  cancel-in-progress: false
+
+jobs:
+  prepare-release:
+    name: Prepare release tag from merged master
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Refresh master and tags
+        run: git fetch origin master --tags
+
+      - name: Skip stale CI runs
+        id: freshness
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          current_master="$(git rev-parse origin/master)"
+          if [ "$HEAD_SHA" != "$current_master" ]; then
+            echo "release_ready=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=master advanced to $current_master" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "release_ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve merged pull request
+        id: pr
+        if: steps.freshness.outputs.release_ready == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          prs_json="$(gh api -H "Accept: application/vnd.github+json" "/repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls")"
+          pr_number="$(
+            PRS_JSON="$prs_json" python3 - <<'PY'
+import json
+import os
+
+prs = json.loads(os.environ["PRS_JSON"])
+candidates = [
+    pr for pr in prs
+    if pr.get("merged_at") and pr.get("base", {}).get("ref") == "master"
+]
+if not candidates:
+    print("")
+else:
+    candidates.sort(key=lambda pr: pr["merged_at"], reverse=True)
+    print(candidates[0]["number"])
+PY
+          )"
+          if [ -z "$pr_number" ]; then
+            echo "release_ready=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=no merged pull request found for ${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "release_ready=true" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Read current app version
+        id: current
+        if: steps.pr.outputs.release_ready == 'true'
+        run: |
+          python3 scripts/prepare_release.py \
+            --cargo-toml Cargo.toml \
+            --cargo-lock Cargo.lock \
+            --print-current \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Choose release version
+        id: version
+        if: steps.pr.outputs.release_ready == 'true'
+        env:
+          CURRENT_VERSION: ${{ steps.current.outputs.current_version }}
+        run: |
+          if git rev-parse -q --verify "refs/tags/v${CURRENT_VERSION}" >/dev/null; then
+            next_version="$(
+              PYTHONPATH="scripts${PYTHONPATH:+:$PYTHONPATH}" \
+                python3 - <<'PY'
+from prepare_release import bump_patch
+import os
+
+print(bump_patch(os.environ["CURRENT_VERSION"]))
+PY
+            )"
+            echo "needs_commit=true" >> "$GITHUB_OUTPUT"
+          else
+            next_version="$CURRENT_VERSION"
+            echo "needs_commit=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "release_ready=true" >> "$GITHUB_OUTPUT"
+          echo "next_version=$next_version" >> "$GITHUB_OUTPUT"
+          echo "tag=v${next_version}" >> "$GITHUB_OUTPUT"
+
+      - name: Skip existing release tag
+        id: tag
+        if: steps.version.outputs.release_ready == 'true'
+        env:
+          NEXT_VERSION: ${{ steps.version.outputs.next_version }}
+        run: |
+          if git rev-parse -q --verify "refs/tags/v${NEXT_VERSION}" >/dev/null; then
+            echo "release_ready=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=tag v${NEXT_VERSION} already exists" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "release_ready=true" >> "$GITHUB_OUTPUT"
+          echo "tag=v${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Update version files
+        if: steps.tag.outputs.release_ready == 'true' && steps.version.outputs.needs_commit == 'true'
+        env:
+          NEXT_VERSION: ${{ steps.version.outputs.next_version }}
+        run: |
+          python3 scripts/prepare_release.py \
+            --cargo-toml Cargo.toml \
+            --cargo-lock Cargo.lock \
+            --next-version "${NEXT_VERSION}"
+
+      - name: Commit version bump
+        if: steps.tag.outputs.release_ready == 'true' && steps.version.outputs.needs_commit == 'true'
+        env:
+          NEXT_VERSION: ${{ steps.version.outputs.next_version }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore(release): cut v${NEXT_VERSION} after merge of #${PR_NUMBER} [skip ci]"
+
+      - name: Tag and push release
+        if: steps.tag.outputs.release_ready == 'true'
+        env:
+          NEXT_VERSION: ${{ steps.version.outputs.next_version }}
+        run: |
+          git tag "v${NEXT_VERSION}"
+          if [ "${{ steps.version.outputs.needs_commit }}" = "true" ]; then
+            git push origin HEAD:master --follow-tags
+          else
+            git push origin "refs/tags/v${NEXT_VERSION}"
+          fi
+
+      - name: Report skipped release
+        if: always() && steps.tag.outputs.release_ready != 'true'
+        run: |
+          echo "Auto-release skipped."
+          echo "Freshness: ${{ steps.freshness.outputs.skip_reason }}"
+          echo "PR resolution: ${{ steps.pr.outputs.skip_reason }}"
+          echo "Versioning: ${{ steps.version.outputs.skip_reason }}"
+          echo "Tag check: ${{ steps.tag.outputs.skip_reason }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,20 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to publish, for example v1.3.6
+        required: true
+        type: string
+      version:
+        description: Normalized release version, for example 1.3.6
+        required: true
+        type: string
+      source_ref:
+        description: Git ref or SHA to check out for the release build
+        required: false
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -34,26 +48,46 @@ jobs:
     outputs:
       tag: ${{ steps.validate.outputs.tag }}
       version: ${{ steps.validate.outputs.version }}
+      checkout_ref: ${{ steps.validate.outputs.checkout_ref }}
     steps:
       - name: Validate release tag
         id: validate
         shell: bash
         env:
-          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_REF_NAME: ${{ github.ref_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_SOURCE_REF: ${{ inputs.source_ref }}
         run: |
           set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            REF_NAME="$INPUT_TAG"
+            VERSION="$INPUT_VERSION"
+          else
+            REF_NAME="$PUSH_REF_NAME"
+            VERSION="${REF_NAME#v}"
+          fi
           if [[ ! "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?(\+[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
             echo "Invalid release tag: $REF_NAME" >&2
             echo "Expected vMAJOR.MINOR.PATCH with optional prerelease and/or build suffix." >&2
             exit 1
           fi
-          VERSION="${REF_NAME#v}"
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?(\+[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
             echo "Invalid normalized version: $VERSION" >&2
             exit 1
           fi
+          if [ "$REF_NAME" != "v$VERSION" ]; then
+            echo "Input version $VERSION did not match tag $REF_NAME" >&2
+            exit 1
+          fi
+          CHECKOUT_REF="$INPUT_SOURCE_REF"
+          if [ -z "$CHECKOUT_REF" ]; then
+            CHECKOUT_REF="refs/tags/$REF_NAME"
+          fi
           echo "tag=$REF_NAME" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=$CHECKOUT_REF" >> "$GITHUB_OUTPUT"
 
   # ── Windows — Inno Setup EXE ───────────────────────────────────────────────
   build-windows:
@@ -62,6 +96,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ needs.validate-release-metadata.outputs.checkout_ref }}
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -109,6 +145,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ needs.validate-release-metadata.outputs.checkout_ref }}
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -180,6 +218,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ needs.validate-release-metadata.outputs.checkout_ref }}
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -264,6 +304,8 @@ jobs:
       artifact-metadata: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ needs.validate-release-metadata.outputs.checkout_ref }}
 
       - name: Collect all installers
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ The release workflow also emits SLSA3 provenance for the published assets via
 the GitHub Actions SLSA generator. That provenance is attached to the release
 for users who prefer `slsa-verifier`-style supply-chain checks.
 
+Merged pull requests to `master` now cut the next patch release automatically
+after the `CI` workflow succeeds. That automated version bump creates the tag
+that feeds the existing signed release pipeline, so `releases/latest` and the
+signed update manifest stay in sync with merged code.
+
 The signed update manifest is the trust anchor for Vigil's update channel. It
 lists the release assets and their SHA-256 digests, then gets signed with an
 embedded Ed25519 public key in the app. You can verify it offline with:

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Prepare the next Vigil release version.
+
+This helper keeps the app version embedded in the binaries aligned with the
+GitHub release tag that the existing release workflow publishes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+
+SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+
+
+def bump_patch(version: str) -> str:
+    match = SEMVER_RE.fullmatch(version.strip())
+    if not match:
+        raise ValueError(
+            f"expected a stable MAJOR.MINOR.PATCH version, got {version!r}"
+        )
+    major, minor, patch = (int(part) for part in match.groups())
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def current_version_from_cargo_toml(text: str) -> str:
+    lines = text.splitlines(keepends=True)
+    in_package = False
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_package = stripped == "[package]"
+            continue
+        if not in_package:
+            continue
+        if not stripped.startswith("version"):
+            continue
+        match = re.match(r'(\s*version\s*=\s*")([^"]+)(".*)', line)
+        if not match:
+            raise ValueError("found package version line in Cargo.toml but could not parse it")
+        return match.group(2)
+
+    raise ValueError("could not find [package] version in Cargo.toml")
+
+
+def current_version_from_cargo_lock(text: str) -> str:
+    lines = text.splitlines(keepends=True)
+    in_package = False
+    package_name = None
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "[[package]]":
+            in_package = True
+            package_name = None
+            continue
+        if stripped.startswith("[") and stripped != "[[package]]":
+            in_package = False
+            package_name = None
+            continue
+        if not in_package:
+            continue
+        if stripped.startswith('name = "'):
+            match = re.match(r'\s*name\s*=\s*"([^"]+)"', line)
+            if match:
+                package_name = match.group(1)
+            continue
+        if package_name != "vigil" or not stripped.startswith("version"):
+            continue
+        match = re.match(r'(\s*version\s*=\s*")([^"]+)(".*)', line)
+        if not match:
+            raise ValueError("found vigil package version line in Cargo.lock but could not parse it")
+        return match.group(2)
+
+    raise ValueError('could not find package "vigil" version in Cargo.lock')
+
+
+def update_cargo_toml(text: str, next_version: str) -> tuple[str, str]:
+    lines = text.splitlines(keepends=True)
+    in_package = False
+
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_package = stripped == "[package]"
+            continue
+        if not in_package:
+            continue
+        if not stripped.startswith("version"):
+            continue
+        match = re.match(r'(\s*version\s*=\s*")([^"]+)(".*)', line)
+        if not match:
+            raise ValueError("found package version line in Cargo.toml but could not parse it")
+        current_version = match.group(2)
+        lines[idx] = f"{match.group(1)}{next_version}{match.group(3)}"
+        return "".join(lines), current_version
+
+    raise ValueError("could not find [package] version in Cargo.toml")
+
+
+def update_cargo_lock(text: str, next_version: str) -> tuple[str, str]:
+    lines = text.splitlines(keepends=True)
+    in_package = False
+    package_name = None
+
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == "[[package]]":
+            in_package = True
+            package_name = None
+            continue
+        if stripped.startswith("[") and stripped != "[[package]]":
+            in_package = False
+            package_name = None
+            continue
+        if not in_package:
+            continue
+        if stripped.startswith('name = "'):
+            match = re.match(r'\s*name\s*=\s*"([^"]+)"', line)
+            if match:
+                package_name = match.group(1)
+            continue
+        if package_name != "vigil" or not stripped.startswith("version"):
+            continue
+        match = re.match(r'(\s*version\s*=\s*")([^"]+)(".*)', line)
+        if not match:
+            raise ValueError("found vigil package version line in Cargo.lock but could not parse it")
+        current_version = match.group(2)
+        lines[idx] = f"{match.group(1)}{next_version}{match.group(3)}"
+        return "".join(lines), current_version
+
+    raise ValueError('could not find package "vigil" version in Cargo.lock')
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Bump Vigil's stable patch version in Cargo.toml and Cargo.lock."
+    )
+    parser.add_argument("--cargo-toml", required=True, type=pathlib.Path)
+    parser.add_argument("--cargo-lock", required=True, type=pathlib.Path)
+    parser.add_argument(
+        "--print-current",
+        action="store_true",
+        help="Validate the current version and print it without modifying files.",
+    )
+    parser.add_argument(
+        "--next-version",
+        help="Explicit version to write. Defaults to the next stable patch version.",
+    )
+    parser.add_argument(
+        "--github-output",
+        type=pathlib.Path,
+        help="Optional path to the GitHub Actions output file.",
+    )
+    args = parser.parse_args()
+
+    cargo_toml_text = args.cargo_toml.read_text(encoding="utf-8")
+    cargo_lock_text = args.cargo_lock.read_text(encoding="utf-8")
+
+    current_toml_version = current_version_from_cargo_toml(cargo_toml_text)
+    current_lock_version = current_version_from_cargo_lock(cargo_lock_text)
+    if current_toml_version != current_lock_version:
+        raise ValueError(
+            "Cargo.toml and Cargo.lock disagree on the current Vigil version "
+            f"({current_toml_version} vs {current_lock_version})"
+        )
+
+    if args.print_current:
+        print(f"current_version={current_toml_version}")
+        if args.github_output is not None:
+            with args.github_output.open("a", encoding="utf-8") as handle:
+                handle.write(f"current_version={current_toml_version}\n")
+        return 0
+
+    next_version = args.next_version or bump_patch(current_toml_version)
+
+    updated_toml, toml_version = update_cargo_toml(cargo_toml_text, next_version)
+    updated_lock, lock_version = update_cargo_lock(cargo_lock_text, next_version)
+
+    if toml_version != lock_version:
+        raise ValueError(
+            "Cargo.toml and Cargo.lock disagree on the current Vigil version "
+            f"({toml_version} vs {lock_version})"
+        )
+
+    args.cargo_toml.write_text(updated_toml, encoding="utf-8")
+    args.cargo_lock.write_text(updated_lock, encoding="utf-8")
+
+    print(f"current_version={current_toml_version}")
+    print(f"next_version={next_version}")
+    if args.github_output is not None:
+        with args.github_output.open("a", encoding="utf-8") as handle:
+            handle.write(f"current_version={current_toml_version}\n")
+            handle.write(f"next_version={next_version}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/test_prepare_release.py
+++ b/scripts/test_prepare_release.py
@@ -1,0 +1,57 @@
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from prepare_release import (
+    bump_patch,
+    current_version_from_cargo_lock,
+    current_version_from_cargo_toml,
+    update_cargo_lock,
+    update_cargo_toml,
+)
+
+
+class PrepareReleaseTests(unittest.TestCase):
+    def test_bump_patch_accepts_stable_semver(self) -> None:
+        self.assertEqual(bump_patch("1.3.5"), "1.3.6")
+
+    def test_bump_patch_rejects_prerelease(self) -> None:
+        with self.assertRaises(ValueError):
+            bump_patch("1.3.5-rc.1")
+
+    def test_update_cargo_toml_updates_package_version_only(self) -> None:
+        text = """[package]
+name = "vigil"
+version = "1.3.5"
+
+[workspace.metadata.dist]
+cargo-dist-version = "0.22.1"
+"""
+        updated, current = update_cargo_toml(text, "1.3.6")
+        self.assertEqual(current, "1.3.5")
+        self.assertIn('version = "1.3.6"\n', updated)
+        self.assertIn('cargo-dist-version = "0.22.1"\n', updated)
+        self.assertEqual(current_version_from_cargo_toml(text), "1.3.5")
+
+    def test_update_cargo_lock_updates_root_package_only(self) -> None:
+        text = """version = 4
+
+[[package]]
+name = "serde"
+version = "1.0.0"
+
+[[package]]
+name = "vigil"
+version = "1.3.5"
+"""
+        updated, current = update_cargo_lock(text, "1.3.6")
+        self.assertEqual(current, "1.3.5")
+        self.assertIn('name = "serde"\nversion = "1.0.0"\n', updated)
+        self.assertIn('name = "vigil"\nversion = "1.3.6"', updated)
+        self.assertEqual(current_version_from_cargo_lock(text), "1.3.5")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an `auto-release` workflow that watches successful `CI` runs on `master`, resolves the merged PR behind the commit, and tags a release automatically
- keep the existing signed tag-based release pipeline intact so the published release still produces the signed update manifest and attached assets
- add a small `scripts/prepare_release.py` helper plus unit tests so version bumping stays deterministic and auditable
- document the new merge-to-release behavior in the README

## Why
Merged code was not producing a new GitHub release unless a maintainer manually created and pushed a version tag. That left `releases/latest` stale, which also meant the updater-facing signed manifest did not advance automatically.

## Behavior
- if `Cargo.toml` already names an unreleased version, the workflow tags that exact version on the merged `master` commit
- otherwise the workflow bumps the patch version in `Cargo.toml` and `Cargo.lock`, commits that automated version change, and tags the new version
- stale CI runs are skipped so only the current `master` tip can cut a release
- direct pushes without an associated merged PR are skipped

## Validation
- `python3 -m unittest scripts/test_prepare_release.py`
- `python3 -m py_compile scripts/prepare_release.py scripts/test_prepare_release.py`
- `python3 scripts/prepare_release.py --cargo-toml Cargo.toml --cargo-lock Cargo.lock --print-current`
- exercised the helper against temporary copies of `Cargo.toml` and `Cargo.lock` to confirm the intended version fields update together

## Notes
- I could not run a full GitHub workflow linter in this container because the required YAML/parser tooling is not installed here
- the release flow still depends on the existing repository secrets and permissions already required by `.github/workflows/release.yml`