### PR TITLE
docs: clarify latest release publication timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ high-noise event into a destructive action.
 - [Manifest signature](https://github.com/YMRYMR/vigil/releases/latest/download/Vigil-latest-update-manifest.json.sig)
 - GHCR Linux package image: `ghcr.io/YMRYMR/vigil`
 
+The latest-release links above are refreshed by the release pipeline after a
+merged `master` change finishes CI and the tag-driven publishing workflow
+completes.
+
 The GHCR image tracks the latest released Linux AppImage as a container package
 so it is easy to mirror, automate, or consume in CI environments:
 


### PR DESCRIPTION
## Summary
- add a small README clarification about when the `releases/latest` links refresh

## Why
This is a tiny, low-risk change intended to exercise the auto-release path after a merged pull request.

## Validation
- documentation-only change
- no behavioral or security surface changes