### PR TITLE
fix(security): rotate embedded update signing trust anchor

### DIFF
--- a/src/security/update.rs
+++ b/src/security/update.rs
@@ -12,7 +12,7 @@ use std::fs;
 use std::path::Path;
 
 const UPDATE_PUBLIC_KEY_HEX: &str =
-    "20e838c609b7c01cf642dfbb48a1f40e57e1f9aba78c030ce818b3dfabce3be0";
+    "e8fc7e4c5ac7cace73e82238b4fc846cda8b1a7bb06275f65b55696eeb8b8bfe";
 const UPDATE_PUBLIC_KEY_LEN: usize = 32;
 const UPDATE_SIGNATURE_LEN: usize = 64;
 const UPDATE_SCHEMA_VERSION: u32 = 1;


### PR DESCRIPTION
## Summary
- rotate Vigil's embedded update-manifest verification key to the newly provided Ed25519 public key
- keep the repository free of the standalone `.pub` file while preserving offline verification through the embedded trust anchor

## Why
Release run #8 reached the signing stage but failed because `VIGIL_UPDATE_SIGNING_KEY` was not configured. The secret is now present, and the uploaded `vigil-update-signing.pub` shows the intended public key for that signing secret. Vigil still embeds the previous trust anchor in `src/security/update.rs`, so releases signed with the new private key would not verify in shipped clients until the embedded verifier is rotated as well.

This keeps the change narrowly scoped to the trust anchor itself and avoids reintroducing the public key file into the repository.

## Validation
- derived the raw Ed25519 public-key bytes from the uploaded `16-vigil-update-signing.pub`
- confirmed the derived key hex is `e8fc7e4c5ac7cace73e82238b4fc846cda8b1a7bb06275f65b55696eeb8b8bfe`
- confirmed that this differs from the current embedded key and updated `src/security/update.rs` to match it
- reviewed the current `release.yml` logic, which already enforces that `VIGIL_UPDATE_SIGNING_KEY` must match the embedded trust anchor before it signs the manifest

## Risk
Previously released manifests signed with the old private key will no longer match the new embedded trust anchor in future builds. That is the expected trust-anchor rotation behavior and is consistent with the existing signed-update model.