### PR TITLE
[codex] Fix boot-time Vigil service startup before login

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,8 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
-const SINGLE_INSTANCE_ID: &str = "com.ymrymr.vigil.single_instance";
+const SINGLE_INSTANCE_UI_ID: &str = "com.ymrymr.vigil.single_instance.gui";
+const SINGLE_INSTANCE_SERVICE_ID: &str = "com.ymrymr.vigil.single_instance.service";
 fn load_app_icon() -> Option<egui::IconData> {
     eframe::icon_data::from_png_bytes(include_bytes!("../assets/vigil_icon.png"))
         .or_else(|_| eframe::icon_data::from_png_bytes(include_bytes!("../assets/vigil.png")))
@@ -83,9 +84,9 @@ fn report_startup_failure(message: &str) {
     eprintln!("{message}");
 }
 
-fn acquire_single_instance(wait_for_release: bool) -> Result<SingleInstance, String> {
+fn acquire_single_instance(instance_id: &str, wait_for_release: bool) -> Result<SingleInstance, String> {
     if !wait_for_release {
-        return SingleInstance::new(SINGLE_INSTANCE_ID)
+        return SingleInstance::new(instance_id)
             .map_err(|err| format!("Could not acquire Vigil instance lock: {err}"));
     }
 
@@ -93,7 +94,7 @@ fn acquire_single_instance(wait_for_release: bool) -> Result<SingleInstance, Str
     let timeout = Duration::from_secs(12);
     let sleep_interval = Duration::from_millis(150);
     loop {
-        let guard = SingleInstance::new(SINGLE_INSTANCE_ID)
+        let guard = SingleInstance::new(instance_id)
             .map_err(|err| format!("Could not acquire Vigil instance lock: {err}"))?;
         if guard.is_single() {
             return Ok(guard);
@@ -104,6 +105,58 @@ fn acquire_single_instance(wait_for_release: bool) -> Result<SingleInstance, Str
         drop(guard);
         std::thread::sleep(sleep_interval);
     }
+}
+
+fn spawn_bootstrap(cfg_bootstrap: Arc<RwLock<Config>>, manage_login_autostart: bool) {
+    std::thread::Builder::new()
+        .name("vigil-bootstrap".into())
+        .spawn(move || {
+            let c = cfg_bootstrap.read().unwrap().clone();
+            geoip::init(&c.geoip_city_db, &c.geoip_asn_db);
+            blocklist::init(&c.blocklist_paths);
+            if c.fswatch_enabled {
+                fswatch::start();
+            }
+            if c.reverse_dns_enabled {
+                revdns::start();
+            }
+            let (n_lists, n_entries) = blocklist::stats();
+            tracing::info!(
+                "Phase 10: geoip={}, blocklists={} ({} entries), fswatch={}, revdns={}",
+                geoip::is_loaded(),
+                n_lists,
+                n_entries,
+                c.fswatch_enabled,
+                c.reverse_dns_enabled
+            );
+            advisory::log_cache_status();
+
+            active_response::reconcile();
+            break_glass::start_heartbeat_loop(cfg_bootstrap.clone());
+            advisory::refresh_nvd_in_background_if_due();
+
+            if manage_login_autostart {
+                {
+                    let mut w = cfg_bootstrap.write().unwrap();
+                    if !w.first_run_done {
+                        if autostart::enable() {
+                            w.autostart = true;
+                            tracing::info!("autostart enabled");
+                        } else {
+                            tracing::warn!("could not enable autostart");
+                        }
+                        w.first_run_done = true;
+                        w.save();
+                    }
+                }
+
+                let c = cfg_bootstrap.read().unwrap();
+                if c.autostart && !autostart::enable() {
+                    tracing::warn!("could not refresh autostart");
+                }
+            }
+        })
+        .expect("failed to spawn bootstrap thread");
 }
 
 fn main() {
@@ -180,11 +233,15 @@ fn main() {
 
     let mut elevated_relaunch = false;
     let mut elevated_launcher = false;
+    let mut service_mode = false;
     for a in &args[1..] {
         match a.as_str() {
             "--install-service" => std::process::exit(service::run_cmd("install")),
             "--uninstall-service" => std::process::exit(service::run_cmd("uninstall")),
             "--break-glass-recover" => std::process::exit(break_glass::recover_if_stale()),
+            service::SERVICE_MODE_FLAG => {
+                service_mode = true;
+            }
             autostart::ELEVATED_RELAUNCH_FLAG => {
                 elevated_relaunch = true;
             }
@@ -192,7 +249,7 @@ fn main() {
                 elevated_launcher = true;
             }
             "--help" | "-h" => {
-                println!("Vigil v{} — real-time network threat monitor\n\nUsage:  vigil [flags]\n\nFlags:\n  --install-service         register Vigil as a boot-time service\n  --uninstall-service       remove the boot-time service\n  --break-glass-recover     watchdog entrypoint for network recovery\n  --verify-update-manifest  MANIFEST SIG\n                           verify a signed release manifest against the embedded trust anchor\n  --import-nvd-snapshot     SNAPSHOT.json [MORE.json ...]\n                           import or merge one or more NVD CVE JSON snapshots into the protected advisory cache\n  --sync-nvd [--force]      fetch or incrementally refresh the protected NVD CVE cache from the live API\n  --advisory-cache-status   show advisory cache status and source health\n  -h, --help                show this help and exit\n\nRun with no flags to launch the GUI.", env!("CARGO_PKG_VERSION"));
+                println!("Vigil v{} — real-time network threat monitor\n\nUsage:  vigil [flags]\n\nFlags:\n  --install-service         register Vigil as a boot-time service\n  --uninstall-service       remove the boot-time service\n  --break-glass-recover     watchdog entrypoint for network recovery\n  --verify-update-manifest  MANIFEST SIG\n                           verify a signed release manifest against the embedded trust anchor\n  --import-nvd-snapshot     SNAPSHOT.json [MORE.json ...]\n                           import or merge one or more NVD CVE JSON snapshots into the protected advisory cache\n  --sync-nvd [--force]      fetch or incrementally refresh the protected NVD CVE cache from the live API\n  --advisory-cache-status   show advisory cache status and source health\n  --service-mode            internal headless service entrypoint\n  -h, --help                show this help and exit\n\nRun with no flags to launch the GUI.", env!("CARGO_PKG_VERSION"));
                 std::process::exit(0);
             }
             _ => {}
@@ -209,7 +266,12 @@ fn main() {
         }
     }
 
-    let _single_instance_guard = match acquire_single_instance(elevated_relaunch) {
+    let instance_id = if service_mode {
+        SINGLE_INSTANCE_SERVICE_ID
+    } else {
+        SINGLE_INSTANCE_UI_ID
+    };
+    let _single_instance_guard = match acquire_single_instance(instance_id, elevated_relaunch) {
         Ok(guard) => guard,
         Err(err) => {
             if !elevated_relaunch && err.contains("instance lock") {
@@ -257,58 +319,23 @@ fn main() {
     startup_integrity::run();
     startup_integrity::scan_operator_inputs(&loaded_cfg);
     let cfg = Arc::new(RwLock::new(loaded_cfg));
-    let cfg_bootstrap = cfg.clone();
-    std::thread::Builder::new()
-        .name("vigil-bootstrap".into())
-        .spawn(move || {
-            let c = cfg_bootstrap.read().unwrap().clone();
-            geoip::init(&c.geoip_city_db, &c.geoip_asn_db);
-            blocklist::init(&c.blocklist_paths);
-            if c.fswatch_enabled {
-                fswatch::start();
-            }
-            if c.reverse_dns_enabled {
-                revdns::start();
-            }
-            let (n_lists, n_entries) = blocklist::stats();
-            tracing::info!(
-                "Phase 10: geoip={}, blocklists={} ({} entries), fswatch={}, revdns={}",
-                geoip::is_loaded(),
-                n_lists,
-                n_entries,
-                c.fswatch_enabled,
-                c.reverse_dns_enabled
-            );
-            advisory::log_cache_status();
-
-            active_response::reconcile();
-            break_glass::start_heartbeat_loop(cfg_bootstrap.clone());
-            advisory::refresh_nvd_in_background_if_due();
-
-            {
-                let mut w = cfg_bootstrap.write().unwrap();
-                if !w.first_run_done {
-                    if autostart::enable() {
-                        w.autostart = true;
-                        tracing::info!("autostart enabled");
-                    } else {
-                        tracing::warn!("could not enable autostart");
-                    }
-                    w.first_run_done = true;
-                    w.save();
-                }
-            }
-
-            let c = cfg_bootstrap.read().unwrap();
-            if c.autostart && !autostart::enable() {
-                tracing::warn!("could not refresh autostart");
-            }
-        })
-        .expect("failed to spawn bootstrap thread");
+    spawn_bootstrap(cfg.clone(), !service_mode);
 
     let mon = Monitor::new(cfg.clone());
-    let event_rx = mon.subscribe();
+    let event_rx = if service_mode {
+        None
+    } else {
+        Some(mon.subscribe())
+    };
     let _mon_handle = mon.start();
+
+    if service_mode {
+        tracing::info!("Vigil service mode active; monitor started without desktop UI");
+        loop {
+            std::thread::park_timeout(Duration::from_secs(3600));
+        }
+    }
+    let event_rx = event_rx.expect("desktop mode requires event stream");
 
     let show_window = Arc::new(AtomicBool::new(false));
     let paused_flag = Arc::new(AtomicBool::new(false));

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,10 @@ fn report_startup_failure(message: &str) {
     eprintln!("{message}");
 }
 
-fn acquire_single_instance(instance_id: &str, wait_for_release: bool) -> Result<SingleInstance, String> {
+fn acquire_single_instance(
+    instance_id: &str,
+    wait_for_release: bool,
+) -> Result<SingleInstance, String> {
     if !wait_for_release {
         return SingleInstance::new(instance_id)
             .map_err(|err| format!("Could not acquire Vigil instance lock: {err}"));

--- a/src/platform/service.rs
+++ b/src/platform/service.rs
@@ -24,6 +24,9 @@
 /// to stdout; `Err(msg)` is printed to stderr and the process exits 1.
 pub type CmdResult = Result<String, String>;
 
+/// Internal headless entrypoint used by OS services / daemons.
+pub const SERVICE_MODE_FLAG: &str = "--service-mode";
+
 pub fn install() -> CmdResult {
     let exe =
         std::env::current_exe().map_err(|e| format!("could not resolve current exe path: {e}"))?;
@@ -46,8 +49,8 @@ mod platform {
     const SVC_NAME: &str = "Vigil";
 
     pub fn install(exe: &Path) -> CmdResult {
-        // sc create Vigil binPath= "\"C:\path\to\vigil.exe\"" start= auto
-        let bin_path = format!("\"{}\"", exe.display());
+        // sc create Vigil binPath= "\"C:\path\to\vigil.exe\" --service-mode" start= auto
+        let bin_path = format!("\"{}\" {}", exe.display(), SERVICE_MODE_FLAG);
         let status = Command::new(command_paths::resolve("sc")?)
             .args([
                 "create",
@@ -158,7 +161,7 @@ mod platform {
 <plist version="1.0">
 <dict>
     <key>Label</key>             <string>{LABEL}</string>
-    <key>ProgramArguments</key>  <array><string>{exe}</string></array>
+    <key>ProgramArguments</key>  <array><string>{exe}</string><string>{service_flag}</string></array>
     <key>RunAtLoad</key>         <true/>
     <key>KeepAlive</key>         <true/>
     <key>StandardOutPath</key>   <string>/var/log/vigil.log</string>
@@ -167,6 +170,7 @@ mod platform {
 </plist>
 "#,
             exe = exe,
+            service_flag = SERVICE_MODE_FLAG,
         );
         let path = plist_path();
         std::fs::write(&path, plist.as_bytes())
@@ -259,7 +263,7 @@ mod platform {
              \n\
              [Service]\n\
              Type=simple\n\
-             ExecStart={exe}\n\
+             ExecStart={exe} {service_flag}\n\
              Restart=on-failure\n\
              RestartSec=5\n\
              StandardOutput=journal\n\
@@ -268,6 +272,7 @@ mod platform {
              [Install]\n\
              WantedBy=multi-user.target\n",
             exe = exe,
+            service_flag = SERVICE_MODE_FLAG,
         );
         let path = unit_path();
         std::fs::write(&path, unit.as_bytes())


### PR DESCRIPTION
## What changed
- added a dedicated internal `--service-mode` entrypoint for boot-time service installs
- updated Windows SCM, launchd, and systemd installers to launch Vigil in that headless service mode
- split the single-instance lock so the boot-time service and the logged-in desktop app can coexist
- skipped login-item autostart registration while running as the boot-time service

## Why
Boot-time service installs were pointing at the normal GUI entrypoint. That meant Vigil still tried to continue through the desktop startup path, and the service and GUI also contended for the same single-instance lock. In practice, that prevented the intended "start before login" behavior from working reliably.

## Impact
Service installs now start the monitor in a headless process before login, while still allowing the normal desktop app to launch later in the user session.

## Validation
- reviewed the service install command/plist/unit generation for Windows, macOS, and Linux
- reviewed the runtime flow in `main.rs` to confirm service mode starts the monitor and does not enter the tray/UI path
- source-level sanity pass on the refactor

## Notes
Rust tooling was not available in this container, so I could not run `cargo fmt` or `cargo check` here.