### PR TITLE
[codex] fix

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,10 +6,7 @@ Please report suspected security vulnerabilities privately through GitHub Securi
 
 https://github.com/YMRYMR/vigil/security/advisories/new
 
-If GitHub Security Advisories are unavailable, email:
-
-- **Security contact:** angeruroth@gmail.com
-- **Subject prefix:** `[Vigil Security]`
+Use GitHub Security Advisories for private vulnerability reporting. If that workflow is unavailable, do not open a public issue; use a private maintainer contact path instead.
 
 Please include:
 


### PR DESCRIPTION
## What changed

This PR removes the public fallback email address from `SECURITY.md`.

The security policy now points reporters to GitHub Security Advisories for private vulnerability disclosure and avoids publishing the email address directly in the repository documents.

## Why

The current repository documents expose a personal email address publicly. This PR removes that live public reference without changing the rest of the disclosure guidance.

## Impact

After merge, the address will no longer appear in the current `master` version of `SECURITY.md`.

## Important limitation

This does **not** remove the address from existing Git history. The email is present in many historical commits because the same `SECURITY.md` line existed across many revisions. Removing it from history would require a repository history rewrite, which is a separate high-impact operation.