### PR TITLE
fix(release): accept raw Ed25519 private-key signing secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -377,6 +377,7 @@ jobs:
 
           PKCS8_ED25519_DER_PREFIX = bytes.fromhex("302e020100300506032b657004220420")
           PKCS8_ED25519_DER_LEN = len(PKCS8_ED25519_DER_PREFIX) + 32
+          ED25519_PRIVATE_KEY_LEN = 64
 
           def private_key_marker(kind: str) -> str:
               return f"-----{kind} {'PRIVATE' + ' KEY'}-----"
@@ -400,6 +401,14 @@ jobs:
                       f"expected a 32-byte Ed25519 seed, got {len(seed)} bytes instead"
                   )
               return PKCS8_ED25519_DER_PREFIX + seed
+
+          def pkcs8_der_from_raw_private_key(private_key: bytes) -> bytes:
+              if len(private_key) != ED25519_PRIVATE_KEY_LEN:
+                  raise ValueError(
+                      "expected a 64-byte Ed25519 private key, "
+                      f"got {len(private_key)} bytes instead"
+                  )
+              return pkcs8_der_from_seed(private_key[:32])
 
           def looks_like_pem(text: str) -> bool:
               return "-----BEGIN " in text and ("PRIVATE" + " KEY-----") in text
@@ -453,6 +462,8 @@ jobs:
               if raw_bytes is not None:
                   if len(raw_bytes) == 32:
                       return pem_from_pkcs8_der(pkcs8_der_from_seed(raw_bytes))
