### PR TITLE
fix(release): keep notes scoped to each release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -319,6 +319,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           NEXT_VERSION: ${{ steps.version.outputs.next_version }}
           SOURCE_REF: ${{ steps.source.outputs.source_ref }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
         run: |
           gh api \
             --method POST \
@@ -327,7 +328,8 @@ jobs:
             -f ref="master" \
             -f inputs[tag]="v${NEXT_VERSION}" \
             -f inputs[version]="${NEXT_VERSION}" \
-            -f inputs[source_ref]="${SOURCE_REF}"
+            -f inputs[source_ref]="${SOURCE_REF}" \
+            -f inputs[pr_number]="${PR_NUMBER}"
 
       - name: Report skipped release
         if: always() && steps.tag.outputs.release_ready != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,10 @@ on:
         description: Full git ref or 40-character commit SHA to check out for the release build; leave empty to build from the release tag
         required: false
         type: string
+      pr_number:
+        description: Pull request number associated with this release; leave empty when publishing manually
+        required: false
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -49,6 +53,7 @@ jobs:
       tag: ${{ steps.validate.outputs.tag }}
       version: ${{ steps.validate.outputs.version }}
       checkout_ref: ${{ steps.validate.outputs.checkout_ref }}
+      pr_number: ${{ steps.validate.outputs.pr_number }}
     steps:
       - name: Validate release tag
         id: validate
@@ -59,6 +64,7 @@ jobs:
           INPUT_TAG: ${{ inputs.tag }}
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_SOURCE_REF: ${{ inputs.source_ref }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
@@ -95,9 +101,16 @@ jobs:
             echo "Expected a full refs/heads/... or refs/tags/... value, the exact release tag, or a 40-character commit SHA." >&2
             exit 1
           fi
+          PR_NUMBER="$INPUT_PR_NUMBER"
+          if [ -n "$PR_NUMBER" ] && [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "Invalid pr_number: $PR_NUMBER" >&2
+            echo "Expected a numeric pull request number." >&2
+            exit 1
+          fi
           echo "tag=$REF_NAME" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "checkout_ref=$CHECKOUT_REF" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
   # ── Windows — Inno Setup EXE ───────────────────────────────────────────────
   build-windows:
@@ -591,6 +604,42 @@ jobs:
         shell: bash
         run: echo "hashes=$(sha256sum dist/* | base64 -w0)" >> "$GITHUB_OUTPUT"
 
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.validate-release-metadata.outputs.pr_number }}
+          RELEASE_TAG: ${{ needs.validate-release-metadata.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          pr_title=""
+          pr_body=""
+          pr_url=""
+          resolved_pr_number="${PR_NUMBER}"
+          fallback_subject="$(git show -s --format=%s "${{ needs.validate-release-metadata.outputs.checkout_ref }}")"
+
+          if [ -z "${resolved_pr_number}" ]; then
+            resolved_pr_number="$(printf '%s' "$fallback_subject" | sed -nE 's/.*#([0-9]+).*/\1/p' | head -n1)"
+          fi
+
+          if [ -n "${resolved_pr_number}" ]; then
+            pr_json="$(curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${resolved_pr_number}")"
+            pr_title="$(printf '%s' "$pr_json" | jq -r '.title // ""')"
+            pr_body="$(printf '%s' "$pr_json" | jq -r '.body // ""')"
+            pr_url="$(printf '%s' "$pr_json" | jq -r '.html_url // ""')"
+          fi
+
+          python3 scripts/generate_release_notes.py \
+            --tag "${RELEASE_TAG}" \
+            --pr-title "$pr_title" \
+            --pr-body "$pr_body" \
+            --pr-url "$pr_url" \
+            --fallback-subject "$fallback_subject" \
+            --output dist/release-notes.md
+
       - name: List release assets
         run: ls -lh dist/
 
@@ -599,7 +648,7 @@ jobs:
         with:
           tag_name: ${{ needs.validate-release-metadata.outputs.tag }}
           name: Vigil ${{ needs.validate-release-metadata.outputs.tag }}
-          generate_release_notes: true
+          body_path: dist/release-notes.md
           files: dist/*
 
       - name: Generate artifact attestations

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -616,7 +616,7 @@ jobs:
           pr_body=""
           pr_url=""
           resolved_pr_number="${PR_NUMBER}"
-          fallback_subject="$(git show -s --format=%s "${{ needs.validate-release-metadata.outputs.checkout_ref }}")"
+          fallback_subject="$(git show -s --format=%s "${{ needs.validate-release-metadata.outputs.checkout_ref }}^{commit}")"
 
           if [ -z "${resolved_pr_number}" ]; then
             resolved_pr_number="$(printf '%s' "$fallback_subject" | sed -nE 's/.*#([0-9]+).*/\1/p' | head -n1)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -623,13 +623,16 @@ jobs:
           fi
 
           if [ -n "${resolved_pr_number}" ]; then
-            pr_json="$(curl -fsSL \
+            if pr_json="$(curl -fsSL \
               -H "Authorization: Bearer ${GH_TOKEN}" \
               -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${resolved_pr_number}")"
-            pr_title="$(printf '%s' "$pr_json" | jq -r '.title // ""')"
-            pr_body="$(printf '%s' "$pr_json" | jq -r '.body // ""')"
-            pr_url="$(printf '%s' "$pr_json" | jq -r '.html_url // ""')"
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${resolved_pr_number}")"; then
+              pr_title="$(printf '%s' "$pr_json" | jq -r '.title // ""')"
+              pr_body="$(printf '%s' "$pr_json" | jq -r '.body // ""')"
+              pr_url="$(printf '%s' "$pr_json" | jq -r '.html_url // ""')"
+            else
+              echo "Unable to fetch PR metadata for #${resolved_pr_number}; falling back to the release subject." >&2
+            fi
           fi
 
           python3 scripts/generate_release_notes.py \

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Build focused release notes for a single Vigil release."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+
+
+SECTION_PRIORITIES = (
+    "what changed",
+    "what's changed",
+    "summary",
+    "changes",
+    "included",
+    "scope",
+    "highlights",
+)
+
+
+def normalize_heading(text: str) -> str:
+    normalized = text.strip().lower()
+    normalized = normalized.replace("’", "'")
+    normalized = re.sub(r"[^\w\s']+", "", normalized)
+    return " ".join(normalized.split())
+
+
+def split_sections(body: str) -> list[tuple[str | None, list[str]]]:
+    sections: list[tuple[str | None, list[str]]] = []
+    current_heading: str | None = None
+    current_lines: list[str] = []
+
+    for line in body.splitlines():
+        heading_match = re.match(r"^\s{0,3}#{1,6}\s+(.+?)\s*$", line)
+        if heading_match:
+            if current_lines:
+                sections.append((current_heading, current_lines))
+            current_heading = heading_match.group(1).strip()
+            current_lines = []
+            continue
+        current_lines.append(line)
+
+    if current_lines:
+        sections.append((current_heading, current_lines))
+
+    return sections
+
+
+def normalize_bullet(text: str) -> str:
+    text = text.strip()
+    text = re.sub(r"^\s*[-*+]\s+", "", text)
+    text = re.sub(r"^\s*\d+\.\s+", "", text)
+    return " ".join(part.strip() for part in text.splitlines() if part.strip())
+
+
+def section_bullets(lines: list[str]) -> list[str]:
+    bullets: list[str] = []
+    current_list_item: list[str] = []
+    paragraph: list[str] = []
+
+    def flush_list_item() -> None:
+        nonlocal current_list_item
+        if not current_list_item:
+            return
+        bullet = normalize_bullet("\n".join(current_list_item))
+        if bullet:
+            bullets.append(bullet)
+        current_list_item = []
+
+    def flush_paragraph() -> None:
+        nonlocal paragraph
+        if not paragraph:
+            return
+        text = " ".join(part.strip() for part in paragraph if part.strip())
+        if text:
+            bullets.append(text)
+        paragraph = []
+
+    for raw_line in lines:
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if not stripped:
+            flush_list_item()
+            flush_paragraph()
+            continue
+        if re.match(r"^\s*[-*+]\s+", line) or re.match(r"^\s*\d+\.\s+", line):
+            flush_list_item()
+            flush_paragraph()
+            current_list_item = [line]
+            continue
+        if current_list_item:
+            current_list_item.append(line)
+        else:
+            paragraph.append(line)
+
+    flush_list_item()
+    flush_paragraph()
+    return bullets
+
+
+def extract_release_bullets(body: str) -> list[str]:
+    if not body.strip():
+        return []
+
+    sections = split_sections(body)
+    prioritized: list[str] = []
+    fallback: list[str] = []
+
+    for heading, lines in sections:
+        bullets = section_bullets(lines)
+        if not bullets:
+            continue
+        if heading is None:
+            fallback.extend(bullets)
+            continue
+        normalized = normalize_heading(heading)
+        if normalized in SECTION_PRIORITIES:
+            prioritized.extend(bullets)
+
+    chosen = prioritized or fallback
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for bullet in chosen:
+        normalized = " ".join(bullet.split()).lower()
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        deduped.append(bullet)
+    return deduped[:6]
+
+
+def build_release_notes(
+    *,
+    tag: str,
+    pr_title: str,
+    pr_body: str,
+    pr_url: str,
+    fallback_subject: str,
+) -> str:
+    bullets = extract_release_bullets(pr_body)
+    if not bullets:
+        title = pr_title.strip() or fallback_subject.strip() or f"Release {tag}"
+        bullets = [title]
+
+    lines = ["## What's changed"]
+    lines.extend(f"- {bullet}" for bullet in bullets)
+
+    reference_url = pr_url.strip()
+    if reference_url:
+        lines.extend(
+            [
+                "",
+                "## Reference",
+                f"- Source PR: {reference_url}",
+            ]
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate release notes from a release PR summary."
+    )
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--pr-title", default="")
+    parser.add_argument("--pr-body", default="")
+    parser.add_argument("--pr-url", default="")
+    parser.add_argument("--fallback-subject", default="")
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args()
+
+    notes = build_release_notes(
+        tag=args.tag,
+        pr_title=args.pr_title,
+        pr_body=args.pr_body,
+        pr_url=args.pr_url,
+        fallback_subject=args.fallback_subject,
+    )
+    args.output.write_text(notes, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_generate_release_notes.py
+++ b/scripts/test_generate_release_notes.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from generate_release_notes import build_release_notes, extract_release_bullets
+
+
+class ReleaseNotesTests(unittest.TestCase):
+    def test_extracts_bullets_from_summary_section(self) -> None:
+        body = """## Summary
+- remove the unnecessary Actions write permission from `auto-release.yml`
+- pin the remaining tag-based workflow dependencies to immutable commit SHAs
+
+## Why
+This should not be included.
+"""
+        self.assertEqual(
+            extract_release_bullets(body),
+            [
+                "remove the unnecessary Actions write permission from `auto-release.yml`",
+                "pin the remaining tag-based workflow dependencies to immutable commit SHAs",
+            ],
+        )
+
+    def test_extracts_paragraphs_from_what_changed_section(self) -> None:
+        body = """## What changed
+
+This updates the active-response query path used by the inspector so selection does not repeatedly reload the protected state file on every repaint.
+
+It adds a short in-memory cache for read-only query calls and refreshes that cache when the state is written.
+
+## Impact
+
+Selecting an item should no longer drag the whole UI down.
+"""
+        self.assertEqual(
+            extract_release_bullets(body),
+            [
+                "This updates the active-response query path used by the inspector so selection does not repeatedly reload the protected state file on every repaint.",
+                "It adds a short in-memory cache for read-only query calls and refreshes that cache when the state is written.",
+            ],
+        )
+
+    def test_falls_back_to_title_when_body_has_no_release_summary(self) -> None:
+        notes = build_release_notes(
+            tag="v1.3.14",
+            pr_title="[codex] Fix inspector selection responsiveness",
+            pr_body="## Why\nBecause it was needed.\n",
+            pr_url="https://github.com/YMRYMR/vigil/pull/118",
+            fallback_subject="release subject",
+        )
+        self.assertIn(
+            "- [codex] Fix inspector selection responsiveness",
+            notes,
+        )
+        self.assertIn(
+            "- Source PR: https://github.com/YMRYMR/vigil/pull/118",
+            notes,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- build release notes from the merged PR summary instead of GitHub's generated tag comparison
- pass the merged PR number through the auto-release dispatch so each release can describe only its own change set
- add focused tests for the release-notes parser and fallback behavior

## Why
Recent releases are reusing older "What's changed" bullets because the generated release notes compare across release-tag history that does not stay linear on `master`.

## Validation
- `python3 -m unittest /workspace/vigil/scripts/test_generate_release_notes.py /workspace/vigil/scripts/test_prepare_release.py`
- `python3 -m py_compile /workspace/vigil/scripts/generate_release_notes.py /workspace/vigil/scripts/prepare_release.py /workspace/vigil/scripts/test_generate_release_notes.py /workspace/vigil/scripts/test_prepare_release.py`

## Notes
- I could not run a standalone YAML parser for the workflows in this container because the usual parser packages were unavailable.