### PR TITLE
chore(release): record v1.3.12 version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4119,7 +4119,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vigil"
-version = "1.3.7"
+version = "1.3.12"
 dependencies = [
  "auto-launch",
  "aya",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "vigil"
-version     = "1.3.7"
+version     = "1.3.12"
 edition     = "2021"
 description = "Real-time network threat monitor"
 license     = "MIT"


### PR DESCRIPTION
## Summary
- align `Cargo.toml` and `Cargo.lock` with the already-cut `v1.3.12` release branch
- preserve the latest release bookkeeping change in a normal reviewable path

## Why
The repository currently has no open pull requests, but `release/v1.3.12` still carries one meaningful unmerged commit with no PR attached. That commit updates the package version from `1.3.7` to `1.3.12` after the recent merged release work.

Opening this PR keeps the branch’s useful bookkeeping change reviewable and prevents the latest release version bump from being stranded outside `master`.

## Validation
- inspected `release/v1.3.12` against `master`
- confirmed the diff is limited to the version bump in `Cargo.toml` and `Cargo.lock`
- confirmed there was no existing pull request for `release/v1.3.12`