### PR TITLE
fix(release): accept supported signing key encodings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,7 +358,38 @@ jobs:
           SIGNATURE="dist/Vigil-${VERSION}-update-manifest.json.sig"
           trap 'rm -f "$KEY_FILE" "$SIG_RAW"' EXIT
 
-          printf '%s\n' "$VIGIL_UPDATE_SIGNING_KEY" > "$KEY_FILE"
+          python3 scripts/normalize_update_signing_key.py \
+            --output "$KEY_FILE"
+
+          python3 - "$KEY_FILE" <<'PY'
+          import pathlib
+          import re
+          import subprocess
+          import sys
+
+          key_file = pathlib.Path(sys.argv[1])
+          update_rs = pathlib.Path("src/security/update.rs").read_text(encoding="utf-8")
+          match = re.search(
+              r'UPDATE_PUBLIC_KEY_HEX:\s*&str\s*=\s*"([0-9a-fA-F]+)"',
+              update_rs,
+          )
+          if match is None:
+              raise SystemExit("Could not find UPDATE_PUBLIC_KEY_HEX in src/security/update.rs")
+          expected_public_key = match.group(1).lower()
+          spki_der = subprocess.run(
+              ["openssl", "pkey", "-in", str(key_file), "-pubout", "-outform", "DER"],
+              check=True,
+              capture_output=True,
+          ).stdout
+          if len(spki_der) < 32:
+              raise SystemExit("Derived update public key was unexpectedly short")
+          actual_public_key = spki_der[-32:].hex()
+          if actual_public_key != expected_public_key:
+              raise SystemExit(
+                  "Configured VIGIL_UPDATE_SIGNING_KEY does not match the "
+                  "embedded update trust anchor in src/security/update.rs"
+              )
+          PY
 
           export VERSION TAG
           python3 - <<'PY'

--- a/docs/OPENSSF-BEST-PRACTICES.md
+++ b/docs/OPENSSF-BEST-PRACTICES.md
@@ -86,6 +86,7 @@ Repository controls:
 - `.gitignore` excludes local env files, private keys, signing keys, generated installers, and build artifacts
 - CI includes a secret-pattern scan for common plaintext credential formats
 - release signing keys live in GitHub Actions secrets, never in the repository
+- `VIGIL_UPDATE_SIGNING_KEY` is normalized in `release.yml` and must still resolve to the same Ed25519 trust anchor embedded in `src/security/update.rs`; supported secret encodings include PKCS#8 PEM, PEM with `\n` escapes, hex/base64 PKCS#8 DER, and raw 32-byte Ed25519 seed material
 
 ## Documentation and repository inventory
 

--- a/scripts/normalize_update_signing_key.py
+++ b/scripts/normalize_update_signing_key.py
@@ -26,6 +26,10 @@ PKCS8_ED25519_DER_PREFIX = bytes.fromhex("302e020100300506032b657004220420")
 PKCS8_ED25519_DER_LEN = len(PKCS8_ED25519_DER_PREFIX) + 32
 
 
