### PR TITLE
fix(ci): restore auto-release workflow parsing

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -84,11 +84,12 @@ jobs:
           fi
 
           if [ -z "$selected_pr" ]; then
-            merge_pr_number="$(git show -s --format=%B "$HEAD_SHA" | python3 - <<'PY'
+            merge_message="$(git show -s --format=%B "$HEAD_SHA")"
+            merge_pr_number="$(MERGE_MESSAGE="$merge_message" python3 - <<'PY'
           import re
-          import sys
+          import os
 
-          text = sys.stdin.read().splitlines()
+          text = os.environ.get("MERGE_MESSAGE", "").splitlines()
           first = text[0] if text else ""
           match = re.match(r"Merge pull request #([0-9]+)", first)
           if match is None:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -84,13 +84,18 @@ jobs:
           fi
 
           if [ -z "$selected_pr" ]; then
-            merge_pr_number="$(git show -s --format=%B "$HEAD_SHA" | python3 -c 'import re, sys
-text = sys.stdin.read().splitlines()
-first = text[0] if text else ""
-match = re.match(r"Merge pull request #([0-9]+)", first)
-if match is None:
-    match = re.search(r"\(#([0-9]+)\)$", first)
-print(match.group(1) if match else "")')"
+            merge_pr_number="$(git show -s --format=%B "$HEAD_SHA" | python3 - <<'PY'
+          import re
+          import sys
+
+          text = sys.stdin.read().splitlines()
+          first = text[0] if text else ""
+          match = re.match(r"Merge pull request #([0-9]+)", first)
+          if match is None:
+              match = re.search(r"\(#([0-9]+)\)$", first)
+          print(match.group(1) if match else "")
+          PY
+            )"
             if [ -n "$merge_pr_number" ]; then
               pr_json="$(gh api -H "Accept: application/vnd.github+json" "/repos/${GITHUB_REPOSITORY}/pulls/${merge_pr_number}" 2>/dev/null || true)"
               if [ -n "$pr_json" ] && is_json "$pr_json" && printf '%s' "$pr_json" | jq -e '.merged_at != null and .base.ref == "master"' >/dev/null 2>&1; then
@@ -146,18 +151,33 @@ print(match.group(1) if match else "")')"
           }
 
           tag_snapshot_matches_current_update_key() {
-            VERSION="$1" python3 -c 'import os, pathlib, re, subprocess
-version = os.environ["VERSION"]
-pattern = re.compile(r"UPDATE_PUBLIC_KEY_HEX:\s*&str\s*=\s*\"([0-9a-fA-F]+)\"")
-current_text = pathlib.Path("src/security/update.rs").read_text(encoding="utf-8")
-current_match = pattern.search(current_text)
-if current_match is None:
-    raise SystemExit(1)
-tag_text = subprocess.run(["git", "show", f"refs/tags/v{version}:src/security/update.rs"], check=True, capture_output=True, text=True).stdout
-tag_match = pattern.search(tag_text)
-if tag_match is None:
-    raise SystemExit(1)
-raise SystemExit(0 if current_match.group(1).lower() == tag_match.group(1).lower() else 1)'
+            VERSION="$1" python3 - <<'PY'
+          import os
+          import pathlib
+          import re
+          import subprocess
+
+          version = os.environ["VERSION"]
+          pattern = re.compile(r"UPDATE_PUBLIC_KEY_HEX:\s*&str\s*=\s*\"([0-9a-fA-F]+)\"")
+          current_text = pathlib.Path("src/security/update.rs").read_text(encoding="utf-8")
+          current_match = pattern.search(current_text)
+          if current_match is None:
+              raise SystemExit(1)
+          tag_text = subprocess.run(
+              ["git", "show", f"refs/tags/v{version}:src/security/update.rs"],
+              check=True,
+              capture_output=True,
+              text=True,
+          ).stdout
+          tag_match = pattern.search(tag_text)
+          if tag_match is None:
+              raise SystemExit(1)
+          raise SystemExit(
+              0
+              if current_match.group(1).lower() == tag_match.group(1).lower()
+              else 1
+          )
+          PY
           }
 
           candidate="$CURRENT_VERSION"


### PR DESCRIPTION
## Summary
- replace the malformed multi-line inline Python snippets in `auto-release.yml` with properly embedded here-doc Python blocks
- keep the merged-PR resolution and update-key comparison logic unchanged while making the workflow file parse again

## Why
GitHub is currently rejecting `.github/workflows/auto-release.yml` before any job starts. The failure annotation reports `Invalid workflow file: .github/workflows/auto-release.yml#L88`, and the resulting workflow runs show no jobs because the definition itself is invalid.

That means the release chain is still broken right now even though the later GHCR fix is already merged: successful `CI` runs on `master` cannot reach the auto-release logic if the workflow file never parses.

## Validation
- confirmed the failing GitHub Actions annotation reports `Invalid workflow file: .github/workflows/auto-release.yml#L88`
- scoped the fix to the two embedded Python snippets that were breaking YAML parsing
- checked the edited file for whitespace problems with `git diff --check`
- all PR checks for commit `248af07af9cfbfbc1c22d2f669daf0bdd15383e5` completed successfully before reopen

## Expected outcome
After this lands, GitHub should stop rejecting the workflow on push, and the next successful `CI` run on `master` can actually execute the auto-release logic again.