### PR TITLE
[codex] Fix Windows installer and silent startup failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,9 @@ Vigil also runs two passive persistence watchers that raise synthetic alerts
 ### Windows — one-click installer
 
 1. Download `Vigil-Setup-<version>-x86_64.exe` from the [latest release].
-2. Run the installer — it places Vigil in `Program Files`, creates a Start
-   Menu shortcut, and registers it for autostart.
+2. Run the installer — by default it installs for the current user, creates a
+   Start Menu shortcut, and registers it for autostart. If you choose an
+   all-users install during setup, Vigil is installed in `Program Files`.
 
 > **Note:** ETW-based real-time monitoring requires Administrator rights.
 > Without elevation, Vigil falls back to polling every few seconds — all

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -20,7 +20,8 @@ Vigil is intentionally conservative about action. Scores and advisory context ar
 ### Windows
 
 1. Download the Windows installer from the latest GitHub Release.
-2. Run the installer.
+2. Run the installer. By default it installs for the current user; if you
+   choose an all-users install during setup, it installs to `Program Files`.
 3. Launch Vigil from the Start Menu or the installed shortcut.
 4. Use **Run as Admin** in the header when you need ETW visibility or active response actions.
 

--- a/installer/windows/setup.iss
+++ b/installer/windows/setup.iss
@@ -26,6 +26,10 @@ AppSupportURL={#MyAppURL}/issues
 AppUpdatesURL={#MyAppURL}/releases
 
 ; Install to Program Files by default; allow per-user install without elevation.
+; Default to current-user mode so standard Windows accounts can install without
+; tripping an upfront admin-only check. The install-mode dialog still lets
+; admins switch to an all-users install.
+PrivilegesRequired=lowest
 DefaultDirName={autopf}\{#MyAppName}
 DefaultGroupName={#MyAppName}
 PrivilegesRequiredOverridesAllowed=dialog

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,22 @@ fn load_app_icon() -> Option<egui::IconData> {
         .ok()
 }
 
+fn report_startup_failure(message: &str) {
+    #[cfg(windows)]
+    {
+        use windows::Win32::UI::WindowsAndMessaging::{MessageBoxW, MB_ICONERROR, MB_OK};
+
+        let title = windows::core::HSTRING::from("Vigil startup failed");
+        let body = windows::core::HSTRING::from(message);
+        unsafe {
+            let _ = MessageBoxW(None, &body, &title, MB_OK | MB_ICONERROR);
+        }
+    }
+
+    #[cfg(not(windows))]
+    eprintln!("{message}");
+}
+
 fn acquire_single_instance(wait_for_release: bool) -> Result<SingleInstance, String> {
     if !wait_for_release {
         return SingleInstance::new(SINGLE_INSTANCE_ID)
@@ -316,15 +332,12 @@ fn main() {
 
     let native_options = eframe::NativeOptions {
         viewport,
-        // Vigil only enables eframe's glow feature; make the runtime choice
-        // explicit so native builds don't drift onto the wgpu backend.
-        renderer: eframe::Renderer::Glow,
         persist_window: true,
         ..Default::default()
     };
 
     let cfg_ui = cfg.clone();
-    eframe::run_native(
+    if let Err(err) = eframe::run_native(
         "Vigil",
         native_options,
         Box::new(move |cc| {
@@ -339,6 +352,13 @@ fn main() {
                 egui_ctx_ui,
             )))
         }),
-    )
-    .expect("eframe failed");
+    ) {
+        let startup_message = format!(
+            "Vigil could not open its desktop window.\n\nError: {err}\n\nLogs: {}",
+            log_dir.display()
+        );
+        tracing::error!(%err, "eframe failed to start");
+        report_startup_failure(&startup_message);
+        std::process::exit(1);
+    }
 }

--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -53,11 +53,13 @@ pub fn load_json_with_integrity(path: &Path) -> Result<Option<Vec<u8>>, String> 
         return Ok(None);
     }
 
-    Err(format!(
-        "policy store {} is missing required integrity signature {}",
-        path.display(),
-        sig_path.display()
-    ))
+    tracing::warn!(
+        "policy store {} is unsigned legacy state; sealing it with integrity sidecars",
+        path.display()
+    );
+    let secret = load_or_create_secret(path)?;
+    save_current_and_backup(path, &secret, &current)?;
+    Ok(Some(current))
 }
 
 pub fn save_json_with_integrity(path: &Path, data: &[u8]) -> Result<(), String> {
@@ -311,31 +313,36 @@ mod tests {
     }
 
     #[test]
-    fn unsigned_existing_store_is_rejected() {
+    fn unsigned_existing_store_is_migrated_to_protected_state() {
         let base = unique_temp_dir();
         fs::create_dir_all(&base).unwrap();
         let path = base.join("vigil.json");
         let json = br#"{"poll_interval_secs":5,"alert_threshold":3,"log_all_connections":false,"autostart":false,"first_run_done":false,"trusted_processes":[],"common_ports":[],"malware_ports":[],"suspicious_path_fragments":[],"lolbins":[],"activity_history_cap":2048,"alerts_history_cap":1024,"geoip_city_db":"","geoip_asn_db":"","allowed_countries":[],"blocklist_paths":[],"fswatch_enabled":true,"fswatch_window_secs":600,"long_lived_secs":3600,"reverse_dns_enabled":false,"dga_entropy_threshold":3.2,"auto_response_enabled":false,"auto_response_dry_run":false,"auto_kill_connection":false,"auto_block_remote":false,"auto_block_process":false,"auto_isolate_machine":false,"auto_response_min_score":10,"auto_response_cooldown_secs":300,"allowlist_mode_enabled":false,"allowlist_mode_dry_run":false,"allowlist_processes":[],"response_rules_enabled":false,"response_rules_dry_run":true,"response_rules_path":"","scheduled_lockdown_enabled":false,"scheduled_lockdown_start_hour":23,"scheduled_lockdown_start_minute":0,"scheduled_lockdown_end_hour":6,"scheduled_lockdown_end_minute":0,"process_dump_on_alert":false,"process_dump_min_score":12,"process_dump_cooldown_secs":600,"process_dump_dir":"","pcap_on_alert":false,"pcap_min_score":12,"pcap_duration_secs":15,"pcap_cooldown_secs":300,"pcap_packet_size_bytes":0,"pcap_dir":"","honeypot_decoys_enabled":false,"honeypot_auto_isolate":false,"honeypot_poll_secs":10,"honeypot_decoy_names":[],"break_glass_enabled":true,"break_glass_timeout_mins":10,"break_glass_heartbeat_secs":30,"ui_scale":1.0}"#;
         fs::write(&path, json).unwrap();
-        let err = load_json_with_integrity(&path).unwrap_err();
-        assert!(err.contains("missing required integrity signature"));
+        let loaded = load_json_with_integrity(&path).unwrap().unwrap();
+        assert_eq!(loaded, json);
+        assert!(secret_path(&path).exists());
+        assert!(signature_path(&path).exists());
+        assert!(backup_data_path(&path).exists());
+        assert!(backup_sig_path(&path).exists());
         let _ = fs::remove_dir_all(base);
     }
 
     #[test]
-    fn unsigned_existing_store_does_not_create_secret_on_failed_load() {
+    fn unsigned_existing_store_migration_is_stable_across_reloads() {
         let base = unique_temp_dir();
         fs::create_dir_all(&base).unwrap();
         let path = base.join("vigil.json");
         fs::write(&path, br#"{"version":1}"#).unwrap();
 
-        let first = load_json_with_integrity(&path).unwrap_err();
-        assert!(first.contains("missing required integrity signature"));
-        assert!(!secret_path(&path).exists());
+        let first = load_json_with_integrity(&path).unwrap().unwrap();
+        assert_eq!(first, br#"{"version":1}"#);
+        assert!(secret_path(&path).exists());
+        assert!(signature_path(&path).exists());
 
-        let second = load_json_with_integrity(&path).unwrap_err();
-        assert!(second.contains("missing required integrity signature"));
-        assert!(!secret_path(&path).exists());
+        let second = load_json_with_integrity(&path).unwrap().unwrap();
+        assert_eq!(second, br#"{"version":1}"#);
+        assert!(secret_path(&path).exists());
 
         let _ = fs::remove_dir_all(base);
     }


### PR DESCRIPTION
## Summary

This PR fixes the Windows release blockers that left recent public installers unusable for some users.

- default the Windows installer to a current-user install so standard Windows accounts do not hit an admin-only installer error before setup even starts
- migrate legacy unsigned `vigil.json` state into the protected policy store instead of exiting during startup on existing installs
- stop forcing the native UI onto the Glow renderer and show a visible startup error dialog if the desktop window still cannot open
- align the Windows install docs with the actual installer behavior

## Why this change

The current public releases still ship with three user-facing Windows problems:

1. the installer script says per-user installs are allowed, but it still defaults to admin-only mode
2. legacy local config from older Vigil installs can make startup exit immediately instead of migrating forward
3. UI startup failures can disappear silently with no visible explanation

Together these regressions make the Windows release path look broken even when the executable is being launched.

## User impact

After this lands and merges to `master`, the repository's auto-release workflow should cut the next patch release. That release should:

- install cleanly for ordinary Windows users
- start successfully on older local Vigil data directories that still have an unsigned config
- show a real Windows error dialog instead of silently disappearing if window initialization still fails on a particular machine

## Validation

- `git diff --check`
- source-level inspection against the shipped `v1.3.10` tag confirmed these fixes are not in the current public release
- reviewed the auto-release workflow to confirm a merge to `master` is the path that drives the next patch release

## Validation limits

- I could not run `cargo test`, `cargo fmt`, `cargo clippy`, or a Windows installer build in this container because the Rust toolchain and Windows build environment are not available here.

## Risk notes

- The legacy-config migration path is intentionally narrow: it only auto-seals existing unsigned local state when there is no existing protected sidecar or backup, while already-protected installs keep the stricter restore path.
- The renderer change removes the explicit Glow pin and returns to eframe's default native renderer selection so Windows startup is more tolerant of local graphics differences.