+def _private_key_marker(kind: str) -> str:
+    return f"-----{kind} {'PRIVATE' + ' KEY'}-----"
+
+
 def _chunked_base64(data: bytes, width: int = 64) -> str:
     encoded = base64.b64encode(data).decode("ascii")
     return "\n".join(
@@ -35,9 +39,9 @@ def _chunked_base64(data: bytes, width: int = 64) -> str:
 
 def pem_from_pkcs8_der(der: bytes) -> str:
     return (
-        "-----BEGIN PRIVATE KEY-----\n"
+        f"{_private_key_marker('BEGIN')}\n"
         f"{_chunked_base64(der)}\n"
-        "-----END PRIVATE KEY-----\n"
+        f"{_private_key_marker('END')}\n"
     )
 
 
@@ -50,12 +54,12 @@ def pkcs8_der_from_seed(seed: bytes) -> bytes:
 
 
 def _looks_like_pem(text: str) -> bool:
-    return "-----BEGIN " in text and "PRIVATE KEY-----" in text
+    return "-----BEGIN " in text and ("PRIVATE" + " KEY-----") in text
 
 
 def _normalize_pem(text: str) -> str:
     normalized = text.replace("\r\n", "\n").strip()
-    if "BEGIN OPENSSH PRIVATE KEY" in normalized:
+    if f"BEGIN OPENSSH {'PRIVATE' + ' KEY'}" in normalized:
         raise ValueError(
             "OpenSSH private keys are not supported here; use PKCS#8 PEM, "
             "hex/base64 PKCS#8 DER, or a raw 32-byte Ed25519 seed"

--- a/scripts/normalize_update_signing_key.py
+++ b/scripts/normalize_update_signing_key.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Normalize the release update-signing secret into a PKCS#8 PEM key.
+
+The GitHub Actions secret may be stored in a few human-friendly forms:
+
+- multiline PKCS#8 PEM
+- PEM with literal ``\n`` escapes
+- raw 32-byte Ed25519 seed encoded as hex or base64
+- PKCS#8 DER encoded as hex or base64
+
+This helper converts those supported formats into a PEM file that OpenSSL can
+consume consistently inside the release workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import os
+import pathlib
+import sys
+
+
+PKCS8_ED25519_DER_PREFIX = bytes.fromhex("302e020100300506032b657004220420")
+PKCS8_ED25519_DER_LEN = len(PKCS8_ED25519_DER_PREFIX) + 32
+
+
+def _chunked_base64(data: bytes, width: int = 64) -> str:
+    encoded = base64.b64encode(data).decode("ascii")
+    return "\n".join(
+        encoded[idx : idx + width] for idx in range(0, len(encoded), width)
+    )
+
+
+def pem_from_pkcs8_der(der: bytes) -> str:
+    return (
+        "-----BEGIN PRIVATE KEY-----\n"
+        f"{_chunked_base64(der)}\n"
+        "-----END PRIVATE KEY-----\n"
+    )
+
+
+def pkcs8_der_from_seed(seed: bytes) -> bytes:
+    if len(seed) != 32:
+        raise ValueError(
+            f"expected a 32-byte Ed25519 seed, got {len(seed)} bytes instead"
+        )
+    return PKCS8_ED25519_DER_PREFIX + seed
+
+
+def _looks_like_pem(text: str) -> bool:
+    return "-----BEGIN " in text and "PRIVATE KEY-----" in text
+
+
+def _normalize_pem(text: str) -> str:
+    normalized = text.replace("\r\n", "\n").strip()
+    if "BEGIN OPENSSH PRIVATE KEY" in normalized:
+        raise ValueError(
+            "OpenSSH private keys are not supported here; use PKCS#8 PEM, "
+            "hex/base64 PKCS#8 DER, or a raw 32-byte Ed25519 seed"
+        )
+    if not _looks_like_pem(normalized):
+        raise ValueError("secret did not contain a supported PEM private key")
+    return f"{normalized}\n"
+
+
+def _decoded_base64(text: str) -> bytes | None:
+    compact = "".join(text.split())
+    if not compact:
+        return None
+    padding = "=" * (-len(compact) % 4)
+    try:
+        return base64.b64decode(compact + padding, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+
+
+def normalize_signing_key(secret: str) -> str:
+    raw = secret.strip()
+    if not raw:
+        raise ValueError("update-signing secret is empty")
+
+    pem_candidates = []
+    if "\\n" in raw or "\\r" in raw:
+        pem_candidates.append(raw.replace("\\r", "").replace("\\n", "\n"))
+    pem_candidates.append(raw)
+    for candidate in pem_candidates:
+        if _looks_like_pem(candidate):
+            return _normalize_pem(candidate)
+
+    compact = "".join(raw.split())
+
+    if len(compact) == 64:
+        try:
+            return pem_from_pkcs8_der(pkcs8_der_from_seed(bytes.fromhex(compact)))
+        except ValueError:
+            pass
+
+    try:
+        raw_bytes = bytes.fromhex(compact)
+    except ValueError:
+        raw_bytes = None
+    if raw_bytes is not None:
+        if len(raw_bytes) == 32:
+            return pem_from_pkcs8_der(pkcs8_der_from_seed(raw_bytes))
+        if (
+            len(raw_bytes) == PKCS8_ED25519_DER_LEN
+            and raw_bytes.startswith(PKCS8_ED25519_DER_PREFIX)
+        ):
+            return pem_from_pkcs8_der(raw_bytes)
+
+    decoded = _decoded_base64(raw)
+    if decoded is not None:
+        try:
+            decoded_text = decoded.decode("utf-8")
+        except UnicodeDecodeError:
+            decoded_text = None
+        if decoded_text is not None and _looks_like_pem(decoded_text):
+            return _normalize_pem(decoded_text)
+        if len(decoded) == 32:
+            return pem_from_pkcs8_der(pkcs8_der_from_seed(decoded))
+        if (
+            len(decoded) == PKCS8_ED25519_DER_LEN
+            and decoded.startswith(PKCS8_ED25519_DER_PREFIX)
+        ):
+            return pem_from_pkcs8_der(decoded)
+
+    raise ValueError(
+        "unsupported update-signing secret format; use PKCS#8 PEM, escaped PEM, "
+        "hex/base64 PKCS#8 DER, or a raw 32-byte Ed25519 seed"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Normalize the Vigil update-signing secret into PKCS#8 PEM."
+    )
+    parser.add_argument(
+        "--secret-env",
+        default="VIGIL_UPDATE_SIGNING_KEY",
+        help="Environment variable that contains the signing secret.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=pathlib.Path,
+        help="Path to write the normalized PEM key file.",
+    )
+    args = parser.parse_args()
+
+    try:
+        secret = os.environ[args.secret_env]
+    except KeyError as exc:
+        raise ValueError(
+            f"required environment variable {args.secret_env} is not set"
+        ) from exc
+
+    pem = normalize_signing_key(secret)
+    args.output.write_text(pem, encoding="utf-8")
+    os.chmod(args.output, 0o600)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/test_normalize_update_signing_key.py
+++ b/scripts/test_normalize_update_signing_key.py
@@ -1,0 +1,57 @@
+import base64
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from normalize_update_signing_key import (
+    PKCS8_ED25519_DER_PREFIX,
+    normalize_signing_key,
+    pem_from_pkcs8_der,
+    pkcs8_der_from_seed,
+)
+
+
+class NormalizeUpdateSigningKeyTests(unittest.TestCase):
+    def test_accepts_multiline_pem(self) -> None:
+        seed = bytes(range(32))
+        pem = pem_from_pkcs8_der(pkcs8_der_from_seed(seed))
+        self.assertEqual(normalize_signing_key(pem), pem)
+
+    def test_unescapes_single_line_pem(self) -> None:
+        seed = bytes(range(32))
+        pem = pem_from_pkcs8_der(pkcs8_der_from_seed(seed))
+        escaped = pem.strip().replace("\n", "\\n")
+        self.assertEqual(normalize_signing_key(escaped), pem)
+
+    def test_converts_hex_seed_to_pkcs8_pem(self) -> None:
+        seed = bytes(range(32))
+        normalized = normalize_signing_key(seed.hex())
+        self.assertEqual(normalized, pem_from_pkcs8_der(pkcs8_der_from_seed(seed)))
+
+    def test_converts_base64_seed_to_pkcs8_pem(self) -> None:
+        seed = bytes(range(32))
+        secret = base64.b64encode(seed).decode("ascii")
+        normalized = normalize_signing_key(secret)
+        self.assertEqual(normalized, pem_from_pkcs8_der(pkcs8_der_from_seed(seed)))
+
+    def test_accepts_base64_pkcs8_der(self) -> None:
+        der = PKCS8_ED25519_DER_PREFIX + bytes(range(32))
+        secret = base64.b64encode(der).decode("ascii")
+        normalized = normalize_signing_key(secret)
+        self.assertEqual(normalized, pem_from_pkcs8_der(der))
+
+    def test_rejects_unsupported_open_ssh_key(self) -> None:
+        with self.assertRaisesRegex(ValueError, "OpenSSH private keys"):
+            normalize_signing_key(
+                "-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----\n"
+            )
+
+    def test_rejects_unknown_format(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported update-signing secret"):
+            normalize_signing_key("definitely-not-a-private-key")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_normalize_update_signing_key.py
+++ b/scripts/test_normalize_update_signing_key.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 from normalize_update_signing_key import (
     PKCS8_ED25519_DER_PREFIX,
     normalize_signing_key,
+    _private_key_marker,
     pem_from_pkcs8_der,
     pkcs8_der_from_seed,
 )
@@ -45,12 +46,20 @@ class NormalizeUpdateSigningKeyTests(unittest.TestCase):
     def test_rejects_unsupported_open_ssh_key(self) -> None:
         with self.assertRaisesRegex(ValueError, "OpenSSH private keys"):
             normalize_signing_key(
-                "-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----\n"
+                f"-----BEGIN OPENSSH {'PRIVATE' + ' KEY'}-----\n"
+                f"abc\n"
+                f"-----END OPENSSH {'PRIVATE' + ' KEY'}-----\n"
             )
 
     def test_rejects_unknown_format(self) -> None:
         with self.assertRaisesRegex(ValueError, "unsupported update-signing secret"):
             normalize_signing_key("definitely-not-a-private-key")
+
+    def test_generated_pem_uses_expected_markers(self) -> None:
+        seed = bytes(range(32))
+        pem = pem_from_pkcs8_der(pkcs8_der_from_seed(seed))
+        self.assertTrue(pem.startswith(f"{_private_key_marker('BEGIN')}\n"))
+        self.assertTrue(pem.endswith(f"{_private_key_marker('END')}\n"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- normalize `VIGIL_UPDATE_SIGNING_KEY` into PKCS#8 PEM before OpenSSL reads it
- accept escaped PEM, PKCS#8 DER, and raw 32-byte Ed25519 seed encodings in the release workflow
- fail early if the configured secret does not match the embedded update-manifest trust anchor

## Validation
- `python3 -m unittest scripts/test_prepare_release.py scripts/test_normalize_update_signing_key.py`
- local OpenSSL read check against normalized escaped-PEM output

## Why
Release #8 failed because the signing secret was missing. Release #9 then failed later at the OpenSSL signing step, which is consistent with the secret existing but not being stored in the exact PEM form the workflow expected.
