### PR TITLE
[codex] fix(ci): publish GHCR for each release

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,10 +1,14 @@
 name: Publish GHCR package image
 
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types: [completed]
+  release:
+    types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to mirror into GHCR. Leave empty to use the latest published release.
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -12,7 +16,6 @@ permissions:
 jobs:
   publish:
     name: Publish Vigil package image
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,7 +29,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          tag=$(gh release view latest -R "${{ github.repository }}" --json tagName -q .tagName)
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "release" ]; then
+            tag="${{ github.event.release.tag_name }}"
+          elif [ -n "${{ inputs.tag }}" ]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag=$(gh release view latest -R "${{ github.repository }}" --json tagName -q .tagName)
+          fi
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?(\+[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "Invalid release tag: $tag" >&2
+            exit 1
+          fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Download release AppImage
@@ -36,8 +50,14 @@ jobs:
           mkdir -p ghcr-context
           gh release download "${{ steps.release.outputs.tag }}" \
             -R "${{ github.repository }}" \
-            --pattern 'Vigil-latest-linux-x86_64.AppImage' \
+            --pattern 'Vigil-*-x86_64.AppImage' \
             --dir ghcr-context
+          appimage_path="$(find ghcr-context -maxdepth 1 -type f -name 'Vigil-*-x86_64.AppImage' ! -name 'Vigil-latest-*' | head -n 1)"
+          if [ -z "$appimage_path" ]; then
+            echo "Could not find a versioned Linux AppImage asset in release ${{ steps.release.outputs.tag }}" >&2
+            exit 1
+          fi
+          mv "$appimage_path" ghcr-context/Vigil-latest-linux-x86_64.AppImage
           chmod +x ghcr-context/Vigil-latest-linux-x86_64.AppImage
           ls -lh ghcr-context/
 


### PR DESCRIPTION
## Summary
- trigger the GHCR publish workflow from the actual published GitHub release event
- resolve the exact release tag that fired the workflow, with a manual `workflow_dispatch` tag override when needed
- download the versioned Linux AppImage from that specific release and normalize it into the existing GHCR build context

## Why
The current GHCR workflow follows the `Release` workflow completion and then asks GitHub for whatever release is `latest` at that moment. That makes the package publish path dependent on a floating alias instead of the specific release that just completed.

For handling any new release safely, the package image should mirror the exact release that was published, not whichever release happens to be newest when the follow-up workflow runs.

## Validation
- reviewed the current release and GHCR workflow interaction
- verified the new workflow still supports manual runs, now with an optional explicit tag input
- checked the edited workflow for formatting issues with `git diff --check`
- sanity-checked the shell flow and tag validation logic locally

## Notes
The container here did not have GitHub CLI credentials for a normal `git push`, so the branch and file update were written through the connected GitHub tools instead.