### PR TITLE
[codex] fix auto-release workflow parsing

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -52,23 +52,7 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           prs_json="$(gh api -H "Accept: application/vnd.github+json" "/repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls")"
-          pr_number="$(
-          PRS_JSON="$prs_json" python3 - <<'PY'
-          import json
-          import os
-
-          prs = json.loads(os.environ["PRS_JSON"])
-          candidates = [
-              pr for pr in prs
-              if pr.get("merged_at") and pr.get("base", {}).get("ref") == "master"
-          ]
-          if not candidates:
-              print("")
-          else:
-              candidates.sort(key=lambda pr: pr["merged_at"], reverse=True)
-              print(candidates[0]["number"])
-          PY
-          )"
+          pr_number="$(PRS_JSON="$prs_json" python3 -c 'import json, os; prs = json.loads(os.environ["PRS_JSON"]); candidates = [pr for pr in prs if pr.get("merged_at") and pr.get("base", {}).get("ref") == "master"]; candidates.sort(key=lambda pr: pr["merged_at"], reverse=True); print(candidates[0]["number"] if candidates else "")')"
           if [ -z "$pr_number" ]; then
             echo "release_ready=false" >> "$GITHUB_OUTPUT"
             echo "skip_reason=no merged pull request found for ${HEAD_SHA}" >> "$GITHUB_OUTPUT"
@@ -94,15 +78,7 @@ jobs:
           CURRENT_VERSION: ${{ steps.current.outputs.current_version }}
         run: |
           if git rev-parse -q --verify "refs/tags/v${CURRENT_VERSION}" >/dev/null; then
-            next_version="$(
-              PYTHONPATH="scripts${PYTHONPATH:+:$PYTHONPATH}" \
-                python3 - <<'PY'
-from prepare_release import bump_patch
-import os
-
-print(bump_patch(os.environ["CURRENT_VERSION"]))
-PY
-            )"
+            next_version="$(PYTHONPATH="scripts${PYTHONPATH:+:$PYTHONPATH}" python3 -c 'from prepare_release import bump_patch; import os; print(bump_patch(os.environ["CURRENT_VERSION"]))')"
             echo "needs_commit=true" >> "$GITHUB_OUTPUT"
           else
             next_version="$CURRENT_VERSION"


### PR DESCRIPTION
## What changed

This PR removes both embedded Python heredocs from `.github/workflows/auto-release.yml` and replaces them with inline `python3 -c` invocations.

The auto-release workflow currently contains two multiline Python snippets:

- one in `Resolve merged pull request`
- one in `Choose release version`

Those blocks have been oscillating between shell-valid and YAML-valid indentation. Replacing them with single-line invocations removes that whole class of parse failures.

## Why

The previous fix was incomplete.

After PR #88 merged on April 26, 2026, the `auto-release` workflow still failed immediately on `master` at 15:44 UTC with zero jobs created. That means GitHub was still rejecting the workflow before execution.

The remaining blocker is the second embedded heredoc in `Choose release version`, and the first block was still fragile for the same reason.

## Impact

After merge, the workflow should stop failing at parse time and finally be able to start jobs on successful `CI` push runs for `master`.

This PR only fixes the workflow parsing failure. It does not itself create the missed release tag or backfill the already-missed release.

## Validation

- confirmed the new post-#88 `auto-release` run on `master` still failed immediately with zero jobs created
- inspected the current `master` workflow file and identified both multiline Python blocks as parse-risk points
- replaced both with single-line Python calls to keep the workflow syntactically simple and stable
- kept the change scoped to `.github/workflows/auto-release.yml`

## Follow-up

After this PR is merged:

1. confirm the next `auto-release` run on `master` starts successfully
2. recover the missed post-#85 release if the automation still does not backfill it automatically