### PR TITLE
[codex] don't block releases on bookkeeping PR creation

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -222,11 +222,13 @@ jobs:
             echo "Version bump PR already open: #$existing_pr"
             exit 0
           fi
-          gh pr create \
+          if ! gh pr create \
             --base master \
             --head "$RELEASE_BRANCH" \
             --title "chore(release): record v${NEXT_VERSION} version bump" \
-            --body "Keeps \`Cargo.toml\` and \`Cargo.lock\` aligned with the already-cut \`v${NEXT_VERSION}\` release commit."
+            --body "Keeps \`Cargo.toml\` and \`Cargo.lock\` aligned with the already-cut \`v${NEXT_VERSION}\` release commit."; then
+            echo "::warning::Could not open release bookkeeping PR for ${RELEASE_BRANCH}. The release branch was pushed successfully, but GitHub Actions is not allowed to create pull requests in this repository."
+          fi
 
       - name: Dispatch release workflow
         if: steps.tag.outputs.release_ready == 'true'


### PR DESCRIPTION
## What changed

This PR makes the bookkeeping PR step in `.github/workflows/auto-release.yml` non-fatal.

The workflow still tries to open the `release/vX.Y.Z` version-bump pull request when it cuts a new release commit, but if GitHub refuses PR creation for the Actions token, the workflow now emits a warning and continues to dispatch the actual release build.

## Why

After PR #91 merged on April 26, 2026, the remaining failure moved forward to the `Open version bump pull request` step.

The workflow error is explicit:

- `GitHub Actions is not permitted to create or approve pull requests (createPullRequest)`

That means the release logic is now blocked by optional bookkeeping rather than by the release itself. The safest fix is to keep the release pipeline moving and treat the version-bump PR as best-effort.

## Impact

After merge, a successful `auto-release` run should still be able to:

- push the `release/vX.Y.Z` bookkeeping branch when a version-bump commit is needed
- dispatch the real `release.yml` workflow
- publish the GitHub Release even when Actions is not allowed to open the follow-up PR automatically

The only degraded behavior is that maintainers may need to open the bookkeeping PR manually when repository policy forbids PR creation from Actions.

## Validation

- inspected the failing step and confirmed the release stop was caused specifically by `gh pr create`
- kept the change scoped to the PR-creation step in `.github/workflows/auto-release.yml`
- verified the updated shell block now warns and continues instead of exiting non-zero

## Follow-up

If you want the bookkeeping PR to be created automatically in the future, the repository will need a token or policy setup that allows pull-request creation from GitHub Actions.