+                  if len(raw_bytes) == ED25519_PRIVATE_KEY_LEN:
+                      return pem_from_pkcs8_der(pkcs8_der_from_raw_private_key(raw_bytes))
                   if (
                       len(raw_bytes) == PKCS8_ED25519_DER_LEN
                       and raw_bytes.startswith(PKCS8_ED25519_DER_PREFIX)
@@ -469,6 +480,8 @@ jobs:
                       return normalize_pem(decoded_text)
                   if len(decoded) == 32:
                       return pem_from_pkcs8_der(pkcs8_der_from_seed(decoded))
+                  if len(decoded) == ED25519_PRIVATE_KEY_LEN:
+                      return pem_from_pkcs8_der(pkcs8_der_from_raw_private_key(decoded))
                   if (
                       len(decoded) == PKCS8_ED25519_DER_LEN
                       and decoded.startswith(PKCS8_ED25519_DER_PREFIX)
@@ -477,7 +490,8 @@ jobs:
 
               raise ValueError(
                   "unsupported update-signing secret format; use PKCS#8 PEM, escaped PEM, "
-                  "hex/base64 PKCS#8 DER, or a raw 32-byte Ed25519 seed"
+                  "hex/base64 PKCS#8 DER, a raw 32-byte Ed25519 seed, "
+                  "or a raw 64-byte Ed25519 private key"
               )
 
           pem = normalize_signing_key(os.environ["VIGIL_UPDATE_SIGNING_KEY"])

--- a/docs/OPENSSF-BEST-PRACTICES.md
+++ b/docs/OPENSSF-BEST-PRACTICES.md
@@ -86,7 +86,7 @@ Repository controls:
 - `.gitignore` excludes local env files, private keys, signing keys, generated installers, and build artifacts
 - CI includes a secret-pattern scan for common plaintext credential formats
 - release signing keys live in GitHub Actions secrets, never in the repository
-- `VIGIL_UPDATE_SIGNING_KEY` is normalized in `release.yml` and must still resolve to the same Ed25519 trust anchor embedded in `src/security/update.rs`; supported secret encodings include PKCS#8 PEM, PEM with `\n` escapes, hex/base64 PKCS#8 DER, and raw 32-byte Ed25519 seed material
+- `VIGIL_UPDATE_SIGNING_KEY` is normalized in `release.yml` and must still resolve to the same Ed25519 trust anchor embedded in `src/security/update.rs`; supported secret encodings include PKCS#8 PEM, PEM with `\n` escapes, hex/base64 PKCS#8 DER, raw 32-byte Ed25519 seed material, and raw 64-byte Ed25519 private keys that store the seed plus public key
 
 ## Documentation and repository inventory
 

--- a/scripts/normalize_update_signing_key.py
+++ b/scripts/normalize_update_signing_key.py
@@ -6,6 +6,7 @@ The GitHub Actions secret may be stored in a few human-friendly forms:
 - multiline PKCS#8 PEM
 - PEM with literal ``\n`` escapes
 - raw 32-byte Ed25519 seed encoded as hex or base64
+- raw 64-byte Ed25519 private key encoded as hex or base64 (seed + public key)
 - PKCS#8 DER encoded as hex or base64
 
 This helper converts those supported formats into a PEM file that OpenSSL can
@@ -24,6 +25,7 @@ import sys
 
 PKCS8_ED25519_DER_PREFIX = bytes.fromhex("302e020100300506032b657004220420")
 PKCS8_ED25519_DER_LEN = len(PKCS8_ED25519_DER_PREFIX) + 32
+ED25519_PRIVATE_KEY_LEN = 64
 
 
 def _private_key_marker(kind: str) -> str:
@@ -51,6 +53,18 @@ def pkcs8_der_from_seed(seed: bytes) -> bytes:
             f"expected a 32-byte Ed25519 seed, got {len(seed)} bytes instead"
         )
     return PKCS8_ED25519_DER_PREFIX + seed
+
+
+def pkcs8_der_from_raw_private_key(private_key: bytes) -> bytes:
+    if len(private_key) != ED25519_PRIVATE_KEY_LEN:
+        raise ValueError(
+            "expected a 64-byte Ed25519 private key, "
+            f"got {len(private_key)} bytes instead"
+        )
+    # Common raw encodings store the 32-byte seed followed by the public key.
+    # The release workflow separately verifies that the derived public key still
+    # matches Vigil's embedded update trust anchor.
+    return pkcs8_der_from_seed(private_key[:32])
 
 
 def _looks_like_pem(text: str) -> bool:
@@ -108,6 +122,8 @@ def normalize_signing_key(secret: str) -> str:
     if raw_bytes is not None:
         if len(raw_bytes) == 32:
             return pem_from_pkcs8_der(pkcs8_der_from_seed(raw_bytes))
+        if len(raw_bytes) == ED25519_PRIVATE_KEY_LEN:
+            return pem_from_pkcs8_der(pkcs8_der_from_raw_private_key(raw_bytes))
         if (
             len(raw_bytes) == PKCS8_ED25519_DER_LEN
             and raw_bytes.startswith(PKCS8_ED25519_DER_PREFIX)
@@ -124,6 +140,8 @@ def normalize_signing_key(secret: str) -> str:
             return _normalize_pem(decoded_text)
         if len(decoded) == 32:
             return pem_from_pkcs8_der(pkcs8_der_from_seed(decoded))
+        if len(decoded) == ED25519_PRIVATE_KEY_LEN:
+            return pem_from_pkcs8_der(pkcs8_der_from_raw_private_key(decoded))
         if (
             len(decoded) == PKCS8_ED25519_DER_LEN
             and decoded.startswith(PKCS8_ED25519_DER_PREFIX)
@@ -132,7 +150,8 @@ def normalize_signing_key(secret: str) -> str:
 
     raise ValueError(
         "unsupported update-signing secret format; use PKCS#8 PEM, escaped PEM, "
-        "hex/base64 PKCS#8 DER, or a raw 32-byte Ed25519 seed"
+        "hex/base64 PKCS#8 DER, a raw 32-byte Ed25519 seed, "
+        "or a raw 64-byte Ed25519 private key"
     )
 
 

--- a/scripts/test_normalize_update_signing_key.py
+++ b/scripts/test_normalize_update_signing_key.py
@@ -6,10 +6,12 @@ import unittest
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
 from normalize_update_signing_key import (
+    ED25519_PRIVATE_KEY_LEN,
     PKCS8_ED25519_DER_PREFIX,
     normalize_signing_key,
     _private_key_marker,
     pem_from_pkcs8_der,
+    pkcs8_der_from_raw_private_key,
     pkcs8_der_from_seed,
 )
 
@@ -36,6 +38,23 @@ class NormalizeUpdateSigningKeyTests(unittest.TestCase):
         secret = base64.b64encode(seed).decode("ascii")
         normalized = normalize_signing_key(secret)
         self.assertEqual(normalized, pem_from_pkcs8_der(pkcs8_der_from_seed(seed)))
+
+    def test_converts_hex_raw_private_key_to_pkcs8_pem(self) -> None:
+        raw_private_key = bytes(range(ED25519_PRIVATE_KEY_LEN))
+        normalized = normalize_signing_key(raw_private_key.hex())
+        self.assertEqual(
+            normalized,
+            pem_from_pkcs8_der(pkcs8_der_from_raw_private_key(raw_private_key)),
+        )
+
+    def test_converts_base64_raw_private_key_to_pkcs8_pem(self) -> None:
+        raw_private_key = bytes(range(ED25519_PRIVATE_KEY_LEN))
+        secret = base64.b64encode(raw_private_key).decode("ascii")
+        normalized = normalize_signing_key(secret)
+        self.assertEqual(
+            normalized,
+            pem_from_pkcs8_der(pkcs8_der_from_raw_private_key(raw_private_key)),
+        )
 
     def test_accepts_base64_pkcs8_der(self) -> None:
         der = PKCS8_ED25519_DER_PREFIX + bytes(range(32))


### PR DESCRIPTION
Fixes the release signing-key normalization path so it also accepts the common raw 64-byte Ed25519 private-key format (`seed || public_key`) in both the reusable helper and the inline workflow copy.

## Why
A recent release run failed while normalizing `VIGIL_UPDATE_SIGNING_KEY`. The workflow already verifies that the derived public key still matches Vigil's embedded trust anchor, so broadening input compatibility here does not weaken trust validation.

## Scope
- accept raw 64-byte Ed25519 private keys in `scripts/normalize_update_signing_key.py`
- mirror the same logic in `.github/workflows/release.yml`
- add tests for hex and base64 64-byte inputs
- document the supported secret shape in OpenSSF notes

## Validation
- `python3 -m unittest scripts/test_normalize_update_signing_key.py`
- synthetic 64-byte key normalized into a PEM that OpenSSL can parse