### PR TITLE
fix(ci): restore auto-release workflow parsing

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -84,13 +84,7 @@ jobs:
           fi
 
           if [ -z "$selected_pr" ]; then
-            merge_pr_number="$(git show -s --format=%B "$HEAD_SHA" | python3 -c 'import re, sys
-text = sys.stdin.read().splitlines()
-first = text[0] if text else ""
-match = re.match(r"Merge pull request #([0-9]+)", first)
-if match is None:
-    match = re.search(r"\(#([0-9]+)\)$", first)
-print(match.group(1) if match else "")')"
+            merge_pr_number="$(git show -s --format=%B "$HEAD_SHA" | python3 -c 'import re, sys; text = sys.stdin.read().splitlines(); first = text[0] if text else ""; match = re.match(r"Merge pull request #([0-9]+)", first); match = match or re.search(r"\(#([0-9]+)\)$", first); print(match.group(1) if match else "")')"
             if [ -n "$merge_pr_number" ]; then
               pr_json="$(gh api -H "Accept: application/vnd.github+json" "/repos/${GITHUB_REPOSITORY}/pulls/${merge_pr_number}" 2>/dev/null || true)"
               if [ -n "$pr_json" ] && is_json "$pr_json" && printf '%s' "$pr_json" | jq -e '.merged_at != null and .base.ref == "master"' >/dev/null 2>&1; then
@@ -146,18 +140,7 @@ print(match.group(1) if match else "")')"
           }
 
           tag_snapshot_matches_current_update_key() {
-            VERSION="$1" python3 -c 'import os, pathlib, re, subprocess
-version = os.environ["VERSION"]
-pattern = re.compile(r"UPDATE_PUBLIC_KEY_HEX:\s*&str\s*=\s*\"([0-9a-fA-F]+)\"")
-current_text = pathlib.Path("src/security/update.rs").read_text(encoding="utf-8")
-current_match = pattern.search(current_text)
-if current_match is None:
-    raise SystemExit(1)
-tag_text = subprocess.run(["git", "show", f"refs/tags/v{version}:src/security/update.rs"], check=True, capture_output=True, text=True).stdout
-tag_match = pattern.search(tag_text)
-if tag_match is None:
-    raise SystemExit(1)
-raise SystemExit(0 if current_match.group(1).lower() == tag_match.group(1).lower() else 1)'
+            VERSION="$1" python3 -c 'import os, pathlib, re, subprocess; version = os.environ["VERSION"]; pattern = re.compile(r"UPDATE_PUBLIC_KEY_HEX:\s*&str\s*=\s*\"([0-9a-fA-F]+)\""); current_text = pathlib.Path("src/security/update.rs").read_text(encoding="utf-8"); current_match = pattern.search(current_text); tag_text = subprocess.run(["git", "show", f"refs/tags/v{version}:src/security/update.rs"], check=True, capture_output=True, text=True).stdout; tag_match = pattern.search(tag_text); raise SystemExit(0 if current_match and tag_match and current_match.group(1).lower() == tag_match.group(1).lower() else 1)'
           }
 
           candidate="$CURRENT_VERSION"


### PR DESCRIPTION
## Summary
- rewrite the two embedded Python invocations in `.github/workflows/auto-release.yml` so they stay on one shell line
- preserve the existing PR-resolution and update-key comparison logic
- remove the YAML formatting regression that makes GitHub reject the workflow before any jobs start

## Why
Recent merges are not triggering the release path because `auto-release.yml` is being rejected on push with zero jobs created.

Concrete examples from April 27, 2026:
- push run `25011382713` for commit `b2a07c8` failed immediately
- push run `25014123188` for commit `51d2bc3` failed immediately
- the real `Release` workflow is also still missing a successful publish, so blocking the auto-release workflow at parse time leaves the repository unable to advance toward a fresh release at all

The regression is in the workflow file shape itself: two inline Python snippets were committed with continuation lines flush-left, which breaks YAML parsing.

## Validation
- inspected the current workflow run metadata and confirmed the failing push-triggered `auto-release.yml` runs have zero jobs
- inspected the checked-out workflow file and verified the embedded Python continuation lines were flush-left in the file
- rewrote those invocations so the logic remains identical but the YAML block stays structurally valid

## Follow-up
After this merges, the next successful `CI` push on `master` should be able to run `Auto release after merge` again instead of failing at workflow parse time. The release may still need one additional pass depending on the current `VIGIL_UPDATE_SIGNING_KEY` secret value, but this removes the present blocker that prevents the auto-release path from starting at all.