### PR TITLE
[codex] fix release recovery after malformed version bump

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -93,31 +93,36 @@ jobs:
             gh api "/repos/${GITHUB_REPOSITORY}/releases/tags/v$1" >/dev/null 2>&1
           }
 
+          tag_snapshot_is_releasable() {
+            VERSION="$1" PYTHONPATH="scripts${PYTHONPATH:+:$PYTHONPATH}" \
+              python3 -c 'import os, subprocess, tomllib; version = os.environ["VERSION"]; cargo_toml = subprocess.run(["git", "show", f"refs/tags/v{version}:Cargo.toml"], check=True, capture_output=True, text=True).stdout; cargo_lock = subprocess.run(["git", "show", f"refs/tags/v{version}:Cargo.lock"], check=True, capture_output=True, text=True).stdout; toml_version = tomllib.loads(cargo_toml)["package"]["version"]; lock_packages = tomllib.loads(cargo_lock)["package"]; vigil = next((pkg for pkg in lock_packages if pkg.get("name") == "vigil"), None); raise SystemExit(0 if vigil and toml_version == version and vigil.get("version") == version else 1)'
+          }
+
           candidate="$CURRENT_VERSION"
+          advanced_past_current=false
           needs_commit=false
           needs_tag_push=false
           recovered_existing_tag=false
 
-          if git rev-parse -q --verify "refs/tags/v${candidate}" >/dev/null; then
-            if ! release_exists "$candidate"; then
-              recovered_existing_tag=true
-            else
-              while true; do
-                candidate="$(bump_patch "$candidate")"
-                if ! git rev-parse -q --verify "refs/tags/v${candidate}" >/dev/null; then
-                  needs_commit=true
-                  needs_tag_push=true
-                  break
-                fi
-                if ! release_exists "$candidate"; then
-                  recovered_existing_tag=true
-                  break
-                fi
-              done
+          while true; do
+            if ! git rev-parse -q --verify "refs/tags/v${candidate}" >/dev/null; then
+              needs_tag_push=true
+              if [ "$advanced_past_current" = "true" ]; then
+                needs_commit=true
+              fi
+              break
             fi
-          else
-            needs_tag_push=true
-          fi
+
+            if ! release_exists "$candidate"; then
+              if tag_snapshot_is_releasable "$candidate"; then
+                recovered_existing_tag=true
+                break
+              fi
+            fi
+
+            candidate="$(bump_patch "$candidate")"
+            advanced_past_current=true
+          done
 
           echo "release_ready=true" >> "$GITHUB_OUTPUT"
           echo "next_version=$candidate" >> "$GITHUB_OUTPUT"

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -11,6 +11,7 @@ import argparse
 import pathlib
 import re
 import sys
+import tomllib
 
 
 SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
@@ -24,6 +25,25 @@ def bump_patch(version: str) -> str:
         )
     major, minor, patch = (int(part) for part in match.groups())
     return f"{major}.{minor}.{patch + 1}"
+
+
+def _preserved_line_ending(line: str) -> str:
+    if line.endswith("\r\n"):
+        return "\r\n"
+    if line.endswith("\n"):
+        return "\n"
+    return ""
+
+
+def _replace_version_line(line: str, next_version: str) -> tuple[str, str]:
+    newline = _preserved_line_ending(line)
+    content = line[: -len(newline)] if newline else line
+    match = re.match(r'(\s*version\s*=\s*")([^"]+)(".*)', content)
+    if not match:
+        raise ValueError("found package version line but could not parse it")
+    current_version = match.group(2)
+    updated = f"{match.group(1)}{next_version}{match.group(3)}{newline}"
+    return updated, current_version
 
 
 def current_version_from_cargo_toml(text: str) -> str:
@@ -48,6 +68,7 @@ def current_version_from_cargo_toml(text: str) -> str:
 
 
 def current_version_from_cargo_lock(text: str) -> str:
+    tomllib.loads(text)
     lines = text.splitlines(keepends=True)
     in_package = False
     package_name = None
@@ -71,7 +92,7 @@ def current_version_from_cargo_lock(text: str) -> str:
             continue
         if package_name != "vigil" or not stripped.startswith("version"):
             continue
-        match = re.match(r'(\s*version\s*=\s*")([^"]+)(".*)', line)
+        match = re.match(r'(\s*version\s*=\s*")([^"]+)(".*)', line.rstrip("\r\n"))
         if not match:
             raise ValueError("found vigil package version line in Cargo.lock but could not parse it")
         return match.group(2)
@@ -92,11 +113,10 @@ def update_cargo_toml(text: str, next_version: str) -> tuple[str, str]:
             continue
         if not stripped.startswith("version"):
             continue
