### PR TITLE
fix(release): inline key normalization for rerun tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,8 +358,123 @@ jobs:
           SIGNATURE="dist/Vigil-${VERSION}-update-manifest.json.sig"
           trap 'rm -f "$KEY_FILE" "$SIG_RAW"' EXIT
 
-          python3 scripts/normalize_update_signing_key.py \
-            --output "$KEY_FILE"
+          python3 - "$KEY_FILE" <<'PY'
+          import base64
+          import binascii
+          import os
+          import pathlib
+          import sys
+
+          PKCS8_ED25519_DER_PREFIX = bytes.fromhex("302e020100300506032b657004220420")
+          PKCS8_ED25519_DER_LEN = len(PKCS8_ED25519_DER_PREFIX) + 32
+
+          def private_key_marker(kind: str) -> str:
+              return f"-----{kind} {'PRIVATE' + ' KEY'}-----"
+
+          def chunked_base64(data: bytes, width: int = 64) -> str:
+              encoded = base64.b64encode(data).decode("ascii")
+              return "\n".join(
+                  encoded[idx : idx + width] for idx in range(0, len(encoded), width)
+              )
+
+          def pem_from_pkcs8_der(der: bytes) -> str:
+              return (
+                  f"{private_key_marker('BEGIN')}\n"
+                  f"{chunked_base64(der)}\n"
+                  f"{private_key_marker('END')}\n"
+              )
+
+          def pkcs8_der_from_seed(seed: bytes) -> bytes:
+              if len(seed) != 32:
+                  raise ValueError(
+                      f"expected a 32-byte Ed25519 seed, got {len(seed)} bytes instead"
+                  )
+              return PKCS8_ED25519_DER_PREFIX + seed
+
+          def looks_like_pem(text: str) -> bool:
+              return "-----BEGIN " in text and ("PRIVATE" + " KEY-----") in text
+
+          def normalize_pem(text: str) -> str:
+              normalized = text.replace("\r\n", "\n").strip()
+              if f"BEGIN OPENSSH {'PRIVATE' + ' KEY'}" in normalized:
+                  raise ValueError(
+                      "OpenSSH private keys are not supported here; use PKCS#8 PEM, "
+                      "hex/base64 PKCS#8 DER, or a raw 32-byte Ed25519 seed"
+                  )
+              if not looks_like_pem(normalized):
+                  raise ValueError("secret did not contain a supported PEM private key")
+              return f"{normalized}\n"
+
+          def decoded_base64(text: str) -> bytes | None:
+              compact = "".join(text.split())
+              if not compact:
+                  return None
+              padding = "=" * (-len(compact) % 4)
+              try:
+                  return base64.b64decode(compact + padding, validate=True)
+              except (binascii.Error, ValueError):
+                  return None
+
+          def normalize_signing_key(secret: str) -> str:
+              raw = secret.strip()
+              if not raw:
+                  raise ValueError("update-signing secret is empty")
+
+              pem_candidates = []
+              if "\\n" in raw or "\\r" in raw:
+                  pem_candidates.append(raw.replace("\\r", "").replace("\\n", "\n"))
+              pem_candidates.append(raw)
+              for candidate in pem_candidates:
+                  if looks_like_pem(candidate):
+                      return normalize_pem(candidate)
+
+              compact = "".join(raw.split())
+
+              if len(compact) == 64:
+                  try:
+                      return pem_from_pkcs8_der(pkcs8_der_from_seed(bytes.fromhex(compact)))
+                  except ValueError:
+                      pass
+
+              try:
+                  raw_bytes = bytes.fromhex(compact)
+              except ValueError:
+                  raw_bytes = None
+              if raw_bytes is not None:
+                  if len(raw_bytes) == 32:
+                      return pem_from_pkcs8_der(pkcs8_der_from_seed(raw_bytes))
+                  if (
+                      len(raw_bytes) == PKCS8_ED25519_DER_LEN
+                      and raw_bytes.startswith(PKCS8_ED25519_DER_PREFIX)
+                  ):
+                      return pem_from_pkcs8_der(raw_bytes)
+
+              decoded = decoded_base64(raw)
+              if decoded is not None:
+                  try:
+                      decoded_text = decoded.decode("utf-8")
+                  except UnicodeDecodeError:
+                      decoded_text = None
+                  if decoded_text is not None and looks_like_pem(decoded_text):
+                      return normalize_pem(decoded_text)
+                  if len(decoded) == 32:
+                      return pem_from_pkcs8_der(pkcs8_der_from_seed(decoded))
+                  if (
+                      len(decoded) == PKCS8_ED25519_DER_LEN
+                      and decoded.startswith(PKCS8_ED25519_DER_PREFIX)
+                  ):
+                      return pem_from_pkcs8_der(decoded)
+
+              raise ValueError(
+                  "unsupported update-signing secret format; use PKCS#8 PEM, escaped PEM, "
+                  "hex/base64 PKCS#8 DER, or a raw 32-byte Ed25519 seed"
+              )
+
+          pem = normalize_signing_key(os.environ["VIGIL_UPDATE_SIGNING_KEY"])
+          output = pathlib.Path(sys.argv[1])
+          output.write_text(pem, encoding="utf-8")
+          output.chmod(0o600)
+          PY
 
           python3 - "$KEY_FILE" <<'PY'
           import pathlib


### PR DESCRIPTION
## Summary
- make the manifest-signing normalization logic self-contained inside `release.yml`
- stop depending on `scripts/normalize_update_signing_key.py` being present in the checked-out release source snapshot
- preserve the trust-anchor verification against the tag's own `src/security/update.rs`

## Root cause
`Release` run #10 failed in the `Publish release` job because it checked out `refs/tags/v1.3.7` and then tried to execute `scripts/normalize_update_signing_key.py`, which was added later on `master` and does not exist in the `v1.3.7` tag snapshot.

The failing line from the job log was:
`python3: can't open file '/home/runner/work/vigil/vigil/scripts/normalize_update_signing_key.py': [Errno 2] No such file or directory`

## Validation
- local replay of the secret-scan regex against tracked files passed
- the updated workflow avoids any external helper-file dependency during `workflow_dispatch` reruns of older tags
