### PR TITLE
fix(release): accept OpenSSH signing key secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -416,8 +416,13 @@ jobs:
           def normalize_pem(text: str) -> str:
               normalized = text.replace("\r\n", "\n").strip()
               if f"BEGIN OPENSSH {'PRIVATE' + ' KEY'}" in normalized:
-                  from cryptography.hazmat.primitives import serialization
-
+                  try:
+                      from cryptography.hazmat.primitives import serialization
+                  except ModuleNotFoundError as exc:
+                      raise ValueError(
+                          "OpenSSH private key PEM requires the cryptography package; "
+                          "use PKCS#8 PEM or install cryptography before normalization"
+                      ) from exc
                   key = serialization.load_ssh_private_key(
                       normalized.encode("utf-8"), password=None
                   )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -375,8 +375,6 @@ jobs:
           import pathlib
           import sys
 
-          from cryptography.hazmat.primitives import serialization
-
           PKCS8_ED25519_DER_PREFIX = bytes.fromhex("302e020100300506032b657004220420")
           PKCS8_ED25519_DER_LEN = len(PKCS8_ED25519_DER_PREFIX) + 32
           ED25519_PRIVATE_KEY_LEN = 64
@@ -418,6 +416,8 @@ jobs:
           def normalize_pem(text: str) -> str:
               normalized = text.replace("\r\n", "\n").strip()
               if f"BEGIN OPENSSH {'PRIVATE' + ' KEY'}" in normalized:
+                  from cryptography.hazmat.primitives import serialization
+
                   key = serialization.load_ssh_private_key(
                       normalized.encode("utf-8"), password=None
                   )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -375,6 +375,8 @@ jobs:
           import pathlib
           import sys
 
+          from cryptography.hazmat.primitives import serialization
+
           PKCS8_ED25519_DER_PREFIX = bytes.fromhex("302e020100300506032b657004220420")
           PKCS8_ED25519_DER_LEN = len(PKCS8_ED25519_DER_PREFIX) + 32
           ED25519_PRIVATE_KEY_LEN = 64
@@ -416,10 +418,14 @@ jobs:
           def normalize_pem(text: str) -> str:
               normalized = text.replace("\r\n", "\n").strip()
               if f"BEGIN OPENSSH {'PRIVATE' + ' KEY'}" in normalized:
-                  raise ValueError(
-                      "OpenSSH private keys are not supported here; use PKCS#8 PEM, "
-                      "hex/base64 PKCS#8 DER, or a raw 32-byte Ed25519 seed"
+                  key = serialization.load_ssh_private_key(
+                      normalized.encode("utf-8"), password=None
                   )
+                  return key.private_bytes(
+                      encoding=serialization.Encoding.PEM,
+                      format=serialization.PrivateFormat.PKCS8,
+                      encryption_algorithm=serialization.NoEncryption(),
+                  ).decode("utf-8")
               if not looks_like_pem(normalized):
                   raise ValueError("secret did not contain a supported PEM private key")
               return f"{normalized}\n"
@@ -490,7 +496,7 @@ jobs:
 
               raise ValueError(
                   "unsupported update-signing secret format; use PKCS#8 PEM, escaped PEM, "
-                  "hex/base64 PKCS#8 DER, a raw 32-byte Ed25519 seed, "
+                  "OpenSSH private key PEM, hex/base64 PKCS#8 DER, a raw 32-byte Ed25519 seed, "
                   "or a raw 64-byte Ed25519 private key"
               )
 

--- a/docs/OPENSSF-BEST-PRACTICES.md
+++ b/docs/OPENSSF-BEST-PRACTICES.md
@@ -86,7 +86,7 @@ Repository controls:
 - `.gitignore` excludes local env files, private keys, signing keys, generated installers, and build artifacts
 - CI includes a secret-pattern scan for common plaintext credential formats
 - release signing keys live in GitHub Actions secrets, never in the repository
-- `VIGIL_UPDATE_SIGNING_KEY` is normalized in `release.yml` and must still resolve to the same Ed25519 trust anchor embedded in `src/security/update.rs`; supported secret encodings include PKCS#8 PEM, PEM with `\n` escapes, hex/base64 PKCS#8 DER, raw 32-byte Ed25519 seed material, and raw 64-byte Ed25519 private keys that store the seed plus public key
+- `VIGIL_UPDATE_SIGNING_KEY` is normalized in `release.yml` and must still resolve to the same Ed25519 trust anchor embedded in `src/security/update.rs`; supported secret encodings include PKCS#8 PEM, PEM with `\n` escapes, OpenSSH private key PEM, hex/base64 PKCS#8 DER, raw 32-byte Ed25519 seed material, and raw 64-byte Ed25519 private keys that store the seed plus public key
 
 ## Documentation and repository inventory
 

--- a/scripts/normalize_update_signing_key.py
+++ b/scripts/normalize_update_signing_key.py
@@ -75,8 +75,13 @@ def _looks_like_pem(text: str) -> bool:
 def _normalize_pem(text: str) -> str:
     normalized = text.replace("\r\n", "\n").strip()
     if f"BEGIN OPENSSH {'PRIVATE' + ' KEY'}" in normalized:
-        from cryptography.hazmat.primitives import serialization
-
+        try:
+            from cryptography.hazmat.primitives import serialization
+        except ModuleNotFoundError as exc:
+            raise ValueError(
+                "OpenSSH private key PEM requires the cryptography package; "
+                "use PKCS#8 PEM or install cryptography before normalization"
+            ) from exc
         key = serialization.load_ssh_private_key(
             normalized.encode("utf-8"), password=None
         )

--- a/scripts/normalize_update_signing_key.py
+++ b/scripts/normalize_update_signing_key.py
@@ -5,6 +5,7 @@ The GitHub Actions secret may be stored in a few human-friendly forms:
 
 - multiline PKCS#8 PEM
 - PEM with literal ``\n`` escapes
+- OpenSSH private key PEM
 - raw 32-byte Ed25519 seed encoded as hex or base64
 - raw 64-byte Ed25519 private key encoded as hex or base64 (seed + public key)
 - PKCS#8 DER encoded as hex or base64
@@ -21,6 +22,8 @@ import binascii
 import os
 import pathlib
 import sys
+
+from cryptography.hazmat.primitives import serialization
 
 
 PKCS8_ED25519_DER_PREFIX = bytes.fromhex("302e020100300506032b657004220420")
@@ -74,10 +77,14 @@ def _looks_like_pem(text: str) -> bool:
 def _normalize_pem(text: str) -> str:
     normalized = text.replace("\r\n", "\n").strip()
     if f"BEGIN OPENSSH {'PRIVATE' + ' KEY'}" in normalized:
-        raise ValueError(
-            "OpenSSH private keys are not supported here; use PKCS#8 PEM, "
-            "hex/base64 PKCS#8 DER, or a raw 32-byte Ed25519 seed"
+        key = serialization.load_ssh_private_key(
+            normalized.encode("utf-8"), password=None
         )
+        return key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode("utf-8")
     if not _looks_like_pem(normalized):
         raise ValueError("secret did not contain a supported PEM private key")
     return f"{normalized}\n"
@@ -150,7 +157,7 @@ def normalize_signing_key(secret: str) -> str:
 
     raise ValueError(
         "unsupported update-signing secret format; use PKCS#8 PEM, escaped PEM, "
-        "hex/base64 PKCS#8 DER, a raw 32-byte Ed25519 seed, "
+        "OpenSSH private key PEM, hex/base64 PKCS#8 DER, a raw 32-byte Ed25519 seed, "
         "or a raw 64-byte Ed25519 private key"
     )
 

--- a/scripts/normalize_update_signing_key.py
+++ b/scripts/normalize_update_signing_key.py
@@ -23,8 +23,6 @@ import os
 import pathlib
 import sys
 
-from cryptography.hazmat.primitives import serialization
-
 
 PKCS8_ED25519_DER_PREFIX = bytes.fromhex("302e020100300506032b657004220420")
 PKCS8_ED25519_DER_LEN = len(PKCS8_ED25519_DER_PREFIX) + 32
@@ -77,6 +75,8 @@ def _looks_like_pem(text: str) -> bool:
 def _normalize_pem(text: str) -> str:
     normalized = text.replace("\r\n", "\n").strip()
     if f"BEGIN OPENSSH {'PRIVATE' + ' KEY'}" in normalized:
+        from cryptography.hazmat.primitives import serialization
+
         key = serialization.load_ssh_private_key(
             normalized.encode("utf-8"), password=None
         )

--- a/scripts/test_normalize_update_signing_key.py
+++ b/scripts/test_normalize_update_signing_key.py
@@ -3,6 +3,9 @@ import pathlib
 import sys
 import unittest
 
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
 from normalize_update_signing_key import (
@@ -62,13 +65,33 @@ class NormalizeUpdateSigningKeyTests(unittest.TestCase):
         normalized = normalize_signing_key(secret)
         self.assertEqual(normalized, pem_from_pkcs8_der(der))
 
-    def test_rejects_unsupported_open_ssh_key(self) -> None:
-        with self.assertRaisesRegex(ValueError, "OpenSSH private keys"):
-            normalize_signing_key(
-                f"-----BEGIN OPENSSH {'PRIVATE' + ' KEY'}-----\n"
-                f"abc\n"
-                f"-----END OPENSSH {'PRIVATE' + ' KEY'}-----\n"
-            )
+    def test_converts_openssh_private_key_to_pkcs8_pem(self) -> None:
+        private_key = Ed25519PrivateKey.generate()
+        openssh = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.OpenSSH,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode("utf-8")
+        pkcs8 = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode("utf-8")
+        self.assertEqual(normalize_signing_key(openssh), pkcs8)
+
+    def test_converts_base64_openssh_private_key_to_pkcs8_pem(self) -> None:
+        private_key = Ed25519PrivateKey.generate()
+        openssh = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.OpenSSH,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        pkcs8 = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode("utf-8")
+        self.assertEqual(normalize_signing_key(base64.b64encode(openssh).decode("ascii")), pkcs8)
 
     def test_rejects_unknown_format(self) -> None:
         with self.assertRaisesRegex(ValueError, "unsupported update-signing secret"):

--- a/scripts/test_normalize_update_signing_key.py
+++ b/scripts/test_normalize_update_signing_key.py
@@ -5,8 +5,12 @@ import sys
 import unittest
 from unittest import mock
 
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+try:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+except ModuleNotFoundError:
+    serialization = None
+    Ed25519PrivateKey = None
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
@@ -80,6 +84,10 @@ class NormalizeUpdateSigningKeyTests(unittest.TestCase):
         normalized = normalize_signing_key(secret)
         self.assertEqual(normalized, pem_from_pkcs8_der(der))
 
+    @unittest.skipUnless(
+        serialization is not None and Ed25519PrivateKey is not None,
+        "cryptography is required for OpenSSH key coverage",
+    )
     def test_converts_openssh_private_key_to_pkcs8_pem(self) -> None:
         private_key = Ed25519PrivateKey.generate()
         openssh = private_key.private_bytes(
@@ -94,6 +102,10 @@ class NormalizeUpdateSigningKeyTests(unittest.TestCase):
         ).decode("utf-8")
         self.assertEqual(normalize_signing_key(openssh), pkcs8)
 
+    @unittest.skipUnless(
+        serialization is not None and Ed25519PrivateKey is not None,
+        "cryptography is required for OpenSSH key coverage",
+    )
     def test_converts_base64_openssh_private_key_to_pkcs8_pem(self) -> None:
         private_key = Ed25519PrivateKey.generate()
         openssh = private_key.private_bytes(

--- a/scripts/test_normalize_update_signing_key.py
+++ b/scripts/test_normalize_update_signing_key.py
@@ -1,7 +1,9 @@
 import base64
+import builtins
 import pathlib
 import sys
 import unittest
+from unittest import mock
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -30,6 +32,19 @@ class NormalizeUpdateSigningKeyTests(unittest.TestCase):
         pem = pem_from_pkcs8_der(pkcs8_der_from_seed(seed))
         escaped = pem.strip().replace("\n", "\\n")
         self.assertEqual(normalize_signing_key(escaped), pem)
+
+    def test_pkcs8_pem_does_not_require_cryptography_import(self) -> None:
+        seed = bytes(range(32))
+        pem = pem_from_pkcs8_der(pkcs8_der_from_seed(seed))
+        original_import = builtins.__import__
+
+        def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name.startswith("cryptography"):
+                raise ModuleNotFoundError(name)
+            return original_import(name, globals, locals, fromlist, level)
+
+        with mock.patch("builtins.__import__", side_effect=guarded_import):
+            self.assertEqual(normalize_signing_key(pem), pem)
 
     def test_converts_hex_seed_to_pkcs8_pem(self) -> None:
         seed = bytes(range(32))


### PR DESCRIPTION
Fixes the release signing-key normalization path so it also accepts OpenSSH private key secrets in both the reusable helper and the inline workflow copy.

## Why
A release branch remains ahead of `master` with focused, tested support for a common secret format that is still not preserved in an active pull request.

## Scope
- accept OpenSSH private key PEM in `scripts/normalize_update_signing_key.py`
- mirror the same logic in `.github/workflows/release.yml`
- add tests that convert OpenSSH Ed25519 keys into PKCS#8 PEM
- document the supported secret format in the OpenSSF notes

## Validation
- `python3 -m unittest scripts/test_normalize_update_signing_key.py`