-        match = re.match(r'(\s*version\s*=\s*")([^"]+)(".*)', line)
-        if not match:
-            raise ValueError("found package version line in Cargo.toml but could not parse it")
-        current_version = match.group(2)
-        lines[idx] = f"{match.group(1)}{next_version}{match.group(3)}"
+        try:
+            lines[idx], current_version = _replace_version_line(line, next_version)
+        except ValueError as exc:
+            raise ValueError("found package version line in Cargo.toml but could not parse it") from exc
         return "".join(lines), current_version
 
     raise ValueError("could not find [package] version in Cargo.toml")
@@ -126,11 +146,10 @@ def update_cargo_lock(text: str, next_version: str) -> tuple[str, str]:
             continue
         if package_name != "vigil" or not stripped.startswith("version"):
             continue
-        match = re.match(r'(\s*version\s*=\s*")([^"]+)(".*)', line)
-        if not match:
-            raise ValueError("found vigil package version line in Cargo.lock but could not parse it")
-        current_version = match.group(2)
-        lines[idx] = f"{match.group(1)}{next_version}{match.group(3)}"
+        try:
+            lines[idx], current_version = _replace_version_line(line, next_version)
+        except ValueError as exc:
+            raise ValueError("found vigil package version line in Cargo.lock but could not parse it") from exc
         return "".join(lines), current_version
 
     raise ValueError('could not find package "vigil" version in Cargo.lock')

--- a/scripts/test_prepare_release.py
+++ b/scripts/test_prepare_release.py
@@ -34,6 +34,7 @@ cargo-dist-version = "0.22.1"
         self.assertIn('version = "1.3.6"\n', updated)
         self.assertIn('cargo-dist-version = "0.22.1"\n', updated)
         self.assertEqual(current_version_from_cargo_toml(text), "1.3.5")
+        self.assertIn('version = "1.3.6"\n\n[workspace.metadata.dist]\n', updated)
 
     def test_update_cargo_lock_updates_root_package_only(self) -> None:
         text = """version = 4
@@ -49,8 +50,16 @@ version = "1.3.5"
         updated, current = update_cargo_lock(text, "1.3.6")
         self.assertEqual(current, "1.3.5")
         self.assertIn('name = "serde"\nversion = "1.0.0"\n', updated)
-        self.assertIn('name = "vigil"\nversion = "1.3.6"', updated)
+        self.assertIn('name = "vigil"\nversion = "1.3.6"\n', updated)
         self.assertEqual(current_version_from_cargo_lock(text), "1.3.5")
+
+    def test_update_cargo_lock_preserves_windows_line_endings(self) -> None:
+        text = (
+            'version = 4\r\n\r\n[[package]]\r\nname = "vigil"\r\nversion = "1.3.5"\r\n'
+        )
+        updated, current = update_cargo_lock(text, "1.3.6")
+        self.assertEqual(current, "1.3.5")
+        self.assertIn('name = "vigil"\r\nversion = "1.3.6"\r\n', updated)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

This PR fixes the remaining release-generation failure after merge.

The changes do two things:

- fix `scripts/prepare_release.py` so version bumps preserve line endings instead of corrupting `Cargo.lock`
- harden `.github/workflows/auto-release.yml` so it only reuses an existing unreleased tag when the tagged snapshot still contains parseable, version-aligned `Cargo.toml` and `Cargo.lock`

## Why

The latest successful `auto-release` run now dispatches the `release.yml` workflow, but the release still fails.

Concrete evidence from April 26, 2026:

- `Auto release after merge` run `24961554344` on commit `20365c9` completed successfully
- that run dispatched `Release` run `24961557549`
- `Release` run `24961557549` failed on all three platform builds
- the failure annotations show the same root cause on each platform: malformed `Cargo.lock` content at the tagged `v1.3.6` snapshot (`version = "1.3.6"dependencies = [`)
- `releases/latest` is still `v1.3.5`

So the remaining blocker is no longer workflow dispatch or protected-branch handling. It is the broken `v1.3.6` release snapshot plus recovery logic that keeps trying to reuse that unreleased bad tag.

## Impact

After merge, the next successful merge to `master` should be able to publish a clean new release again.

In the current repository state, the hardened selector will skip the malformed unreleased `v1.3.6` tag and cut a fresh `v1.3.7` release instead of retrying the same broken snapshot forever.

## Validation

- `python3 -m unittest scripts/test_prepare_release.py`
- confirmed the existing `v1.3.6` tag fails TOML parsing for `Cargo.lock`
- simulated the updated release-selection logic locally against the current repository state; it now chooses `v1.3.7` with a new version-bump commit/tag instead of reusing broken `v1.3.6`

## Follow-up

After this PR lands, the repository should still treat `v1.3.6` as a broken unreleased tag. I did not rewrite or move that existing tag automatically because that would be a higher-risk history mutation.