### PR TITLE
fix(ci): recover auto-release from squash merges and stale tags

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -84,7 +84,13 @@ jobs:
           fi
 
           if [ -z "$selected_pr" ]; then
-            merge_pr_number="$(git show -s --format=%B "$HEAD_SHA" | sed -n 's/^Merge pull request #\([0-9][0-9]*\).*/\1/p' | head -n1)"
+            merge_pr_number="$(git show -s --format=%B "$HEAD_SHA" | python3 -c 'import re, sys
+text = sys.stdin.read().splitlines()
+first = text[0] if text else ""
+match = re.match(r"Merge pull request #([0-9]+)", first)
+if match is None:
+    match = re.search(r"\(#([0-9]+)\)$", first)
+print(match.group(1) if match else "")')"
             if [ -n "$merge_pr_number" ]; then
               pr_json="$(gh api -H "Accept: application/vnd.github+json" "/repos/${GITHUB_REPOSITORY}/pulls/${merge_pr_number}" 2>/dev/null || true)"
               if [ -n "$pr_json" ] && is_json "$pr_json" && printf '%s' "$pr_json" | jq -e '.merged_at != null and .base.ref == "master"' >/dev/null 2>&1; then
@@ -139,6 +145,21 @@ jobs:
               python3 -c 'import os, subprocess, tomllib; version = os.environ["VERSION"]; cargo_toml = subprocess.run(["git", "show", f"refs/tags/v{version}:Cargo.toml"], check=True, capture_output=True, text=True).stdout; cargo_lock = subprocess.run(["git", "show", f"refs/tags/v{version}:Cargo.lock"], check=True, capture_output=True, text=True).stdout; toml_version = tomllib.loads(cargo_toml)["package"]["version"]; lock_packages = tomllib.loads(cargo_lock)["package"]; vigil = next((pkg for pkg in lock_packages if pkg.get("name") == "vigil"), None); raise SystemExit(0 if vigil and toml_version == version and vigil.get("version") == version else 1)'
           }
 
+          tag_snapshot_matches_current_update_key() {
+            VERSION="$1" python3 -c 'import os, pathlib, re, subprocess
+version = os.environ["VERSION"]
+pattern = re.compile(r"UPDATE_PUBLIC_KEY_HEX:\s*&str\s*=\s*\"([0-9a-fA-F]+)\"")
+current_text = pathlib.Path("src/security/update.rs").read_text(encoding="utf-8")
+current_match = pattern.search(current_text)
+if current_match is None:
+    raise SystemExit(1)
+tag_text = subprocess.run(["git", "show", f"refs/tags/v{version}:src/security/update.rs"], check=True, capture_output=True, text=True).stdout
+tag_match = pattern.search(tag_text)
+if tag_match is None:
+    raise SystemExit(1)
+raise SystemExit(0 if current_match.group(1).lower() == tag_match.group(1).lower() else 1)'
+          }
+
           candidate="$CURRENT_VERSION"
           advanced_past_current=false
           needs_commit=false
@@ -155,7 +176,7 @@ jobs:
             fi
 
             if ! release_exists "$candidate"; then
-              if tag_snapshot_is_releasable "$candidate"; then
+              if tag_snapshot_is_releasable "$candidate" && tag_snapshot_matches_current_update_key "$candidate"; then
                 recovered_existing_tag=true
                 break
               fi


### PR DESCRIPTION
## Summary
- resolve merged PR numbers from squash-merge commit subjects like `... (#105)` in addition to classic merge commits
- stop auto-release from reusing unreleased tags whose embedded update-manifest trust anchor no longer matches the current tree
- force the next recoverable release to advance past stale tags like `v1.3.7` instead of retrying a publish that can no longer succeed

## Why
As of April 27, 2026, there are two distinct release blockers in the live repository state:

1. The recent auto-release run for commit `dbe8cf3` skipped with:
   - `PR resolution: no merged pull request found for dbe8cf3db7d5ddd59b7027001e871824bf1cac20`

   That commit is a squash merge (`fix(ci): harden auto-release PR resolution (#105)`), so the existing fallback logic misses the PR number when `workflow_run.pull_requests` is empty and the commit-to-pulls API does not return usable data.

2. The dispatched `Release` run for `v1.3.7` failed in `Generate signed update manifest` with:
   - `Configured VIGIL_UPDATE_SIGNING_KEY does not match the embedded update trust anchor in src/security/update.rs`

   The `v1.3.7` tag snapshot predates the update-signing trust-anchor rotation, so it is no longer publishable with the current signing key. Reusing that unreleased tag will keep failing and will never create a GitHub Release object.

## What changed
- extended the PR-number fallback to parse squash-merge subjects ending in `(#123)`
- kept the existing classic `Merge pull request #123` fallback
- added a tag-snapshot trust-anchor check in version selection
- unreleased tags are now only reused when they are both structurally releasable and use the same embedded update public key as the current tree
- mismatched stale tags are skipped so the workflow can advance to a fresh patch version instead of retrying an impossible publish

## Validation
- inspected the live auto-release log for run `25009967670` and confirmed the squash-merge PR lookup miss
- inspected the live release log for run `25003246869` and confirmed the signing-key/trust-anchor mismatch on `v1.3.7`
- kept the change scoped to `.github/workflows/auto-release.yml`

## Follow-up
After this merges, the next successful merge to `master` should be able to cut a fresh releasable tag instead of retrying `v1.3.7`. It will not retroactively create release objects for `v1.3.6` or `v1.3.7`, which remain blocked by the old trust anchor in those tag snapshots.