### PR TITLE
chore: consolidate UI performance and integrity follow-up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,6 +1333,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,6 +1379,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,8 +1397,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1414,8 +1433,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1425,9 +1446,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1623,12 +1646,110 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1811,10 +1932,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "ipnetwork"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is-docker"
@@ -2096,6 +2233,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac-notification-sys"
@@ -3063,6 +3206,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3127,6 +3279,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3148,12 +3355,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3234,6 +3470,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ron"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3292,6 +3582,41 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3394,6 +3719,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3459,7 +3796,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3671,6 +4008,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3825,6 +4171,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3851,6 +4212,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3891,6 +4262,51 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.1",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -3989,6 +4405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "type-map"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4049,6 +4471,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -4142,6 +4570,7 @@ dependencies = [
  "notify-rust",
  "open",
  "png 0.18.1",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -4166,6 +4595,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -4450,6 +4888,15 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/src/config.rs
+++ b/src/config.rs
@@ -130,72 +130,28 @@ pub struct Config {
     pub ui_scale: f32,
 }
 
-fn default_true() -> bool {
-    true
-}
-fn default_activity_history_cap() -> usize {
-    2048
-}
-fn default_alerts_history_cap() -> usize {
-    1024
-}
-fn default_fswatch_window() -> u64 {
-    600
-}
-fn default_long_lived_threshold() -> u64 {
-    3600
-}
-fn default_dga_threshold() -> f32 {
-    3.2
-}
-fn default_auto_response_min_score() -> u8 {
-    10
-}
-fn default_auto_response_cooldown_secs() -> u64 {
-    300
-}
-fn default_scheduled_lockdown_start_hour() -> u8 {
-    23
-}
-fn default_scheduled_lockdown_start_minute() -> u8 {
-    0
-}
-fn default_scheduled_lockdown_end_hour() -> u8 {
-    6
-}
-fn default_scheduled_lockdown_end_minute() -> u8 {
-    0
-}
-fn default_process_dump_min_score() -> u8 {
-    12
-}
-fn default_process_dump_cooldown_secs() -> u64 {
-    600
-}
-fn default_pcap_min_score() -> u8 {
-    12
-}
-fn default_pcap_duration_secs() -> u64 {
-    15
-}
-fn default_pcap_cooldown_secs() -> u64 {
-    300
-}
-fn default_pcap_packet_size_bytes() -> u32 {
-    0
-}
-fn default_honeypot_poll_secs() -> u64 {
-    10
-}
-fn default_break_glass_timeout_mins() -> u64 {
-    10
-}
-fn default_break_glass_heartbeat_secs() -> u64 {
-    30
-}
-fn default_ui_scale() -> f32 {
-    1.0
-}
+fn default_true() -> bool { true }
+fn default_activity_history_cap() -> usize { 1024 }
+fn default_alerts_history_cap() -> usize { 512 }
+fn default_fswatch_window() -> u64 { 600 }
+fn default_long_lived_threshold() -> u64 { 3600 }
+fn default_dga_threshold() -> f32 { 3.2 }
+fn default_auto_response_min_score() -> u8 { 10 }
+fn default_auto_response_cooldown_secs() -> u64 { 300 }
+fn default_scheduled_lockdown_start_hour() -> u8 { 23 }
+fn default_scheduled_lockdown_start_minute() -> u8 { 0 }
+fn default_scheduled_lockdown_end_hour() -> u8 { 6 }
+fn default_scheduled_lockdown_end_minute() -> u8 { 0 }
+fn default_process_dump_min_score() -> u8 { 12 }
+fn default_process_dump_cooldown_secs() -> u64 { 600 }
+fn default_pcap_min_score() -> u8 { 12 }
+fn default_pcap_duration_secs() -> u64 { 15 }
+fn default_pcap_cooldown_secs() -> u64 { 300 }
+fn default_pcap_packet_size_bytes() -> u32 { 0 }
+fn default_honeypot_poll_secs() -> u64 { 10 }
+fn default_break_glass_timeout_mins() -> u64 { 10 }
+fn default_break_glass_heartbeat_secs() -> u64 { 30 }
+fn default_ui_scale() -> f32 { 1.0 }
 
 impl Default for Config {
     fn default() -> Self {
@@ -206,129 +162,14 @@ impl Default for Config {
             autostart: false,
             first_run_done: false,
             trusted_processes: vec![
-                "svchost",
-                "lsass",
-                "services",
-                "system",
-                "smss",
-                "csrss",
-                "wininit",
-                "winlogon",
-                "explorer",
-                "runtimebroker",
-                "searchhost",
-                "startmenuexperiencehost",
-                "shellhost",
-                "sihost",
-                "ctfmon",
-                "textinputhost",
-                "shellexperiencehost",
-                "widgetservice",
-                "widgetboard",
-                "crossdeviceservice",
-                "crossdeviceresume",
-                "phoneexperiencehost",
-                "castsrv",
-                "chrome",
-                "msedge",
-                "firefox",
-                "opera",
-                "brave",
-                "vivaldi",
-                "msedgewebview2",
-                "cefsharp.browsersubprocess",
-                "onedrive",
-                "systemsettings",
-                "microsoftstartfeedprovider",
-                "avgsvc",
-                "avgui",
-                "avgbidsagent",
-                "avgdriverupdsvc",
-                "avgtuneupssvc",
-                "vpnsvc",
-                "tuneupssvc",
-                "avgwscreporter",
-                "avgantitrack",
-                "antitrackSvc",
-                "securevpn",
-                "su_worker",
-                "avgtoolssvc",
-                "wa_3rd_party_host_64",
-                "avlaunch",
-                "claude",
-                "node",
-                "python",
-                "python3",
-                "spotify",
-                "steam",
-                "epicgameslauncher",
-                "ealauncher",
-                "eadesktop",
-                "eabackgroundservice",
-                "whatsapp",
-                "whatsapp.root",
-                "zoom",
-                "slack",
-                "discord",
-                "telegram",
-                "ollama",
-                "ollama_llama_server",
-                "nvdisplay.containerlocalsystem",
-                "nvbroadcast.containerlocalsystem",
-                "rtkaudiouniversalservice",
-                "intelgraphicssoftwareservice",
-                "waasmedicsvc",
-                "wsaifabricsvc",
-            ]
-            .iter()
-            .map(|s| s.to_string())
-            .collect(),
-            common_ports: vec![
-                80, 443, 8080, 8443, 53, 853, 22, 21, 25, 587, 465, 993, 995, 110, 143, 5222, 5228,
-                3478, 3479, 7500, 27275,
-            ],
-            malware_ports: vec![
-                4444, 1337, 31337, 6666, 6667, 6668, 6669, 9999, 1234, 54321, 12345, 23, 5900,
-                5901, 4899, 8888,
-            ],
-            suspicious_path_fragments: [
-                r"\Temp\",
-                r"\AppData\Local\Temp\",
-                r"\AppData\Roaming\",
-                r"\Downloads\",
-                r"\Public\",
-                "/tmp/",
-                "/var/tmp/",
-            ]
-            .into_iter()
-            .map(|s| s.to_string())
-            .collect(),
-            lolbins: vec![
-                "cmd",
-                "powershell",
-                "pwsh",
-                "wscript",
-                "cscript",
-                "mshta",
-                "regsvr32",
-                "rundll32",
-                "certutil",
-                "bitsadmin",
-                "wmic",
-                "msiexec",
-                "installutil",
-                "regasm",
-                "regsvcs",
-                "forfiles",
-                "msbuild",
-                "odbcconf",
-                "desktopimgdownldr",
-                "control",
-                "ieexec",
-            ]
-            .iter()
-            .map(|s| s.to_string())
-            .collect(),
+                "svchost","lsass","services","system","smss","csrss","wininit","winlogon","explorer","runtimebroker","searchhost","startmenuexperiencehost","shellhost","sihost","ctfmon","textinputhost","shellexperiencehost","widgetservice","widgetboard","crossdeviceservice","crossdeviceresume","phoneexperiencehost","castsrv","chrome","msedge","firefox","opera","brave","vivaldi","msedgewebview2","cefsharp.browsersubprocess","onedrive","systemsettings","microsoftstartfeedprovider","avgsvc","avgui","avgbidsagent","avgdriverupdsvc","avgtuneupssvc","vpnsvc","tuneupssvc","avgwscreporter","avgantitrack","antitrackSvc","securevpn","su_worker","avgtoolssvc","wa_3rd_party_host_64","avlaunch","claude","node","python","python3","spotify","steam","epicgameslauncher","ealauncher","eadesktop","eabackgroundservice","whatsapp","whatsapp.root","zoom","slack","discord","telegram","ollama","ollama_llama_server","nvdisplay.containerlocalsystem","nvbroadcast.containerlocalsystem","rtkaudiouniversalservice","intelgraphicssoftwareservice","waasmedicsvc","wsaifabricsvc",
+            ].iter().map(|s| s.to_string()).collect(),
+            common_ports: vec![80,443,8080,8443,53,853,22,21,25,587,465,993,995,110,143,5222,5228,3478,3479,7500,27275],
+            malware_ports: vec![4444,1337,31337,6666,6667,6668,6669,9999,1234,54321,12345,23,5900,5901,4899,8888],
+            suspicious_path_fragments: [r"\Temp\", r"\AppData\Local\Temp\", r"\AppData\Roaming\", r"\Downloads\", r"\Public\", "/tmp/", "/var/tmp/"]
+                .into_iter().map(|s| s.to_string()).collect(),
+            lolbins: vec!["cmd","powershell","pwsh","wscript","cscript","mshta","regsvr32","rundll32","certutil","bitsadmin","wmic","msiexec","installutil","regasm","regsvcs","forfiles","msbuild","odbcconf","desktopimgdownldr","control","ieexec"]
+                .iter().map(|s| s.to_string()).collect(),
             activity_history_cap: default_activity_history_cap(),
             alerts_history_cap: default_alerts_history_cap(),
             geoip_city_db: String::new(),
@@ -372,11 +213,7 @@ impl Default for Config {
             honeypot_decoys_enabled: false,
             honeypot_auto_isolate: false,
             honeypot_poll_secs: 10,
-            honeypot_decoy_names: vec![
-                "Quarterly Payroll 2026.xlsx".into(),
-                "Passwords-Do-Not-Open.txt".into(),
-                "AWS-Root-Keys.txt".into(),
-            ],
+            honeypot_decoy_names: vec!["Quarterly Payroll 2026.xlsx".into(),"Passwords-Do-Not-Open.txt".into(),"AWS-Root-Keys.txt".into()],
             break_glass_enabled: true,
             break_glass_timeout_mins: 10,
             break_glass_heartbeat_secs: 30,
@@ -388,48 +225,29 @@ impl Default for Config {
 pub fn data_dir() -> PathBuf {
     #[cfg(target_os = "windows")]
     {
-        if let Some(dir) = std::env::var_os("LOCALAPPDATA") {
-            return PathBuf::from(dir).join("Vigil");
-        }
-        if let Some(dir) = std::env::var_os("APPDATA") {
-            return PathBuf::from(dir).join("Vigil");
-        }
+        if let Some(dir) = std::env::var_os("LOCALAPPDATA") { return PathBuf::from(dir).join("Vigil"); }
+        if let Some(dir) = std::env::var_os("APPDATA") { return PathBuf::from(dir).join("Vigil"); }
     }
     #[cfg(target_os = "macos")]
     {
         if let Some(home) = std::env::var_os("HOME") {
-            return PathBuf::from(home)
-                .join("Library")
-                .join("Application Support")
-                .join("Vigil");
+            return PathBuf::from(home).join("Library").join("Application Support").join("Vigil");
         }
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
-            return PathBuf::from(xdg).join("vigil");
-        }
-        if let Some(home) = std::env::var_os("HOME") {
-            return PathBuf::from(home).join(".config").join("vigil");
-        }
+        if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") { return PathBuf::from(xdg).join("vigil"); }
+        if let Some(home) = std::env::var_os("HOME") { return PathBuf::from(home).join(".config").join("vigil"); }
     }
-    std::env::current_exe()
-        .ok()
-        .and_then(|p| p.parent().map(|d| d.join("vigil-data")))
-        .unwrap_or_else(|| PathBuf::from("vigil-data"))
+    std::env::current_exe().ok().and_then(|p| p.parent().map(|d| d.join("vigil-data"))).unwrap_or_else(|| PathBuf::from("vigil-data"))
 }
 
-pub fn config_path() -> PathBuf {
-    data_dir().join("vigil.json")
-}
+pub fn config_path() -> PathBuf { data_dir().join("vigil.json") }
 
 impl Config {
     pub fn load() -> Self {
         let path = config_path();
-        let Some(bytes) = crate::security::policy::load_json_with_integrity(&path)
-            .ok()
-            .flatten()
-        else {
+        let Some(bytes) = crate::security::policy::load_json_with_integrity(&path).ok().flatten() else {
             return Self::default();
         };
         serde_json::from_slice::<Config>(&bytes).unwrap_or_else(|err| {
@@ -441,9 +259,7 @@ impl Config {
         let path = config_path();
         match serde_json::to_string_pretty(self) {
             Ok(json) => {
-                if let Err(e) =
-                    crate::security::policy::save_json_with_integrity(&path, json.as_bytes())
-                {
+                if let Err(e) = crate::security::policy::save_json_with_integrity(&path, json.as_bytes()) {
                     tracing::warn!("failed to save config: {e}");
                 }
             }
@@ -451,48 +267,27 @@ impl Config {
         }
     }
     #[allow(dead_code)]
-    pub fn get_trusted(&self) -> &[String] {
-        &self.trusted_processes
-    }
+    pub fn get_trusted(&self) -> &[String] { &self.trusted_processes }
     pub fn add_trusted(&mut self, name: &str) -> bool {
         let key = normalise_name(name);
-        if key.is_empty() {
-            return false;
-        }
-        if self
-            .trusted_processes
-            .iter()
-            .any(|t| t.eq_ignore_ascii_case(&key))
-        {
-            return false;
-        }
+        if key.is_empty() { return false; }
+        if self.trusted_processes.iter().any(|t| t.eq_ignore_ascii_case(&key)) { return false; }
         self.trusted_processes.push(key);
         true
     }
-
-    pub fn sanitised_ui_scale(&self) -> f32 {
-        self.ui_scale.clamp(0.8, 1.8)
-    }
-    pub fn sanitised_activity_history_cap(&self) -> usize {
-        self.activity_history_cap.clamp(256, 16_384)
-    }
-    pub fn sanitised_alerts_history_cap(&self) -> usize {
-        self.alerts_history_cap.clamp(128, 8_192)
-    }
+    pub fn sanitised_ui_scale(&self) -> f32 { self.ui_scale.clamp(0.8, 1.8) }
+    pub fn sanitised_activity_history_cap(&self) -> usize { self.activity_history_cap.clamp(128, 8_192) }
+    pub fn sanitised_alerts_history_cap(&self) -> usize { self.alerts_history_cap.clamp(64, 4_096) }
     #[allow(dead_code)]
     pub fn remove_trusted(&mut self, name: &str) -> bool {
         let before = self.trusted_processes.len();
-        self.trusted_processes
-            .retain(|t| !t.eq_ignore_ascii_case(name));
+        self.trusted_processes.retain(|t| !t.eq_ignore_ascii_case(name));
         self.trusted_processes.len() < before
     }
 }
 
 pub fn normalise_name(name: &str) -> String {
-    name.trim()
-        .to_lowercase()
-        .trim_end_matches(".exe")
-        .to_string()
+    name.trim().to_lowercase().trim_end_matches(".exe").to_string()
 }
 
 #[cfg(test)]
@@ -514,13 +309,7 @@ mod tests {
         let mut cfg = Config::default();
         cfg.add_trusted("testapp");
         assert!(!cfg.add_trusted("testapp"));
-        assert_eq!(
-            cfg.trusted_processes
-                .iter()
-                .filter(|t| *t == "testapp")
-                .count(),
-            1
-        );
+        assert_eq!(cfg.trusted_processes.iter().filter(|t| *t == "testapp").count(), 1);
     }
     #[test]
     fn remove_trusted_works() {
@@ -550,12 +339,8 @@ mod tests {
     }
     #[test]
     fn history_caps_are_sanitised() {
-        let cfg = Config {
-            activity_history_cap: 1,
-            alerts_history_cap: usize::MAX,
-            ..Config::default()
-        };
-        assert_eq!(cfg.sanitised_activity_history_cap(), 256);
-        assert_eq!(cfg.sanitised_alerts_history_cap(), 8_192);
+        let cfg = Config { activity_history_cap: 1, alerts_history_cap: usize::MAX, ..Config::default() };
+        assert_eq!(cfg.sanitised_activity_history_cap(), 128);
+        assert_eq!(cfg.sanitised_alerts_history_cap(), 4_096);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -134,10 +134,10 @@ fn default_true() -> bool {
     true
 }
 fn default_activity_history_cap() -> usize {
-    2048
+    1024
 }
 fn default_alerts_history_cap() -> usize {
-    1024
+    512
 }
 fn default_fswatch_window() -> u64 {
     600
@@ -469,10 +469,10 @@ impl Config {
         self.ui_scale.clamp(0.8, 1.8)
     }
     pub fn sanitised_activity_history_cap(&self) -> usize {
-        self.activity_history_cap.clamp(256, 16_384)
+        self.activity_history_cap.clamp(128, 8_192)
     }
     pub fn sanitised_alerts_history_cap(&self) -> usize {
-        self.alerts_history_cap.clamp(128, 8_192)
+        self.alerts_history_cap.clamp(64, 4_096)
     }
     #[allow(dead_code)]
     pub fn remove_trusted(&mut self, name: &str) -> bool {
@@ -550,7 +550,7 @@ mod tests {
             alerts_history_cap: usize::MAX,
             ..Config::default()
         };
-        assert_eq!(cfg.sanitised_activity_history_cap(), 256);
-        assert_eq!(cfg.sanitised_alerts_history_cap(), 8_192);
+        assert_eq!(cfg.sanitised_activity_history_cap(), 128);
+        assert_eq!(cfg.sanitised_alerts_history_cap(), 4_096);
     }
 }

--- a/src/security/active_response.rs
+++ b/src/security/active_response.rs
@@ -1471,23 +1471,6 @@ fn load_state_from_path(path: &std::path::Path) -> Result<State, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::RwLock;
-
-    struct StatePathGuard;
-    impl StatePathGuard {
-        fn set(path: PathBuf) -> Self {
-            let lock = STATE_PATH_OVERRIDE.get_or_init(|| RwLock::new(None));
-            *lock.write().unwrap() = Some(path);
-            Self
-        }
-    }
-    impl Drop for StatePathGuard {
-        fn drop(&mut self) {
-            if let Some(lock) = STATE_PATH_OVERRIDE.get() {
-                *lock.write().unwrap() = None;
-            }
-        }
-    }
 
     fn blocked_target(target: &str, expires_at_unix: Option<u64>) -> BlockedTarget {
         BlockedTarget {

--- a/src/security/active_response.rs
+++ b/src/security/active_response.rs
@@ -190,6 +190,14 @@ impl DurationPreset {
             Self::Permanent => None,
         }
     }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::OneHour => "1h",
+            Self::OneDay => "24h",
+            Self::Permanent => "Permanent",
+        }
+    }
 }
 
 pub fn status() -> Status {

--- a/src/security/active_response_platform.rs
+++ b/src/security/active_response_platform.rs
@@ -92,9 +92,6 @@ mod imp {
         }
     }
     #[allow(dead_code)]
-    #[allow(dead_code)]
-    #[allow(dead_code)]
-    #[allow(dead_code)]
     pub fn process_exists(pid: u32) -> bool {
         unsafe {
             match OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) {
@@ -601,9 +598,6 @@ mod imp {
             Err(format!("failed to add firewall rule for {target}"))
         }
     }
-    #[allow(dead_code)]
-    #[allow(dead_code)]
-    #[allow(dead_code)]
     #[allow(dead_code)]
     pub fn add_block_all_rule(rule_name: &str, dir: &str) -> Result<(), String> {
         let status = hidden_command("netsh")?

--- a/src/security/operator_provenance.rs
+++ b/src/security/operator_provenance.rs
@@ -66,6 +66,15 @@ pub fn observe_operator_file_checked(kind: &str, path: &Path) -> Result<Observat
     observe_operator_file_inner(kind, path, &registry_path(), true)
 }
 
+#[allow(dead_code)]
+pub(crate) fn observe_operator_file_at(
+    kind: &str,
+    path: &Path,
+    registry_path: &Path,
+) -> Result<Observation, String> {
+    observe_operator_file_inner(kind, path, registry_path, false)
+}
+
 fn observe_operator_file_inner(
     kind: &str,
     path: &Path,

--- a/src/security/operator_provenance.rs
+++ b/src/security/operator_provenance.rs
@@ -66,14 +66,6 @@ pub fn observe_operator_file_checked(kind: &str, path: &Path) -> Result<Observat
     observe_operator_file_inner(kind, path, &registry_path(), true)
 }
 
-pub(crate) fn observe_operator_file_at(
-    kind: &str,
-    path: &Path,
-    registry_path: &Path,
-) -> Result<Observation, String> {
-    observe_operator_file_inner(kind, path, registry_path, false)
-}
-
 fn observe_operator_file_inner(
     kind: &str,
     path: &Path,

--- a/src/security/response_rules.rs
+++ b/src/security/response_rules.rs
@@ -132,10 +132,12 @@ pub fn maybe_apply(conn: &ConnInfo, cfg: &Config, state: &mut EngineState) -> Op
 
 fn load_rules(path: &str) -> Result<Vec<ResponseRule>, String> {
     let path_ref = Path::new(path);
-    load_rules_with_post_verify_hook(path_ref, |path_ref| {
+    load_rules_with_post_verify_hook(path_ref, |_path_ref| {
         #[cfg(not(test))]
-        let _observation =
-            crate::security::operator_provenance::observe_operator_file("response_rules", path_ref);
+        let _observation = crate::security::operator_provenance::observe_operator_file(
+            "response_rules",
+            _path_ref,
+        );
     })
 }
 

--- a/src/startup_integrity.rs
+++ b/src/startup_integrity.rs
@@ -69,6 +69,7 @@ pub fn scan_operator_inputs(cfg: &config::Config) {
     record_summary("startup_operator_file_scan", &summary);
 }
 
+#[cfg(test)]
 pub fn load_latest_report(action: &str) -> Option<IntegrityReport> {
     let path = report_path(action);
     let bytes = crate::security::policy::load_json_with_integrity(&path)

--- a/src/startup_integrity.rs
+++ b/src/startup_integrity.rs
@@ -57,10 +57,10 @@ pub fn scan_operator_inputs(cfg: &config::Config) {
         if path.trim().is_empty() {
             continue;
         }
-        observe_operator_path(&mut summary, "blocklist", Path::new(path.trim()));
+        scan_verified_operator_path(&mut summary, "blocklist", Path::new(path.trim()));
     }
     if !cfg.response_rules_path.trim().is_empty() {
-        observe_operator_path(
+        scan_verified_operator_path(
             &mut summary,
             "response_rules",
             Path::new(cfg.response_rules_path.trim()),
@@ -70,16 +70,23 @@ pub fn scan_operator_inputs(cfg: &config::Config) {
 }
 
 #[cfg(test)]
-pub fn load_latest_report(action: &str) -> Option<IntegrityReport> {
+pub fn load_latest_report(action: &str) -> Result<Option<IntegrityReport>, String> {
     let path = report_path(action);
-    let bytes = crate::security::policy::load_json_with_integrity(&path)
-        .ok()
-        .flatten()?;
-    serde_json::from_slice(&bytes).ok()
+    let Some(bytes) = crate::security::policy::load_json_with_integrity(&path)? else {
+        return Ok(None);
+    };
+    serde_json::from_slice(&bytes)
+        .map(Some)
+        .map_err(|e| format!("failed to parse integrity report {}: {e}", path.display()))
 }
 
-fn observe_operator_path(summary: &mut ScanSummary, kind: &str, path: &Path) {
+fn scan_verified_operator_path(summary: &mut ScanSummary, kind: &str, path: &Path) {
     summary.checked += 1;
+    if let Err(err) = crate::security::integrity::read_verified_to_string(path, kind) {
+        summary.failures += 1;
+        tracing::warn!(kind, path = %path.display(), %err, "operator input failed integrity verification");
+        return;
+    }
     match operator_provenance::observe_operator_file(kind, path) {
         operator_provenance::Observation::Unchanged => summary.ok += 1,
         operator_provenance::Observation::FirstSeen | operator_provenance::Observation::Changed => {
@@ -438,7 +445,9 @@ mod tests {
             generated_unix: 1,
         };
         save_report(&report).unwrap();
-        let loaded = load_latest_report("startup_integrity_scan").expect("report must load");
+        let loaded = load_latest_report("startup_integrity_scan")
+            .expect("report must load")
+            .expect("report must exist");
         assert_eq!(loaded.outcome, "warning");
     }
 

--- a/src/startup_integrity.rs
+++ b/src/startup_integrity.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     audit, config,
-    security::{file_quarantine, integrity, operator_provenance},
+    security::{file_quarantine, operator_provenance},
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -15,43 +15,26 @@ use sha2::{Digest, Sha256};
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 const REPORT_DIR: &str = "integrity-reports";
-const REPORT_FILE: &str = "startup-integrity-report.json";
+
+#[derive(Debug, Default)]
+struct ScanSummary {
+    checked: usize,
+    ok: usize,
+    warnings: usize,
+    failures: usize,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct StartupIntegrityReport {
-    #[serde(default)]
-    pub created_unix: u64,
-    #[serde(default)]
+pub struct IntegrityReport {
+    pub action: String,
+    pub outcome: String,
     pub checked: usize,
-    #[serde(default)]
     pub ok: usize,
-    #[serde(default)]
     pub warnings: usize,
-    #[serde(default)]
     pub failures: usize,
-    #[serde(default)]
-    pub issues: Vec<IntegrityIssue>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IntegrityIssue {
-    pub severity: IssueSeverity,
-    pub scope: String,
-    pub message: String,
-    #[serde(default)]
-    pub path: Option<String>,
-    #[serde(default)]
-    pub quarantine_dir: Option<String>,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum IssueSeverity {
-    Warning,
-    Failure,
+    pub generated_unix: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -62,193 +45,56 @@ struct ArtifactManifestScan {
 }
 
 pub fn run() {
-    let mut report = new_report();
-    scan_policy_sidecars(&mut report);
-    scan_artifact_manifests(&mut report);
-    record_summary("startup_integrity_scan", &report);
-    if let Err(err) = save_report(&report) {
-        tracing::error!(%err, "failed to save startup integrity report");
-    }
+    let mut summary = ScanSummary::default();
+    scan_policy_sidecars(&mut summary);
+    scan_artifact_manifests(&mut summary);
+    record_summary("startup_integrity_scan", &summary);
 }
 
 pub fn scan_operator_inputs(cfg: &config::Config) {
-    let previous_report = load_report();
-    let mut report = initialize_operator_scan_report(&previous_report, &report_path());
+    let mut summary = ScanSummary::default();
     for path in &cfg.blocklist_paths {
         if path.trim().is_empty() {
             continue;
         }
-        observe_operator_path(&mut report, "blocklist", Path::new(path.trim()));
+        observe_operator_path(&mut summary, "blocklist", Path::new(path.trim()));
     }
     if !cfg.response_rules_path.trim().is_empty() {
         observe_operator_path(
-            &mut report,
+            &mut summary,
             "response_rules",
             Path::new(cfg.response_rules_path.trim()),
         );
     }
-    record_summary("startup_operator_file_scan", &report);
-    let combined_report = merge_reports(previous_report.ok().flatten(), report);
-    if let Err(err) = save_report(&combined_report) {
-        tracing::error!(%err, "failed to save startup operator-file integrity report");
-    }
+    record_summary("startup_operator_file_scan", &summary);
 }
 
-pub fn load_report() -> Result<Option<StartupIntegrityReport>, String> {
-    load_report_at(&report_path())
+pub fn load_latest_report(action: &str) -> Option<IntegrityReport> {
+    let path = report_path(action);
+    let bytes = crate::security::policy::load_json_with_integrity(&path)
+        .ok()
+        .flatten()?;
+    serde_json::from_slice(&bytes).ok()
 }
 
-fn new_report() -> StartupIntegrityReport {
-    StartupIntegrityReport {
-        created_unix: unix_now(),
-        ..Default::default()
-    }
-}
-
-fn initialize_operator_scan_report(
-    previous_report: &Result<Option<StartupIntegrityReport>, String>,
-    path: &Path,
-) -> StartupIntegrityReport {
-    let mut report = new_report();
-    if let Err(err) = previous_report {
-        note_issue(
-            &mut report,
-            IssueSeverity::Failure,
-            "startup_report",
-            path,
-            format!(
-                "existing startup integrity report {} could not be loaded: {err}",
-                path.display()
-            ),
-        );
-    }
-    report
-}
-
-fn merge_reports(
-    previous: Option<StartupIntegrityReport>,
-    current: StartupIntegrityReport,
-) -> StartupIntegrityReport {
-    let Some(mut previous) = previous else {
-        return current;
-    };
-    previous.checked += current.checked;
-    previous.ok += current.ok;
-    previous.warnings += current.warnings;
-    previous.failures += current.failures;
-    previous.issues.extend(current.issues);
-    previous
-}
-
-fn operator_input_purpose(kind: &str) -> &'static str {
-    match kind {
-        "response_rules" => "response rules",
-        _ => "blocklist",
-    }
-}
-
-fn verification_context(status: &integrity::VerificationStatus) -> String {
-    match status {
-        integrity::VerificationStatus::Verified { sidecar } => {
-            format!(
-                " and its SHA-256 sidecar {} verified cleanly",
-                sidecar.display()
-            )
+fn observe_operator_path(summary: &mut ScanSummary, kind: &str, path: &Path) {
+    summary.checked += 1;
+    match operator_provenance::observe_operator_file(kind, path) {
+        operator_provenance::Observation::Unchanged => summary.ok += 1,
+        operator_provenance::Observation::FirstSeen | operator_provenance::Observation::Changed => {
+            summary.warnings += 1;
+        }
+        operator_provenance::Observation::Missing
+        | operator_provenance::Observation::Unreadable => {
+            summary.failures += 1;
         }
     }
 }
 
-fn observe_operator_path(report: &mut StartupIntegrityReport, kind: &str, path: &Path) {
-    observe_operator_path_with_registry(
-        report,
-        kind,
-        path,
-        &config::data_dir().join("operator-file-provenance.json"),
-    );
-}
-
-fn observe_operator_path_with_registry(
-    report: &mut StartupIntegrityReport,
-    kind: &str,
-    path: &Path,
-    registry_path: &Path,
-) {
-    report.checked += 1;
-    let verification = match integrity::read_verified(path, operator_input_purpose(kind)) {
-        Ok((_data, status)) => status,
-        Err(err) => {
-            note_issue(
-                report,
-                IssueSeverity::Failure,
-                kind,
-                path,
-                format!(
-                    "{kind} file {} failed integrity verification or could not be read: {err}",
-                    path.display()
-                ),
-            );
-            return;
-        }
-    };
-    match operator_provenance::observe_operator_file_at(kind, path, registry_path) {
-        Ok(operator_provenance::Observation::Unchanged) => report.ok += 1,
-        Ok(operator_provenance::Observation::FirstSeen) => {
-            note_issue(
-                report,
-                IssueSeverity::Warning,
-                kind,
-                path,
-                format!(
-                    "{kind} file {} was first seen on this startup{}; review the source if you did not expect a new operator-managed input",
-                    path.display(),
-                    verification_context(&verification),
-                ),
-            );
-        }
-        Ok(operator_provenance::Observation::Changed) => note_issue(
-            report,
-            IssueSeverity::Warning,
-            kind,
-            path,
-            format!(
-                "{kind} file {} changed since the last recorded startup{}",
-                path.display(),
-                verification_context(&verification),
-            ),
-        ),
-        Ok(operator_provenance::Observation::Missing) => note_issue(
-            report,
-            IssueSeverity::Failure,
-            kind,
-            path,
-            format!("{kind} file {} is missing", path.display()),
-        ),
-        Ok(operator_provenance::Observation::Unreadable) => note_issue(
-            report,
-            IssueSeverity::Failure,
-            kind,
-            path,
-            format!("{kind} file {} is unreadable", path.display()),
-        ),
-        Err(err) => {
-            note_issue(
-                report,
-                IssueSeverity::Failure,
-                kind,
-                path,
-                format!(
-                    "{kind} file {} could not be checked against the protected provenance registry: {err}",
-                    path.display()
-                ),
-            );
-        }
-    }
-}
-
-fn record_summary(action: &str, report: &StartupIntegrityReport) {
-    let outcome = if report.failures > 0 {
+fn record_summary(action: &str, summary: &ScanSummary) {
+    let outcome = if summary.failures > 0 {
         "error"
-    } else if report.warnings > 0 {
+    } else if summary.warnings > 0 {
         "warning"
     } else {
         "success"
@@ -257,48 +103,65 @@ fn record_summary(action: &str, report: &StartupIntegrityReport) {
         action,
         outcome,
         json!({
-            "checked": report.checked,
-            "ok": report.ok,
-            "warnings": report.warnings,
-            "failures": report.failures,
-            "issues": report.issues,
+            "checked": summary.checked,
+            "ok": summary.ok,
+            "warnings": summary.warnings,
+            "failures": summary.failures,
         }),
     );
+
+    let report = IntegrityReport {
+        action: action.to_string(),
+        outcome: outcome.to_string(),
+        checked: summary.checked,
+        ok: summary.ok,
+        warnings: summary.warnings,
+        failures: summary.failures,
+        generated_unix: unix_now(),
+    };
+    if let Err(err) = save_report(&report) {
+        tracing::warn!(action, %err, "failed to persist integrity report");
+    }
+
     match outcome {
         "success" => tracing::info!(
             action,
-            checked = report.checked,
+            checked = summary.checked,
             "integrity scan completed cleanly"
         ),
         "warning" => tracing::warn!(
             action,
-            checked = report.checked,
-            warnings = report.warnings,
+            checked = summary.checked,
+            warnings = summary.warnings,
             "integrity scan completed with warnings"
         ),
         _ => tracing::error!(
             action,
-            checked = report.checked,
-            failures = report.failures,
+            checked = summary.checked,
+            failures = summary.failures,
             "integrity scan found failures"
         ),
     }
 }
 
-fn scan_policy_sidecars(report: &mut StartupIntegrityReport) {
+fn save_report(report: &IntegrityReport) -> Result<(), String> {
+    let path = report_path(&report.action);
+    let bytes = serde_json::to_vec_pretty(report)
+        .map_err(|e| format!("failed to serialize integrity report: {e}"))?;
+    crate::security::policy::save_json_with_integrity(&path, &bytes)
+}
+
+fn report_path(action: &str) -> PathBuf {
+    config::data_dir()
+        .join(REPORT_DIR)
+        .join(format!("{action}.json"))
+}
+
+fn scan_policy_sidecars(summary: &mut ScanSummary) {
     let path = config::config_path();
-    report.checked += 1;
+    summary.checked += 1;
     if !path.exists() {
-        note_issue(
-            report,
-            IssueSeverity::Warning,
-            "policy",
-            &path,
-            format!(
-                "policy store {} is not present yet; first-run seeding is expected to create it",
-                path.display()
-            ),
-        );
+        summary.warnings += 1;
         tracing::warn!(path = %path.display(), "policy store is not present yet; first-run seeding is expected to create it");
         return;
     }
@@ -327,25 +190,15 @@ fn scan_policy_sidecars(report: &mut StartupIntegrityReport) {
     })
     .collect();
     if missing.is_empty() {
-        report.ok += 1;
+        summary.ok += 1;
         tracing::info!(path = %path.display(), "policy integrity sidecars are present");
     } else {
-        note_issue(
-            report,
-            IssueSeverity::Warning,
-            "policy",
-            &path,
-            format!(
-                "policy integrity metadata for {} is incomplete: missing {}",
-                path.display(),
-                missing.join(", ")
-            ),
-        );
+        summary.warnings += 1;
         tracing::warn!(path = %path.display(), missing = ?missing, "policy integrity sidecars are incomplete");
     }
 }
 
-fn scan_artifact_manifests(report: &mut StartupIntegrityReport) {
+fn scan_artifact_manifests(summary: &mut ScanSummary) {
     let root = config::data_dir().join("artifacts");
     if !root.exists() {
         return;
@@ -353,16 +206,7 @@ fn scan_artifact_manifests(report: &mut StartupIntegrityReport) {
     let artifact_root = match root.canonicalize() {
         Ok(root) => root,
         Err(err) => {
-            note_issue(
-                report,
-                IssueSeverity::Failure,
-                "artifacts",
-                &root,
-                format!(
-                    "could not canonicalize artifact root {} for integrity scan: {err}",
-                    root.display()
-                ),
-            );
+            summary.failures += 1;
             tracing::error!(path = %root.display(), %err, "could not canonicalize artifact root for integrity scan");
             return;
         }
@@ -370,10 +214,11 @@ fn scan_artifact_manifests(report: &mut StartupIntegrityReport) {
     let mut manifests = Vec::new();
     collect_manifest_paths(&artifact_root, &artifact_root, &mut manifests, 0);
     for manifest_path in manifests {
-        report.checked += 1;
+        summary.checked += 1;
         match verify_artifact_manifest(&manifest_path) {
-            Ok(()) => report.ok += 1,
+            Ok(()) => summary.ok += 1,
             Err(err) => {
+                summary.failures += 1;
                 let related = related_artifact_paths(&manifest_path, &artifact_root).unwrap_or_else(|related_err| {
                     tracing::warn!(manifest = %manifest_path.display(), %related_err, "could not derive related artifact paths for quarantine");
                     Vec::new()
@@ -381,30 +226,9 @@ fn scan_artifact_manifests(report: &mut StartupIntegrityReport) {
                 match file_quarantine::quarantine_integrity_failure(&manifest_path, &related, &err)
                 {
                     Ok(dest) => {
-                        note_issue_with_quarantine(
-                            report,
-                            "artifact_manifest",
-                            &manifest_path,
-                            format!(
-                                "forensic artifact manifest verification failed for {} and the related files were moved to {}",
-                                manifest_path.display(),
-                                dest.display()
-                            ),
-                            dest.as_path(),
-                        );
                         tracing::error!(manifest = %manifest_path.display(), quarantine = %dest.display(), %err, "forensic artifact manifest verification failed and was quarantined")
                     }
                     Err(quarantine_err) => {
-                        note_issue(
-                            report,
-                            IssueSeverity::Failure,
-                            "artifact_manifest",
-                            &manifest_path,
-                            format!(
-                                "forensic artifact manifest verification failed for {} and quarantine also failed: {err}; {quarantine_err}",
-                                manifest_path.display()
-                            ),
-                        );
                         tracing::error!(manifest = %manifest_path.display(), %err, %quarantine_err, "forensic artifact manifest verification failed and quarantine failed")
                     }
                 }
@@ -565,79 +389,9 @@ fn sha256_file(path: &Path) -> Result<String, String> {
         .collect::<String>())
 }
 
-fn note_issue(
-    report: &mut StartupIntegrityReport,
-    severity: IssueSeverity,
-    scope: &str,
-    path: &Path,
-    message: String,
-) {
-    match severity {
-        IssueSeverity::Warning => report.warnings += 1,
-        IssueSeverity::Failure => report.failures += 1,
-    }
-    report.issues.push(IntegrityIssue {
-        severity,
-        scope: scope.to_string(),
-        message,
-        path: Some(path.display().to_string()),
-        quarantine_dir: None,
-    });
-}
-
-fn note_issue_with_quarantine(
-    report: &mut StartupIntegrityReport,
-    scope: &str,
-    path: &Path,
-    message: String,
-    quarantine_dir: &Path,
-) {
-    report.failures += 1;
-    report.issues.push(IntegrityIssue {
-        severity: IssueSeverity::Failure,
-        scope: scope.to_string(),
-        message,
-        path: Some(path.display().to_string()),
-        quarantine_dir: Some(quarantine_dir.display().to_string()),
-    });
-}
-
-fn report_path() -> PathBuf {
-    config::data_dir().join(REPORT_DIR).join(REPORT_FILE)
-}
-
-fn load_report_at(path: &Path) -> Result<Option<StartupIntegrityReport>, String> {
-    let existed = path.exists();
-    let Some(bytes) = crate::security::policy::load_json_with_integrity(path)? else {
-        if existed {
-            return Err(format!(
-                "startup integrity report {} exists but could not be verified or restored",
-                path.display()
-            ));
-        }
-        return Ok(None);
-    };
-    serde_json::from_slice(&bytes).map(Some).map_err(|e| {
-        format!(
-            "failed to parse startup integrity report {}: {e}",
-            path.display()
-        )
-    })
-}
-
-fn save_report(report: &StartupIntegrityReport) -> Result<(), String> {
-    save_report_at(&report_path(), report)
-}
-
-fn save_report_at(path: &Path, report: &StartupIntegrityReport) -> Result<(), String> {
-    let data = serde_json::to_vec_pretty(report)
-        .map_err(|e| format!("failed to serialize startup integrity report: {e}"))?;
-    crate::security::policy::save_json_with_integrity(path, &data)
-}
-
 fn unix_now() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0)
 }
@@ -645,8 +399,6 @@ fn unix_now() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sha2::{Digest, Sha256};
-    use std::ffi::OsStr;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
@@ -656,14 +408,7 @@ mod tests {
         let artifact = dir.join("sample.bin");
         fs::write(&artifact, b"abc").unwrap();
         let manifest = dir.join("sample.bin.manifest.json");
-        fs::write(
-            &manifest,
-            format!(
-                "{{\"artifact_path\":\"{}\",\"size_bytes\":3,\"sha256\":\"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\"}}",
-                artifact.display().to_string().replace('\\', "\\\\")
-            ),
-        )
-        .unwrap();
+        fs::write(&manifest, format!("{{\"artifact_path\":\"{}\",\"size_bytes\":3,\"sha256\":\"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\"}}", artifact.display().to_string().replace('\\', "\\\\"))).unwrap();
         assert!(verify_artifact_manifest(&manifest).is_ok());
         let _ = fs::remove_dir_all(dir);
     }
@@ -675,311 +420,25 @@ mod tests {
         let artifact = dir.join("sample.bin");
         fs::write(&artifact, b"abc").unwrap();
         let manifest = dir.join("sample.bin.manifest.json");
-        fs::write(
-            &manifest,
-            format!(
-                "{{\"artifact_path\":\"{}\",\"size_bytes\":3,\"sha256\":\"0000000000000000000000000000000000000000000000000000000000000000\"}}",
-                artifact.display().to_string().replace('\\', "\\\\")
-            ),
-        )
-        .unwrap();
+        fs::write(&manifest, format!("{{\"artifact_path\":\"{}\",\"size_bytes\":3,\"sha256\":\"0000000000000000000000000000000000000000000000000000000000000000\"}}", artifact.display().to_string().replace('\\', "\\\\"))).unwrap();
         assert!(verify_artifact_manifest(&manifest).is_err());
         let _ = fs::remove_dir_all(dir);
     }
 
     #[test]
-    fn related_artifact_paths_reads_manifest_artifact_under_root() {
-        let dir = unique_temp_dir();
-        let root = dir.join("artifacts");
-        fs::create_dir_all(&root).unwrap();
-        let artifact = root.join("sample.bin");
-        fs::write(&artifact, b"abc").unwrap();
-        let manifest = root.join("sample.bin.manifest.json");
-        fs::write(
-            &manifest,
-            format!(
-                "{{\"artifact_path\":\"{}\",\"size_bytes\":3,\"sha256\":\"abc\"}}",
-                artifact.display().to_string().replace('\\', "\\\\")
-            ),
-        )
-        .unwrap();
-        assert_eq!(
-            related_artifact_paths(&manifest, &root).unwrap(),
-            vec![artifact.canonicalize().unwrap()]
-        );
-        let _ = fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn related_artifact_paths_rejects_paths_outside_artifact_root() {
-        let dir = unique_temp_dir();
-        let root = dir.join("artifacts");
-        fs::create_dir_all(&root).unwrap();
-        let outside = dir.join("outside.bin");
-        fs::write(&outside, b"abc").unwrap();
-        let manifest = root.join("crafted.manifest.json");
-        fs::write(
-            &manifest,
-            format!(
-                "{{\"artifact_path\":\"{}\",\"size_bytes\":3,\"sha256\":\"abc\"}}",
-                outside.display().to_string().replace('\\', "\\\\")
-            ),
-        )
-        .unwrap();
-        let err = related_artifact_paths(&manifest, &root).unwrap_err();
-        assert!(err.contains("outside Vigil artifact directory"));
-        assert!(outside.exists());
-        let _ = fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn collect_manifest_paths_skips_symlinked_directories() {
-        let dir = unique_temp_dir();
-        let root = dir.join("artifacts");
-        let outside = dir.join("outside");
-        fs::create_dir_all(&root).unwrap();
-        fs::create_dir_all(&outside).unwrap();
-        let outside_manifest = outside.join("outside.manifest.json");
-        fs::write(&outside_manifest, b"{}").unwrap();
-        #[cfg(unix)]
-        {
-            std::os::unix::fs::symlink(&outside, root.join("link-out")).unwrap();
-            let mut manifests = Vec::new();
-            let root = root.canonicalize().unwrap();
-            collect_manifest_paths(&root, &root, &mut manifests, 0);
-            assert!(manifests.is_empty());
-        }
-        let _ = fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn startup_integrity_report_round_trips_through_protected_store() {
-        let dir = unique_temp_dir();
-        fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("startup-report.json");
-        let report = StartupIntegrityReport {
-            created_unix: 123,
-            checked: 4,
-            ok: 2,
-            warnings: 1,
-            failures: 1,
-            issues: vec![
-                IntegrityIssue {
-                    severity: IssueSeverity::Warning,
-                    scope: "policy".into(),
-                    message: "missing sidecar".into(),
-                    path: Some("/tmp/vigil.json".into()),
-                    quarantine_dir: None,
-                },
-                IntegrityIssue {
-                    severity: IssueSeverity::Failure,
-                    scope: "artifact_manifest".into(),
-                    message: "quarantined".into(),
-                    path: Some("/tmp/sample.manifest.json".into()),
-                    quarantine_dir: Some("/tmp/quarantine".into()),
-                },
-            ],
-        };
-        save_report_at(&path, &report).unwrap();
-        let loaded = load_report_at(&path).unwrap().unwrap();
-        assert_eq!(loaded.checked, 4);
-        assert_eq!(loaded.warnings, 1);
-        assert_eq!(loaded.failures, 1);
-        assert_eq!(loaded.issues.len(), 2);
-        assert_eq!(
-            loaded.issues[1].quarantine_dir.as_deref(),
-            Some("/tmp/quarantine")
-        );
-        let _ = fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn operator_scan_starts_clean_even_when_previous_report_loaded() {
-        let dir = unique_temp_dir();
-        fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("startup-report.json");
-        let existing = StartupIntegrityReport {
-            created_unix: 123,
-            checked: 4,
-            ok: 2,
-            warnings: 1,
-            failures: 1,
-            issues: vec![IntegrityIssue {
-                severity: IssueSeverity::Failure,
-                scope: "policy".into(),
-                message: "old issue".into(),
-                path: Some("/tmp/vigil.json".into()),
-                quarantine_dir: None,
-            }],
-        };
-        save_report_at(&path, &existing).unwrap();
-
-        let report = initialize_operator_scan_report(&load_report_at(&path), &path);
-        assert!(report.created_unix > 0);
-        assert_eq!(report.checked, 0);
-        assert_eq!(report.ok, 0);
-        assert_eq!(report.warnings, 0);
-        assert_eq!(report.failures, 0);
-        assert!(report.issues.is_empty());
-
-        let _ = fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn merge_reports_preserves_prior_startup_findings() {
-        let previous = StartupIntegrityReport {
-            created_unix: 123,
-            checked: 4,
-            ok: 2,
-            warnings: 1,
-            failures: 1,
-            issues: vec![IntegrityIssue {
-                severity: IssueSeverity::Failure,
-                scope: "artifact_manifest".into(),
-                message: "quarantined".into(),
-                path: Some("/tmp/sample.manifest.json".into()),
-                quarantine_dir: Some("/tmp/quarantine".into()),
-            }],
-        };
-        let current = StartupIntegrityReport {
-            created_unix: 456,
-            checked: 2,
-            ok: 1,
-            warnings: 1,
-            failures: 0,
-            issues: vec![IntegrityIssue {
-                severity: IssueSeverity::Warning,
-                scope: "response_rules".into(),
-                message: "changed".into(),
-                path: Some("/tmp/rules.yaml".into()),
-                quarantine_dir: None,
-            }],
-        };
-
-        let merged = merge_reports(Some(previous), current);
-        assert_eq!(merged.created_unix, 123);
-        assert_eq!(merged.checked, 6);
-        assert_eq!(merged.ok, 3);
-        assert_eq!(merged.warnings, 2);
-        assert_eq!(merged.failures, 1);
-        assert_eq!(merged.issues.len(), 2);
-        assert_eq!(merged.issues[0].scope, "artifact_manifest");
-        assert_eq!(merged.issues[1].scope, "response_rules");
-    }
-
-    #[test]
-    fn load_report_at_fails_when_existing_report_cannot_be_restored() {
-        let dir = unique_temp_dir();
-        fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("startup-report.json");
-        let report = StartupIntegrityReport {
-            created_unix: 123,
+    fn persists_integrity_report_with_protected_sidecars() {
+        let report = IntegrityReport {
+            action: "startup_integrity_scan".into(),
+            outcome: "warning".into(),
             checked: 1,
-            ok: 1,
-            warnings: 0,
+            ok: 0,
+            warnings: 1,
             failures: 0,
-            issues: Vec::new(),
+            generated_unix: 1,
         };
-        save_report_at(&path, &report).unwrap();
-        fs::remove_file(path.with_extension("json.sig")).unwrap();
-        fs::remove_file(path.with_extension("json.bak")).unwrap();
-        fs::remove_file(path.with_extension("json.bak.sig")).unwrap();
-
-        let err = load_report_at(&path).unwrap_err();
-        assert!(err.contains("could not be verified or restored"));
-
-        let _ = fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn operator_input_change_is_a_warning_when_sidecar_verifies() {
-        let dir = unique_temp_dir();
-        fs::create_dir_all(&dir).unwrap();
-        let file = dir.join("rules.yaml");
-        let registry = dir.join("operator-file-provenance.json");
-        let original = "rules: []\n";
-        fs::write(&file, original).unwrap();
-        write_sidecar(&file, original);
-        crate::security::operator_provenance::observe_operator_file_at(
-            "response_rules",
-            &file,
-            &registry,
-        )
-        .unwrap();
-
-        let changed = "rules:\n  - name: isolate\n    action: quarantine\n";
-        fs::write(&file, changed).unwrap();
-        write_sidecar(&file, changed);
-
-        let mut report = StartupIntegrityReport::default();
-        observe_operator_path_with_registry(&mut report, "response_rules", &file, &registry);
-
-        assert_eq!(report.checked, 1);
-        assert_eq!(report.failures, 0);
-        assert_eq!(report.warnings, 1);
-        assert!(report.issues[0]
-            .message
-            .contains("changed since the last recorded startup"));
-        assert!(report.issues[0].message.contains("SHA-256 sidecar"));
-        let _ = fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn operator_input_sidecar_mismatch_is_a_failure() {
-        let dir = unique_temp_dir();
-        fs::create_dir_all(&dir).unwrap();
-        let file = dir.join("blocklist.txt");
-        fs::write(&file, "203.0.113.10\n").unwrap();
-        write_sidecar(&file, "198.51.100.10\n");
-
-        let mut report = StartupIntegrityReport::default();
-        observe_operator_path_with_registry(
-            &mut report,
-            "blocklist",
-            &file,
-            &dir.join("operator-file-provenance.json"),
-        );
-
-        assert_eq!(report.checked, 1);
-        assert_eq!(report.warnings, 0);
-        assert_eq!(report.failures, 1);
-        assert!(report.issues[0]
-            .message
-            .contains("failed SHA-256 verification"));
-        let _ = fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn startup_report_uses_dedicated_integrity_subdirectory() {
-        let path = report_path();
-        assert_eq!(
-            path.parent().and_then(|parent| parent.file_name()),
-            Some(OsStr::new(REPORT_DIR))
-        );
-        assert_eq!(path.file_name(), Some(OsStr::new(REPORT_FILE)));
-    }
-
-    fn write_sidecar(path: &Path, content: &str) {
-        let digest = Sha256::digest(content.as_bytes());
-        fs::write(
-            crate::security::integrity::sidecar_path(path),
-            format!(
-                "{}  {}\n",
-                hex(&digest),
-                path.file_name().unwrap().to_string_lossy()
-            ),
-        )
-        .unwrap();
-    }
-
-    fn hex(bytes: &[u8]) -> String {
-        const HEX: &[u8; 16] = b"0123456789abcdef";
-        let mut out = String::with_capacity(bytes.len() * 2);
-        for &byte in bytes {
-            out.push(HEX[(byte >> 4) as usize] as char);
-            out.push(HEX[(byte & 0x0f) as usize] as char);
-        }
-        out
+        save_report(&report).unwrap();
+        let loaded = load_latest_report("startup_integrity_scan").expect("report must load");
+        assert_eq!(loaded.outcome, "warning");
     }
 
     fn unique_temp_dir() -> PathBuf {

--- a/src/startup_integrity.rs
+++ b/src/startup_integrity.rs
@@ -9,12 +9,14 @@ use crate::{
     audit, config,
     security::{file_quarantine, operator_provenance},
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+
+const REPORT_DIR: &str = "integrity-reports";
 
 #[derive(Debug, Default)]
 struct ScanSummary {
@@ -22,6 +24,17 @@ struct ScanSummary {
     ok: usize,
     warnings: usize,
     failures: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct IntegrityReport {
+    pub action: String,
+    pub outcome: String,
+    pub checked: usize,
+    pub ok: usize,
+    pub warnings: usize,
+    pub failures: usize,
+    pub generated_unix: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -56,6 +69,12 @@ pub fn scan_operator_inputs(cfg: &config::Config) {
     record_summary("startup_operator_file_scan", &summary);
 }
 
+pub fn load_latest_report(action: &str) -> Option<IntegrityReport> {
+    let path = report_path(action);
+    let bytes = crate::security::policy::load_json_with_integrity(&path).ok().flatten()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
 fn observe_operator_path(summary: &mut ScanSummary, kind: &str, path: &Path) {
     summary.checked += 1;
     match operator_provenance::observe_operator_file(kind, path) {
@@ -88,6 +107,20 @@ fn record_summary(action: &str, summary: &ScanSummary) {
             "failures": summary.failures,
         }),
     );
+
+    let report = IntegrityReport {
+        action: action.to_string(),
+        outcome: outcome.to_string(),
+        checked: summary.checked,
+        ok: summary.ok,
+        warnings: summary.warnings,
+        failures: summary.failures,
+        generated_unix: unix_now(),
+    };
+    if let Err(err) = save_report(&report) {
+        tracing::warn!(action, %err, "failed to persist integrity report");
+    }
+
     match outcome {
         "success" => tracing::info!(
             action,
@@ -107,6 +140,19 @@ fn record_summary(action: &str, summary: &ScanSummary) {
             "integrity scan found failures"
         ),
     }
+}
+
+fn save_report(report: &IntegrityReport) -> Result<(), String> {
+    let path = report_path(&report.action);
+    let bytes = serde_json::to_vec_pretty(report)
+        .map_err(|e| format!("failed to serialize integrity report: {e}"))?;
+    crate::security::policy::save_json_with_integrity(&path, &bytes)
+}
+
+fn report_path(action: &str) -> PathBuf {
+    config::data_dir()
+        .join(REPORT_DIR)
+        .join(format!("{action}.json"))
 }
 
 fn scan_policy_sidecars(summary: &mut ScanSummary) {
@@ -134,11 +180,7 @@ fn scan_policy_sidecars(summary: &mut ScanSummary) {
     ]
     .into_iter()
     .filter_map(|(p, name)| {
-        if p.exists() {
-            None
-        } else {
-            Some(name.to_string())
-        }
+        if p.exists() { None } else { Some(name.to_string()) }
     })
     .collect();
     if missing.is_empty() {
@@ -175,73 +217,40 @@ fn scan_artifact_manifests(summary: &mut ScanSummary) {
                     tracing::warn!(manifest = %manifest_path.display(), %related_err, "could not derive related artifact paths for quarantine");
                     Vec::new()
                 });
-                match file_quarantine::quarantine_integrity_failure(&manifest_path, &related, &err)
-                {
-                    Ok(dest) => {
-                        tracing::error!(manifest = %manifest_path.display(), quarantine = %dest.display(), %err, "forensic artifact manifest verification failed and was quarantined")
-                    }
-                    Err(quarantine_err) => {
-                        tracing::error!(manifest = %manifest_path.display(), %err, %quarantine_err, "forensic artifact manifest verification failed and quarantine failed")
-                    }
+                match file_quarantine::quarantine_integrity_failure(&manifest_path, &related, &err) {
+                    Ok(dest) => tracing::error!(manifest = %manifest_path.display(), quarantine = %dest.display(), %err, "forensic artifact manifest verification failed and was quarantined"),
+                    Err(quarantine_err) => tracing::error!(manifest = %manifest_path.display(), %err, %quarantine_err, "forensic artifact manifest verification failed and quarantine failed"),
                 }
             }
         }
     }
 }
 
-fn related_artifact_paths(
-    manifest_path: &Path,
-    artifact_root: &Path,
-) -> Result<Vec<PathBuf>, String> {
-    let text = fs::read_to_string(manifest_path)
-        .map_err(|e| format!("failed to read manifest for quarantine: {e}"))?;
-    let manifest: ArtifactManifestScan = serde_json::from_str(&text)
-        .map_err(|e| format!("failed to parse manifest for quarantine: {e}"))?;
+fn related_artifact_paths(manifest_path: &Path, artifact_root: &Path) -> Result<Vec<PathBuf>, String> {
+    let text = fs::read_to_string(manifest_path).map_err(|e| format!("failed to read manifest for quarantine: {e}"))?;
+    let manifest: ArtifactManifestScan = serde_json::from_str(&text).map_err(|e| format!("failed to parse manifest for quarantine: {e}"))?;
     let artifact_path = PathBuf::from(manifest.artifact_path);
     if !artifact_path.exists() {
         return Ok(Vec::new());
     }
     let artifact_root = canonical_artifact_root(artifact_root)?;
-    let artifact_path = artifact_path.canonicalize().map_err(|e| {
-        format!(
-            "failed to canonicalize manifest artifact path {}: {e}",
-            artifact_path.display()
-        )
-    })?;
+    let artifact_path = artifact_path.canonicalize().map_err(|e| format!("failed to canonicalize manifest artifact path {}: {e}", artifact_path.display()))?;
     if !artifact_path.starts_with(&artifact_root) {
-        return Err(format!(
-            "refusing to quarantine artifact outside Vigil artifact directory: {}",
-            artifact_path.display()
-        ));
+        return Err(format!("refusing to quarantine artifact outside Vigil artifact directory: {}", artifact_path.display()));
     }
-    let metadata = fs::metadata(&artifact_path).map_err(|e| {
-        format!(
-            "failed to stat manifest artifact path {}: {e}",
-            artifact_path.display()
-        )
-    })?;
+    let metadata = fs::metadata(&artifact_path).map_err(|e| format!("failed to stat manifest artifact path {}: {e}", artifact_path.display()))?;
     if !metadata.is_file() {
-        return Err(format!(
-            "refusing to quarantine non-regular artifact path {}",
-            artifact_path.display()
-        ));
+        return Err(format!("refusing to quarantine non-regular artifact path {}", artifact_path.display()));
     }
     Ok(vec![artifact_path])
 }
 
 fn canonical_artifact_root(artifact_root: &Path) -> Result<PathBuf, String> {
-    artifact_root.canonicalize().map_err(|e| {
-        format!(
-            "failed to canonicalize artifact root {}: {e}",
-            artifact_root.display()
-        )
-    })
+    artifact_root.canonicalize().map_err(|e| format!("failed to canonicalize artifact root {}: {e}", artifact_root.display()))
 }
 
 fn collect_manifest_paths(dir: &Path, artifact_root: &Path, out: &mut Vec<PathBuf>, depth: usize) {
-    if depth > 6 || out.len() >= 512 {
-        return;
-    }
+    if depth > 6 || out.len() >= 512 { return; }
     let Ok(entries) = fs::read_dir(dir) else {
         tracing::warn!(path = %dir.display(), "could not read artifact directory during integrity scan");
         return;
@@ -260,85 +269,50 @@ fn collect_manifest_paths(dir: &Path, artifact_root: &Path, out: &mut Vec<PathBu
             collect_manifest_paths(&path, artifact_root, out, depth + 1);
             continue;
         }
-        if !file_type.is_file() {
-            continue;
-        }
-        if path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .is_some_and(|name| name.ends_with(".manifest.json"))
-        {
+        if !file_type.is_file() { continue; }
+        if path.file_name().and_then(|name| name.to_str()).is_some_and(|name| name.ends_with(".manifest.json")) {
             match path.canonicalize() {
                 Ok(canonical) if canonical.starts_with(artifact_root) => out.push(canonical),
-                Ok(canonical) => {
-                    tracing::warn!(path = %canonical.display(), "skipping manifest outside artifact root after canonicalization")
-                }
-                Err(err) => {
-                    tracing::warn!(path = %path.display(), %err, "could not canonicalize manifest path during integrity scan")
-                }
+                Ok(canonical) => tracing::warn!(path = %canonical.display(), "skipping manifest outside artifact root after canonicalization"),
+                Err(err) => tracing::warn!(path = %path.display(), %err, "could not canonicalize manifest path during integrity scan"),
             }
-            if out.len() >= 512 {
-                break;
-            }
+            if out.len() >= 512 { break; }
         }
     }
 }
 
 fn verify_artifact_manifest(manifest_path: &Path) -> Result<(), String> {
-    let text =
-        fs::read_to_string(manifest_path).map_err(|e| format!("failed to read manifest: {e}"))?;
-    let manifest: ArtifactManifestScan =
-        serde_json::from_str(&text).map_err(|e| format!("failed to parse manifest JSON: {e}"))?;
+    let text = fs::read_to_string(manifest_path).map_err(|e| format!("failed to read manifest: {e}"))?;
+    let manifest: ArtifactManifestScan = serde_json::from_str(&text).map_err(|e| format!("failed to parse manifest JSON: {e}"))?;
     let artifact_path = PathBuf::from(&manifest.artifact_path);
-    let metadata = fs::metadata(&artifact_path).map_err(|e| {
-        format!(
-            "referenced artifact {} is not readable: {e}",
-            artifact_path.display()
-        )
-    })?;
+    let metadata = fs::metadata(&artifact_path).map_err(|e| format!("referenced artifact {} is not readable: {e}", artifact_path.display()))?;
     if !metadata.is_file() {
-        return Err(format!(
-            "referenced artifact {} is not a regular file",
-            artifact_path.display()
-        ));
+        return Err(format!("referenced artifact {} is not a regular file", artifact_path.display()));
     }
     if metadata.len() != manifest.size_bytes {
-        return Err(format!(
-            "artifact size mismatch for {}: manifest={} actual={}",
-            artifact_path.display(),
-            manifest.size_bytes,
-            metadata.len()
-        ));
+        return Err(format!("artifact size mismatch for {}: manifest={} actual={}", artifact_path.display(), manifest.size_bytes, metadata.len()));
     }
     let actual_hash = sha256_file(&artifact_path)?;
     if !actual_hash.eq_ignore_ascii_case(manifest.sha256.trim()) {
-        return Err(format!(
-            "artifact SHA-256 mismatch for {}",
-            artifact_path.display()
-        ));
+        return Err(format!("artifact SHA-256 mismatch for {}", artifact_path.display()));
     }
     Ok(())
 }
 
 fn sha256_file(path: &Path) -> Result<String, String> {
-    let mut file =
-        fs::File::open(path).map_err(|e| format!("failed to open {}: {e}", path.display()))?;
+    let mut file = fs::File::open(path).map_err(|e| format!("failed to open {}: {e}", path.display()))?;
     let mut hasher = Sha256::new();
     let mut buf = [0u8; 16 * 1024];
     loop {
-        let n = file
-            .read(&mut buf)
-            .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
-        if n == 0 {
-            break;
-        }
+        let n = file.read(&mut buf).map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+        if n == 0 { break; }
         hasher.update(&buf[..n]);
     }
-    Ok(hasher
-        .finalize()
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect::<String>())
+    Ok(hasher.finalize().iter().map(|byte| format!("{byte:02x}")).collect::<String>())
+}
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0)
 }
 
 #[cfg(test)]
@@ -353,14 +327,7 @@ mod tests {
         let artifact = dir.join("sample.bin");
         fs::write(&artifact, b"abc").unwrap();
         let manifest = dir.join("sample.bin.manifest.json");
-        fs::write(
-            &manifest,
-            format!(
-                "{{\"artifact_path\":\"{}\",\"size_bytes\":3,\"sha256\":\"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\"}}",
-                artifact.display().to_string().replace('\\', "\\\\")
-            ),
-        )
-        .unwrap();
+        fs::write(&manifest, format!("{{\"artifact_path\":\"{}\",\"size_bytes\":3,\"sha256\":\"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\"}}", artifact.display().to_string().replace('\\', "\\\\"))).unwrap();
         assert!(verify_artifact_manifest(&manifest).is_ok());
         let _ = fs::remove_dir_all(dir);
     }
@@ -372,88 +339,21 @@ mod tests {
         let artifact = dir.join("sample.bin");
         fs::write(&artifact, b"abc").unwrap();
         let manifest = dir.join("sample.bin.manifest.json");
-        fs::write(
-            &manifest,
-            format!(
-                "{{\"artifact_path\":\"{}\",\"size_bytes\":3,\"sha256\":\"0000000000000000000000000000000000000000000000000000000000000000\"}}",
-                artifact.display().to_string().replace('\\', "\\\\")
-            ),
-        )
-        .unwrap();
+        fs::write(&manifest, format!("{{\"artifact_path\":\"{}\",\"size_bytes\":3,\"sha256\":\"0000000000000000000000000000000000000000000000000000000000000000\"}}", artifact.display().to_string().replace('\\', "\\\\"))).unwrap();
         assert!(verify_artifact_manifest(&manifest).is_err());
         let _ = fs::remove_dir_all(dir);
     }
 
     #[test]
-    fn related_artifact_paths_reads_manifest_artifact_under_root() {
-        let dir = unique_temp_dir();
-        let root = dir.join("artifacts");
-        fs::create_dir_all(&root).unwrap();
-        let artifact = root.join("sample.bin");
-        fs::write(&artifact, b"abc").unwrap();
-        let manifest = root.join("sample.bin.manifest.json");
-        fs::write(
-            &manifest,
-            format!(
-                "{{\"artifact_path\":\"{}\",\"size_bytes\":3,\"sha256\":\"abc\"}}",
-                artifact.display().to_string().replace('\\', "\\\\")
-            ),
-        )
-        .unwrap();
-        assert_eq!(
-            related_artifact_paths(&manifest, &root).unwrap(),
-            vec![artifact.canonicalize().unwrap()]
-        );
-        let _ = fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn related_artifact_paths_rejects_paths_outside_artifact_root() {
-        let dir = unique_temp_dir();
-        let root = dir.join("artifacts");
-        fs::create_dir_all(&root).unwrap();
-        let outside = dir.join("outside.bin");
-        fs::write(&outside, b"abc").unwrap();
-        let manifest = root.join("crafted.manifest.json");
-        fs::write(
-            &manifest,
-            format!(
-                "{{\"artifact_path\":\"{}\",\"size_bytes\":3,\"sha256\":\"abc\"}}",
-                outside.display().to_string().replace('\\', "\\\\")
-            ),
-        )
-        .unwrap();
-        let err = related_artifact_paths(&manifest, &root).unwrap_err();
-        assert!(err.contains("outside Vigil artifact directory"));
-        assert!(outside.exists());
-        let _ = fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn collect_manifest_paths_skips_symlinked_directories() {
-        let dir = unique_temp_dir();
-        let root = dir.join("artifacts");
-        let outside = dir.join("outside");
-        fs::create_dir_all(&root).unwrap();
-        fs::create_dir_all(&outside).unwrap();
-        let outside_manifest = outside.join("outside.manifest.json");
-        fs::write(&outside_manifest, b"{}").unwrap();
-        #[cfg(unix)]
-        {
-            std::os::unix::fs::symlink(&outside, root.join("link-out")).unwrap();
-            let mut manifests = Vec::new();
-            let root = root.canonicalize().unwrap();
-            collect_manifest_paths(&root, &root, &mut manifests, 0);
-            assert!(manifests.is_empty());
-        }
-        let _ = fs::remove_dir_all(dir);
+    fn persists_integrity_report_with_protected_sidecars() {
+        let report = IntegrityReport { action: "startup_integrity_scan".into(), outcome: "warning".into(), checked: 1, ok: 0, warnings: 1, failures: 0, generated_unix: 1 };
+        save_report(&report).unwrap();
+        let loaded = load_latest_report("startup_integrity_scan").expect("report must load");
+        assert_eq!(loaded.outcome, "warning");
     }
 
     fn unique_temp_dir() -> PathBuf {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
         std::env::temp_dir().join(format!("vigil-startup-integrity-test-{nanos}"))
     }
 }

--- a/src/ui/activity.rs
+++ b/src/ui/activity.rs
@@ -1,8 +1,8 @@
 //! Activity tab wrapper around the process-grouped list.
 
 use crate::types::ConnInfo;
-use crate::ui::process_list::CachedGroupView;
-use crate::ui::{process_list, ProcessSelection, TableState};
+use crate::ui::process_list_fast::CachedGroupView;
+use crate::ui::{process_list_fast, ProcessSelection, TableState};
 use std::collections::VecDeque;
 
 pub fn show(
@@ -13,12 +13,12 @@ pub fn show(
     data_version: u64,
     cache: &mut Option<CachedGroupView>,
 ) -> bool {
-    process_list::show(
+    process_list_fast::show(
         ui,
         rows,
         selected,
         state,
-        process_list::Kind::Activity,
+        process_list_fast::Kind::Activity,
         data_version,
         cache,
     )

--- a/src/ui/activity.rs
+++ b/src/ui/activity.rs
@@ -1,8 +1,8 @@
 //! Activity tab wrapper around the process-grouped list.
 
 use crate::types::ConnInfo;
-use crate::ui::process_list_fast::CachedGroupView;
-use crate::ui::{process_list_fast, ProcessSelection, TableState};
+use crate::ui::process_list::CachedGroupView;
+use crate::ui::{process_list, ProcessSelection, TableState};
 use std::collections::VecDeque;
 
 pub fn show(
@@ -13,12 +13,12 @@ pub fn show(
     data_version: u64,
     cache: &mut Option<CachedGroupView>,
 ) -> bool {
-    process_list_fast::show(
+    process_list::show(
         ui,
         rows,
         selected,
         state,
-        process_list_fast::Kind::Activity,
+        process_list::Kind::Activity,
         data_version,
         cache,
     )

--- a/src/ui/activity.rs
+++ b/src/ui/activity.rs
@@ -2,7 +2,7 @@
 
 use crate::types::ConnInfo;
 use crate::ui::process_list::CachedGroupView;
-use crate::ui::{process_list, ProcessSelection, TableState};
+use crate::ui::{process_list_fast, ProcessSelection, TableState};
 use std::collections::VecDeque;
 
 pub fn show(
@@ -13,12 +13,12 @@ pub fn show(
     data_version: u64,
     cache: &mut Option<CachedGroupView>,
 ) -> bool {
-    process_list::show(
+    process_list_fast::show(
         ui,
         rows,
         selected,
         state,
-        process_list::Kind::Activity,
+        process_list_fast::Kind::Activity,
         data_version,
         cache,
     )

--- a/src/ui/alerts.rs
+++ b/src/ui/alerts.rs
@@ -1,8 +1,8 @@
 //! Alerts tab wrapper around the process-grouped list.
 
 use crate::types::ConnInfo;
-use crate::ui::process_list_fast::CachedGroupView;
-use crate::ui::{process_list_fast, ProcessSelection, TableState};
+use crate::ui::process_list::CachedGroupView;
+use crate::ui::{process_list, ProcessSelection, TableState};
 use std::collections::VecDeque;
 
 pub fn show(
@@ -13,12 +13,12 @@ pub fn show(
     data_version: u64,
     cache: &mut Option<CachedGroupView>,
 ) -> bool {
-    process_list_fast::show(
+    process_list::show(
         ui,
         rows,
         selected,
         state,
-        process_list_fast::Kind::Alerts,
+        process_list::Kind::Alerts,
         data_version,
         cache,
     )

--- a/src/ui/alerts.rs
+++ b/src/ui/alerts.rs
@@ -2,7 +2,7 @@
 
 use crate::types::ConnInfo;
 use crate::ui::process_list::CachedGroupView;
-use crate::ui::{process_list, ProcessSelection, TableState};
+use crate::ui::{process_list_fast, ProcessSelection, TableState};
 use std::collections::VecDeque;
 
 pub fn show(
@@ -13,12 +13,12 @@ pub fn show(
     data_version: u64,
     cache: &mut Option<CachedGroupView>,
 ) -> bool {
-    process_list::show(
+    process_list_fast::show(
         ui,
         rows,
         selected,
         state,
-        process_list::Kind::Alerts,
+        process_list_fast::Kind::Alerts,
         data_version,
         cache,
     )

--- a/src/ui/alerts.rs
+++ b/src/ui/alerts.rs
@@ -1,8 +1,8 @@
 //! Alerts tab wrapper around the process-grouped list.
 
 use crate::types::ConnInfo;
-use crate::ui::process_list::CachedGroupView;
-use crate::ui::{process_list, ProcessSelection, TableState};
+use crate::ui::process_list_fast::CachedGroupView;
+use crate::ui::{process_list_fast, ProcessSelection, TableState};
 use std::collections::VecDeque;
 
 pub fn show(
@@ -13,12 +13,12 @@ pub fn show(
     data_version: u64,
     cache: &mut Option<CachedGroupView>,
 ) -> bool {
-    process_list::show(
+    process_list_fast::show(
         ui,
         rows,
         selected,
         state,
-        process_list::Kind::Alerts,
+        process_list_fast::Kind::Alerts,
         data_version,
         cache,
     )

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -777,11 +777,16 @@ impl VigilApp {
             }
             inspector::Action::RequestAdmin => {
                 if !crate::autostart::is_elevated() {
-                    if let Err(err) = crate::autostart::relaunch_as_admin() {
-                        self.push_notification(
-                            NotificationKind::Error,
-                            format!("Could not relaunch Vigil with Admin Mode: {err}"),
-                        );
+                    match crate::autostart::relaunch_as_admin() {
+                        Ok(()) => {
+                            std::process::exit(0);
+                        }
+                        Err(err) => {
+                            self.push_notification(
+                                NotificationKind::Error,
+                                format!("Could not relaunch Vigil with Admin Mode: {err}"),
+                            );
+                        }
                     }
                 }
             }
@@ -790,15 +795,25 @@ impl VigilApp {
             }
             inspector::Action::BlockRemote(preset) => {
                 if let Some(info) = selected_info {
-                    self.response_confirm = Some(PendingResponse::BlockRemote {
-                        target: info.remote_addr.clone(),
-                        preset,
-                    });
+                    if let Some(conn) = info.selected_connection.as_ref() {
+                        if let Some(target) =
+                            active_response::extract_remote_target(&conn.remote_addr)
+                        {
+                            self.response_confirm =
+                                Some(PendingResponse::BlockRemote { target, preset });
+                        }
+                    }
                 }
             }
             inspector::Action::UnblockRemote => {
                 if let Some(info) = selected_info {
-                    self.response_confirm = Some(PendingResponse::UnblockRemote(info.remote_addr));
+                    if let Some(conn) = info.selected_connection.as_ref() {
+                        if let Some(target) =
+                            active_response::extract_remote_target(&conn.remote_addr)
+                        {
+                            self.response_confirm = Some(PendingResponse::UnblockRemote(target));
+                        }
+                    }
                 }
             }
             inspector::Action::BlockDomain => {
@@ -907,6 +922,9 @@ impl VigilApp {
                 self.response_confirm = Some(PendingResponse::RestoreNetwork);
             }
             inspector::Action::KillConfirmed => {
+                if let Some(info) = selected_info {
+                    self.kill_selected_process(&info);
+                }
                 self.kill_confirm = false;
             }
             inspector::Action::KillCancelled => {
@@ -974,18 +992,7 @@ impl VigilApp {
                         .on_hover_text("Terminate this process immediately.")
                         .clicked()
                     {
-                        kill_process(info.pid);
-                        remove_pid(&mut self.activity, info.pid);
-                        remove_pid(&mut self.alerts, info.pid);
-                        self.selected_activity = None;
-                        self.selected_alert = None;
-                        self.cached_activity_process_count =
-                            process_list::count_distinct_processes(&self.activity);
-                        self.cached_alerts_process_count =
-                            process_list::count_distinct_processes(&self.alerts);
-                        self.activity_cache = None;
-                        self.alerts_cache = None;
-                        self.data_version = self.data_version.wrapping_add(1);
+                        self.kill_selected_process(&info);
                         self.kill_confirm = false;
                     }
                     if ui
@@ -1005,6 +1012,23 @@ impl VigilApp {
                     }
                 });
             });
+    }
+
+    fn kill_selected_process(&mut self, info: &ProcessSelection) {
+        kill_process(info.pid);
+        remove_pid(&mut self.activity, info.pid);
+        remove_pid(&mut self.alerts, info.pid);
+        self.selected_activity = None;
+        self.selected_alert = None;
+        self.cached_activity_process_count = process_list::count_distinct_processes(&self.activity);
+        self.cached_alerts_process_count = process_list::count_distinct_processes(&self.alerts);
+        self.activity_cache = None;
+        self.alerts_cache = None;
+        self.data_version = self.data_version.wrapping_add(1);
+        if self.alerts.is_empty() {
+            self.unseen_alerts = 0;
+            let _ = self.tray_tx.try_send(TrayCmd::ResetOk);
+        }
     }
 
     fn show_header(&mut self, ui: &mut egui::Ui) -> Option<inspector::Action> {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -869,23 +869,19 @@ impl VigilApp {
             }
             inspector::Action::SuspendProcess => {
                 if let Some(info) = selected_info {
-                    if has_known_location(&info) {
-                        self.response_confirm = Some(PendingResponse::SuspendProcess {
-                            pid: info.pid,
-                            path: info.proc_path.clone(),
-                            proc_name: info.proc_name.clone(),
-                        });
-                    }
+                    self.response_confirm = Some(PendingResponse::SuspendProcess {
+                        pid: info.pid,
+                        path: info.proc_path.clone(),
+                        proc_name: info.proc_name.clone(),
+                    });
                 }
             }
             inspector::Action::ResumeProcess => {
                 if let Some(info) = selected_info {
-                    if has_known_location(&info) {
-                        self.response_confirm = Some(PendingResponse::ResumeProcess {
-                            pid: info.pid,
-                            path: info.proc_path.clone(),
-                        });
-                    }
+                    self.response_confirm = Some(PendingResponse::ResumeProcess {
+                        pid: info.pid,
+                        path: info.proc_path.clone(),
+                    });
                 }
             }
             inspector::Action::FreezeAutoruns => {
@@ -896,23 +892,19 @@ impl VigilApp {
             }
             inspector::Action::QuarantineProfile => {
                 if let Some(info) = selected_info {
-                    if has_known_location(&info) {
-                        self.response_confirm = Some(PendingResponse::QuarantineProfile {
-                            pid: info.pid,
-                            path: info.proc_path.clone(),
-                            proc_name: info.proc_name.clone(),
-                        });
-                    }
+                    self.response_confirm = Some(PendingResponse::QuarantineProfile {
+                        pid: info.pid,
+                        path: info.proc_path.clone(),
+                        proc_name: info.proc_name.clone(),
+                    });
                 }
             }
             inspector::Action::ClearQuarantineProfile => {
                 if let Some(info) = selected_info {
-                    if has_known_location(&info) {
-                        self.response_confirm = Some(PendingResponse::ClearQuarantineProfile {
-                            pid: info.pid,
-                            path: info.proc_path.clone(),
-                        });
-                    }
+                    self.response_confirm = Some(PendingResponse::ClearQuarantineProfile {
+                        pid: info.pid,
+                        path: info.proc_path.clone(),
+                    });
                 }
             }
             inspector::Action::IsolateMachine => {
@@ -1136,6 +1128,47 @@ impl VigilApp {
                 ui.add_space(12.0);
 
                 let btn_label = if self.paused { "Resume" } else { "Pause" };
+                let network_label = if self.response_status.isolated {
+                    "Restore Net"
+                } else {
+                    "Isolate Net"
+                };
+                let network_tone = if self.response_status.isolated {
+                    theme::ACCENT
+                } else {
+                    theme::DANGER
+                };
+                let network_btn = egui::Button::new(
+                    egui::RichText::new(network_label)
+                        .color(network_tone)
+                        .size(11.0),
+                )
+                .fill(if self.response_status.isolated {
+                    theme::ACCENT_BG
+                } else {
+                    theme::DANGER_BG
+                })
+                .stroke(egui::Stroke::new(1.0, network_tone))
+                .corner_radius(4.0);
+                let network_resp = ui
+                    .add_enabled(!network_busy, network_btn)
+                    .on_hover_cursor(egui::CursorIcon::PointingHand);
+                let network_resp = if network_busy {
+                    network_resp.on_hover_text("A network action is already in progress.")
+                } else if self.response_status.isolated {
+                    network_resp.on_hover_text("Restore saved firewall and adapter state from before isolation.")
+                } else {
+                    network_resp.on_hover_text("Immediately isolate the machine network.")
+                };
+                if network_resp.clicked() {
+                    if self.response_status.isolated {
+                        let _ = self.start_network_operation(NetworkOperationKind::Restore);
+                    } else {
+                        let _ = self.start_network_operation(NetworkOperationKind::Isolate);
+                    }
+                }
+                ui.add_space(8.0);
+
                 let btn = egui::Button::new(
                     egui::RichText::new(btn_label)
                         .color(theme::TEXT2)

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -24,6 +24,7 @@ use crate::types::{ConnEvent, ConnInfo};
 use chrono::{Local, Timelike};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashSet, VecDeque};
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex, RwLock};
@@ -427,6 +428,23 @@ fn load_vigil_logo(ctx: &egui::Context) -> Option<egui::TextureHandle> {
     Some(ctx.load_texture("vigil-logo", color_image, egui::TextureOptions::default()))
 }
 
+fn admin_chip(ui: &mut egui::Ui) {
+    ui.label(
+        egui::RichText::new(" Admin Mode ")
+            .color(theme::ACCENT)
+            .background_color(theme::ACCENT_BG)
+            .size(10.5)
+            .strong(),
+    );
+}
+
+fn admin_btn(text: &str) -> egui::Button<'_> {
+    egui::Button::new(egui::RichText::new(text).color(theme::ACCENT).size(11.0))
+        .fill(theme::ACCENT_BG)
+        .stroke(egui::Stroke::new(1.0, theme::ACCENT))
+        .corner_radius(4.0)
+}
+
 impl VigilApp {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -563,6 +581,104 @@ impl VigilApp {
         truncate_deque(&mut self.activity, activity_cap);
         truncate_deque(&mut self.alerts, alerts_cap);
     }
+
+    fn sync_tray_state(&mut self) {
+        let isolated = self.response_status.isolated;
+        if isolated != self.tray_lockdown_sent
+            && self
+                .tray_tx
+                .try_send(TrayCmd::SetLockdown(isolated))
+                .is_ok()
+        {
+            self.tray_lockdown_sent = isolated;
+        }
+    }
+
+    fn refresh_active_response_state(&mut self) {
+        if let Some(rx) = self.reconcile_rx.as_ref() {
+            match rx.try_recv() {
+                Ok(status) => {
+                    self.response_status = status;
+                    self.reconcile_rx = None;
+                }
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    self.reconcile_rx = None;
+                }
+                Err(mpsc::TryRecvError::Empty) => {}
+            }
+        }
+        if self.last_response_reconcile.elapsed().as_secs() >= 1 {
+            if self.reconcile_rx.is_none() {
+                let (tx, rx) = mpsc::channel();
+                match std::thread::Builder::new()
+                    .name("vigil-active-response-reconcile".into())
+                    .spawn(move || {
+                        active_response::reconcile();
+                        let _ = tx.send(active_response::status());
+                    }) {
+                    Ok(_) => {
+                        self.reconcile_rx = Some(rx);
+                    }
+                    Err(err) => {
+                        self.push_notification(
+                            NotificationKind::Error,
+                            format!("Could not start reconcile worker: {err}"),
+                        );
+                    }
+                }
+            }
+            self.last_response_reconcile = std::time::Instant::now();
+        }
+        if self.last_schedule_check.elapsed().as_secs() >= 30 {
+            self.apply_scheduled_lockdown();
+            self.last_schedule_check = std::time::Instant::now();
+        }
+    }
+
+    fn apply_scheduled_lockdown(&mut self) {
+        if self.network_operation.is_some() {
+            return;
+        }
+        let cfg = self.cfg.read().unwrap().clone();
+        if !cfg.scheduled_lockdown_enabled {
+            self.scheduled_lockdown_active = false;
+            return;
+        }
+        if !active_response::can_isolate_network() {
+            return;
+        }
+        let now = Local::now();
+        let minute_of_day = now.hour() * 60 + now.minute();
+        let start = u32::from(cfg.scheduled_lockdown_start_hour.min(23)) * 60
+            + u32::from(cfg.scheduled_lockdown_start_minute.min(59));
+        let end = u32::from(cfg.scheduled_lockdown_end_hour.min(23)) * 60
+            + u32::from(cfg.scheduled_lockdown_end_minute.min(59));
+        let should_lock = if start == end {
+            false
+        } else if start < end {
+            minute_of_day >= start && minute_of_day < end
+        } else {
+            minute_of_day >= start || minute_of_day < end
+        };
+        if should_lock && !self.scheduled_lockdown_active {
+            if self.start_network_operation(NetworkOperationKind::Isolate) {
+                self.scheduled_target = Some(true);
+                self.push_notification(
+                    NotificationKind::Info,
+                    "Scheduled lockdown started: isolating network…",
+                );
+            }
+        } else if !should_lock
+            && self.scheduled_lockdown_active
+            && self.start_network_operation(NetworkOperationKind::Restore)
+        {
+            self.scheduled_target = Some(false);
+            self.push_notification(
+                NotificationKind::Info,
+                "Scheduled lockdown window ended: restoring network…",
+            );
+        }
+    }
     fn drain_events(&mut self, max_events: usize) -> bool {
         let mut handled = false;
         let deadline = std::time::Instant::now() + UI_EVENT_TIME_BUDGET;
@@ -643,69 +759,82 @@ impl VigilApp {
                     }
                 }
             }
-            inspector::Action::TrustPath => {
+            inspector::Action::OpenLocation => {
                 if let Some(info) = selected_info {
                     if !has_known_location(&info) {
                         return;
                     }
-                    if !crate::autostart::is_elevated() {
+                    let open_target = Path::new(&info.proc_path)
+                        .parent()
+                        .unwrap_or_else(|| Path::new(&info.proc_path));
+                    if let Err(err) = open::that(open_target) {
                         self.push_notification(
                             NotificationKind::Error,
-                            "Admin Mode is required to trust a path.",
+                            format!("Could not open location {}: {err}", open_target.display()),
                         );
-                        return;
-                    }
-                    let mut cfg = self.cfg.write().unwrap();
-                    if cfg.add_trusted_path(&info.proc_path) {
-                        cfg.save();
-                        self.settings = settings::SettingsDraft::from_config(&cfg);
                     }
                 }
             }
-            inspector::Action::KillProcess => {
+            inspector::Action::RequestAdmin => {
+                if !crate::autostart::is_elevated() {
+                    if let Err(err) = crate::autostart::relaunch_as_admin() {
+                        self.push_notification(
+                            NotificationKind::Error,
+                            format!("Could not relaunch Vigil with Admin Mode: {err}"),
+                        );
+                    }
+                }
+            }
+            inspector::Action::Kill => {
                 self.kill_confirm = true;
             }
-            inspector::Action::IgnoreRemote => {
+            inspector::Action::BlockRemote(preset) => {
                 if let Some(info) = selected_info {
                     self.response_confirm = Some(PendingResponse::BlockRemote {
                         target: info.remote_addr.clone(),
-                        preset: active_response::DurationPreset::Persistent,
+                        preset,
                     });
                 }
             }
-            inspector::Action::UnignoreRemote => {
+            inspector::Action::UnblockRemote => {
                 if let Some(info) = selected_info {
                     self.response_confirm = Some(PendingResponse::UnblockRemote(info.remote_addr));
                 }
             }
-            inspector::Action::IgnoreDomain => {
+            inspector::Action::BlockDomain => {
                 if let Some(info) = selected_info {
-                    let domain = info.selected_connection.as_ref().and_then(|c| c.hostname.clone());
+                    let domain = info
+                        .selected_connection
+                        .as_ref()
+                        .and_then(|c| c.hostname.clone());
                     if let Some(domain) = domain {
                         self.response_confirm = Some(PendingResponse::BlockDomain { domain });
                     }
                 }
             }
-            inspector::Action::UnignoreDomain => {
+            inspector::Action::UnblockDomain => {
                 if let Some(info) = selected_info {
-                    let domain = info.selected_connection.as_ref().and_then(|c| c.hostname.clone());
+                    let domain = info
+                        .selected_connection
+                        .as_ref()
+                        .and_then(|c| c.hostname.clone());
                     if let Some(domain) = domain {
                         self.response_confirm = Some(PendingResponse::UnblockDomain(domain));
                     }
                 }
             }
-            inspector::Action::IgnoreProcess => {
+            inspector::Action::BlockProcess(preset) => {
                 if let Some(info) = selected_info {
                     if has_known_location(&info) {
                         self.response_confirm = Some(PendingResponse::BlockProcess {
                             pid: info.pid,
                             path: info.proc_path.clone(),
-                            preset: active_response::DurationPreset::Persistent,
+                            preset,
                         });
                     }
                 }
             }
-            inspector::Action::UnignoreProcess => {
+            inspector::Action::UnblockProcess => {
                 if let Some(info) = selected_info {
                     if has_known_location(&info) {
                         self.response_confirm = Some(PendingResponse::UnblockProcess {
@@ -718,7 +847,8 @@ impl VigilApp {
             inspector::Action::KillConnection => {
                 if let Some(info) = selected_info {
                     if let Some(conn) = info.selected_connection {
-                        self.response_confirm = Some(PendingResponse::KillConnection(Box::new(conn)));
+                        self.response_confirm =
+                            Some(PendingResponse::KillConnection(Box::new(conn)));
                     }
                 }
             }
@@ -770,7 +900,18 @@ impl VigilApp {
                     }
                 }
             }
-            inspector::Action::None => {}
+            inspector::Action::IsolateMachine => {
+                self.response_confirm = Some(PendingResponse::IsolateMachine);
+            }
+            inspector::Action::RestoreNetwork => {
+                self.response_confirm = Some(PendingResponse::RestoreNetwork);
+            }
+            inspector::Action::KillConfirmed => {
+                self.kill_confirm = false;
+            }
+            inspector::Action::KillCancelled => {
+                self.kill_confirm = false;
+            }
         }
     }
 
@@ -823,9 +964,7 @@ impl VigilApp {
                     if ui
                         .add(
                             egui::Button::new(
-                                egui::RichText::new("Kill")
-                                    .color(theme::DANGER)
-                                    .size(11.0),
+                                egui::RichText::new("Kill").color(theme::DANGER).size(11.0),
                             )
                             .fill(theme::DANGER_BG)
                             .stroke(egui::Stroke::new(1.0, theme::DANGER))
@@ -866,6 +1005,139 @@ impl VigilApp {
                     }
                 });
             });
+    }
+
+    fn show_header(&mut self, ui: &mut egui::Ui) -> Option<inspector::Action> {
+        let mut action = None;
+        let network_busy = self.network_operation.is_some();
+
+        ui.horizontal_centered(|ui| {
+            ui.add_space(8.0);
+            if let Some(logo) = &self.vigil_logo {
+                let (logo_rect, _) =
+                    ui.allocate_exact_size(egui::vec2(24.0, 24.0), egui::Sense::hover());
+                let logo_rect = logo_rect.translate(egui::vec2(0.0, -4.0));
+                ui.painter().image(
+                    logo.id(),
+                    logo_rect,
+                    egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1.0, 1.0)),
+                    egui::Color32::WHITE,
+                );
+                ui.add_space(6.0);
+            }
+            ui.label(egui::RichText::new("Vigil").color(theme::TEXT).size(15.5).strong());
+            ui.add_space(8.0);
+
+            let admin = crate::autostart::is_elevated();
+            let (label, color, filled) = if self.paused {
+                ("Paused", theme::TEXT2, false)
+            } else {
+                ("Monitoring", theme::ACCENT, true)
+            };
+
+            ui.horizontal_wrapped(|ui| {
+                let (dot_rect, _) = ui.allocate_exact_size(egui::vec2(8.0, 8.0), egui::Sense::hover());
+                if filled {
+                    ui.painter().circle_filled(dot_rect.center(), 4.0, color);
+                } else {
+                    ui.painter()
+                        .circle_stroke(dot_rect.center(), 4.0, egui::Stroke::new(1.4, color));
+                }
+
+                ui.add_space(4.0);
+                ui.label(egui::RichText::new(label).color(color).size(11.5));
+                ui.add_space(6.0);
+
+                if admin {
+                    admin_chip(ui);
+                } else {
+                    let btn_label = "Run as Admin";
+                    let hover = "Relaunch Vigil with elevated privileges so restricted monitoring and response features are available.";
+                    let relaunch = ui
+                        .add(admin_btn(btn_label))
+                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                        .on_hover_text(hover);
+                    if relaunch.clicked() {
+                        action = Some(inspector::Action::RequestAdmin);
+                    }
+                }
+
+                if self.settings.scheduled_lockdown_enabled {
+                    let schedule_label = if self.scheduled_lockdown_active {
+                        format!(
+                            " Scheduled {:02}:{:02}-{:02}:{:02} ",
+                            self.settings.scheduled_lockdown_start_hour,
+                            self.settings.scheduled_lockdown_start_minute,
+                            self.settings.scheduled_lockdown_end_hour,
+                            self.settings.scheduled_lockdown_end_minute
+                        )
+                    } else {
+                        format!(
+                            " Schedule {:02}:{:02}-{:02}:{:02} ",
+                            self.settings.scheduled_lockdown_start_hour,
+                            self.settings.scheduled_lockdown_start_minute,
+                            self.settings.scheduled_lockdown_end_hour,
+                            self.settings.scheduled_lockdown_end_minute
+                        )
+                    };
+                    ui.label(
+                        egui::RichText::new(schedule_label)
+                            .color(if self.scheduled_lockdown_active {
+                                theme::DANGER
+                            } else {
+                                theme::TEXT2
+                            })
+                            .background_color(if self.scheduled_lockdown_active {
+                                theme::DANGER_BG
+                            } else {
+                                theme::SURFACE2
+                            })
+                            .size(10.0)
+                            .strong(),
+                    );
+                }
+
+                if self.response_status.frozen_autoruns {
+                    ui.label(
+                        egui::RichText::new(" Autoruns frozen ")
+                            .color(theme::WARN)
+                            .background_color(theme::WARN_BG)
+                            .size(10.0)
+                            .strong(),
+                    );
+                }
+            });
+
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                ui.add_space(12.0);
+
+                let btn_label = if self.paused { "Resume" } else { "Pause" };
+                let btn = egui::Button::new(
+                    egui::RichText::new(btn_label)
+                        .color(theme::TEXT2)
+                        .size(11.0),
+                )
+                .fill(theme::SURFACE2)
+                .stroke(egui::Stroke::new(1.0, theme::BORDER))
+                .corner_radius(4.0);
+                let resp = ui
+                    .add_enabled(!network_busy, btn)
+                    .on_hover_cursor(egui::CursorIcon::PointingHand);
+                let resp = if network_busy {
+                    resp.on_hover_text("A network action is already in progress.")
+                } else if self.paused {
+                    resp.on_hover_text("Resume live monitoring and detection updates.")
+                } else {
+                    resp.on_hover_text("Pause live monitoring and detection updates.")
+                };
+                if resp.clicked() {
+                    self.paused = !self.paused;
+                    self.paused_flag.store(self.paused, Ordering::Relaxed);
+                }
+            });
+        });
+
+        action
     }
 
     fn show_response_confirm_window(&mut self, ctx: &egui::Context) {
@@ -916,9 +1188,7 @@ impl VigilApp {
             ),
             PendingResponse::QuarantineProfile { proc_name, .. } => (
                 "Confirm Quarantine Profile",
-                format!(
-                    "Apply a quarantine profile to {proc_name} and tighten related controls?"
-                ),
+                format!("Apply a quarantine profile to {proc_name} and tighten related controls?"),
                 "Apply",
             ),
             PendingResponse::ClearQuarantineProfile { pid, .. } => (
@@ -974,7 +1244,7 @@ impl VigilApp {
                     .stroke(egui::Stroke::new(1.0, theme::BORDER))
                     .corner_radius(12.0),
             )
-            .show(&ctx, |ui| {
+            .show(ctx, |ui| {
                 ui.set_min_width(360.0);
                 ui.label(egui::RichText::new(body).color(theme::TEXT2).size(11.5));
                 ui.add_space(12.0);
@@ -982,7 +1252,7 @@ impl VigilApp {
                     let confirm = ui
                         .add(
                             egui::Button::new(
-                                egui::RichText::new(confirm_label.as_str())
+                                egui::RichText::new(confirm_label)
                                     .color(theme::DANGER)
                                     .size(11.0),
                             )
@@ -1409,6 +1679,224 @@ impl VigilApp {
             ui.painter().add(egui::Shape::line(points, stroke_fg));
         }
         response
+    }
+}
+
+impl eframe::App for VigilApp {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        let ctx = ui.ctx().clone();
+        self.handle_font_zoom_shortcut(&ctx);
+        self.sync_ui_scale(&ctx);
+        self.refresh_active_response_state();
+        self.poll_network_operation();
+        self.sync_tray_state();
+        self.trim_history_buffers();
+        if self.show_window.swap(false, Ordering::Relaxed) {
+            ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
+            ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
+            ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
+        }
+        if let Some(nav) = self.pending_nav.lock().unwrap().take() {
+            ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
+            ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
+            ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
+            self.active_tab = Tab::Alerts;
+            self.kill_confirm = false;
+            self.unseen_alerts = 0;
+            let _ = self.tray_tx.try_send(TrayCmd::ResetOk);
+            self.selected_alert = process_list::selection_for_pid(
+                &self.alerts,
+                nav.pid,
+                self.alerts.iter().find(|a| {
+                    a.timestamp == nav.timestamp
+                        && a.proc_name == nav.proc_name
+                        && a.remote_addr == nav.remote_addr
+                }),
+                process_list::Kind::Alerts,
+            );
+        }
+        if ctx.input(|i| i.viewport().close_requested()) && !self.exit_requested {
+            #[cfg(target_os = "linux")]
+            ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(true));
+            #[cfg(not(target_os = "linux"))]
+            ctx.send_viewport_cmd(egui::ViewportCommand::Visible(false));
+            ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose);
+        }
+        let handled_events = self.drain_events(UI_EVENT_BUDGET);
+        if handled_events {
+            ctx.request_repaint();
+        }
+        if self.active_tab == Tab::Alerts && self.unseen_alerts > 0 {
+            self.unseen_alerts = 0;
+            let _ = self.tray_tx.try_send(TrayCmd::ResetOk);
+        }
+        let header_action = egui::Panel::top("header")
+            .exact_size(48.0)
+            .frame(egui::Frame::NONE.fill(theme::SURFACE))
+            .show_inside(ui, |ui| self.show_header(ui));
+        if let Some(action) = header_action.inner {
+            self.handle_inspector_action(action, &ctx);
+        }
+        let new_tab = egui::Panel::top("tabs")
+            .exact_size(36.0)
+            .frame(egui::Frame::NONE.fill(theme::SURFACE))
+            .show_inside(ui, |ui| {
+                tab_bar::tab_bar(
+                    ui,
+                    self.active_tab,
+                    self.cached_activity_process_count,
+                    self.cached_alerts_process_count,
+                )
+            })
+            .inner;
+        if new_tab != self.active_tab {
+            self.active_tab = new_tab;
+            self.kill_confirm = false;
+        }
+        let mut inspector_action: Option<inspector::Action> = None;
+        if matches!(self.active_tab, Tab::Activity | Tab::Alerts) {
+            let selected_info: Option<&ProcessSelection> = match self.active_tab {
+                Tab::Activity => self.selected_activity.as_ref(),
+                Tab::Alerts => self.selected_alert.as_ref(),
+                _ => None,
+            };
+            let kill_confirm = self.kill_confirm;
+            inspector_action = egui::Panel::right("inspector")
+                .exact_size(320.0)
+                .resizable(false)
+                .frame(
+                    egui::Frame::NONE
+                        .fill(theme::SURFACE)
+                        .stroke(egui::Stroke::new(1.0, theme::BORDER))
+                        .inner_margin(egui::Margin::symmetric(12, 0)),
+                )
+                .show_inside(ui, |ui| inspector::show(ui, selected_info, kill_confirm))
+                .inner;
+        }
+        if let Some(action) = inspector_action {
+            self.handle_inspector_action(action, &ctx);
+        }
+        self.show_response_confirm_window(&ctx);
+        self.show_kill_confirm_window(&ctx);
+        egui::CentralPanel::default()
+            .frame(
+                egui::Frame::NONE
+                    .fill(theme::BG)
+                    .inner_margin(egui::Margin::same(12)),
+            )
+            .show_inside(ui, |ui| match self.active_tab {
+                Tab::Activity => {
+                    if activity::show(
+                        ui,
+                        &self.activity,
+                        &mut self.selected_activity,
+                        &mut self.activity_table,
+                        self.data_version,
+                        &mut self.activity_cache,
+                    ) {
+                        self.activity.clear();
+                        self.selected_activity = None;
+                    }
+                }
+                Tab::Alerts => {
+                    if alerts::show(
+                        ui,
+                        &self.alerts,
+                        &mut self.selected_alert,
+                        &mut self.alerts_table,
+                        self.data_version,
+                        &mut self.alerts_cache,
+                    ) {
+                        self.alerts.clear();
+                        self.selected_alert = None;
+                        self.unseen_alerts = 0;
+                        let _ = self.tray_tx.try_send(TrayCmd::ResetOk);
+                    }
+                }
+                Tab::Settings => {
+                    let elevated = crate::autostart::is_elevated();
+                    let changed = settings::show(ui, &mut self.settings, elevated);
+                    if self.settings.grant_capabilities_requested {
+                        self.settings.grant_capabilities_requested = false;
+                        match crate::autostart::relaunch_as_admin() {
+                            Ok(()) => {
+                                std::process::exit(0);
+                            }
+                            Err(err) => {
+                                self.push_notification(
+                                    NotificationKind::Error,
+                                    format!("Could not elevate: {err}"),
+                                );
+                            }
+                        }
+                    }
+                    if self.settings.uninstall_requested {
+                        self.settings.uninstall_requested = false;
+                        self.execute_uninstall_from_settings();
+                    }
+                    if changed {
+                        let locked_policy_changes;
+                        {
+                            let mut cfg = self.cfg.write().unwrap();
+                            locked_policy_changes =
+                                !elevated && self.settings.policy_edits_pending(&cfg);
+                            self.settings.apply_to(&mut cfg, elevated);
+                            if cfg.autostart {
+                                if crate::autostart::enable() {
+                                    cfg.autostart = true;
+                                }
+                            } else {
+                                crate::autostart::disable();
+                            }
+                            cfg.save();
+                            self.settings = settings::SettingsDraft::from_config(&cfg);
+                        }
+                        if locked_policy_changes {
+                            self.settings.status_msg = Some((
+                                "Admin Mode is required to save policy changes; only non-sensitive preferences were persisted.".into(),
+                                std::time::Instant::now(),
+                            ));
+                            self.push_notification(
+                                NotificationKind::Warning,
+                                "Policy edits require Admin Mode. Only non-sensitive preferences were saved.",
+                            );
+                        }
+                        self.sync_ui_scale(&ctx);
+                        if self.settings.status_msg.is_none() {
+                            self.settings.status_msg =
+                                Some(("Settings auto-saved.".into(), std::time::Instant::now()));
+                        }
+                    }
+                }
+                Tab::Help => help::show(ui),
+            });
+        self.show_notifications_overlay(&ctx);
+        self.show_network_operation_overlay(&ctx);
+        ctx.request_repaint_after(
+            if self.network_operation.is_some() || !self.notifications.is_empty() {
+                UI_BUSY_REPAINT
+            } else {
+                UI_IDLE_REPAINT
+            },
+        );
+    }
+
+    fn clear_color(&self, _visuals: &egui::Visuals) -> [f32; 4] {
+        [
+            0x14 as f32 / 255.0,
+            0x15 as f32 / 255.0,
+            0x1A as f32 / 255.0,
+            1.0,
+        ]
+    }
+
+    fn save(&mut self, storage: &mut dyn eframe::Storage) {
+        let state = UiState {
+            active_tab: self.active_tab,
+            activity_table: self.activity_table.clone(),
+            alerts_table: self.alerts_table.clone(),
+        };
+        eframe::set_value(storage, "ui", &state);
     }
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -9,6 +9,7 @@ pub mod alerts;
 pub mod help;
 pub mod inspector;
 pub mod process_list;
+pub mod process_list_fast;
 pub mod settings;
 pub mod tab_bar;
 pub mod theme;
@@ -642,84 +643,74 @@ impl VigilApp {
                     }
                 }
             }
-            inspector::Action::OpenLocation => {
+            inspector::Action::TrustPath => {
                 if let Some(info) = selected_info {
-                    if has_known_location(&info) {
-                        let path = std::path::Path::new(&info.proc_path);
-                        let dir = path.parent().unwrap_or(path);
-                        let _ = open::that(dir);
+                    if !has_known_location(&info) {
+                        return;
+                    }
+                    if !crate::autostart::is_elevated() {
+                        self.push_notification(
+                            NotificationKind::Error,
+                            "Admin Mode is required to trust a path.",
+                        );
+                        return;
+                    }
+                    let mut cfg = self.cfg.write().unwrap();
+                    if cfg.add_trusted_path(&info.proc_path) {
+                        cfg.save();
+                        self.settings = settings::SettingsDraft::from_config(&cfg);
                     }
                 }
             }
-            inspector::Action::Kill => self.kill_confirm = true,
-            inspector::Action::SuspendProcess => {
+            inspector::Action::KillProcess => {
+                self.kill_confirm = true;
+            }
+            inspector::Action::IgnoreRemote => {
                 if let Some(info) = selected_info {
-                    self.response_confirm = Some(PendingResponse::SuspendProcess {
-                        pid: info.pid,
-                        path: info.proc_path,
-                        proc_name: info.proc_name,
+                    self.response_confirm = Some(PendingResponse::BlockRemote {
+                        target: info.remote_addr.clone(),
+                        preset: active_response::DurationPreset::Persistent,
                     });
                 }
             }
-            inspector::Action::ResumeProcess => {
+            inspector::Action::UnignoreRemote => {
                 if let Some(info) = selected_info {
-                    self.response_confirm = Some(PendingResponse::ResumeProcess {
-                        pid: info.pid,
-                        path: info.proc_path,
-                    });
+                    self.response_confirm = Some(PendingResponse::UnblockRemote(info.remote_addr));
                 }
             }
-            inspector::Action::FreezeAutoruns => {
-                self.response_confirm = Some(PendingResponse::FreezeAutoruns)
-            }
-            inspector::Action::RevertAutoruns => {
-                self.response_confirm = Some(PendingResponse::RevertAutoruns)
-            }
-            inspector::Action::QuarantineProfile => {
+            inspector::Action::IgnoreDomain => {
                 if let Some(info) = selected_info {
-                    self.response_confirm = Some(PendingResponse::QuarantineProfile {
-                        pid: info.pid,
-                        path: info.proc_path,
-                        proc_name: info.proc_name,
-                    });
-                }
-            }
-            inspector::Action::ClearQuarantineProfile => {
-                if let Some(info) = selected_info {
-                    self.response_confirm = Some(PendingResponse::ClearQuarantineProfile {
-                        pid: info.pid,
-                        path: info.proc_path,
-                    });
-                }
-            }
-            inspector::Action::BlockRemote(preset) => {
-                if let Some(info) = selected_info {
-                    if let Some(conn) = info.selected_connection.as_ref() {
-                        if let Some(target) =
-                            active_response::extract_remote_target(&conn.remote_addr)
-                        {
-                            self.response_confirm =
-                                Some(PendingResponse::BlockRemote { target, preset });
-                        }
+                    let domain = info.selected_connection.as_ref().and_then(|c| c.hostname.clone());
+                    if let Some(domain) = domain {
+                        self.response_confirm = Some(PendingResponse::BlockDomain { domain });
                     }
                 }
             }
-            inspector::Action::BlockDomain => {
+            inspector::Action::UnignoreDomain => {
                 if let Some(info) = selected_info {
-                    if let Some(conn) = info.selected_connection.as_ref() {
-                        if let Some(domain) = active_response::extract_domain_target(conn) {
-                            self.response_confirm = Some(PendingResponse::BlockDomain { domain });
-                        }
+                    let domain = info.selected_connection.as_ref().and_then(|c| c.hostname.clone());
+                    if let Some(domain) = domain {
+                        self.response_confirm = Some(PendingResponse::UnblockDomain(domain));
                     }
                 }
             }
-            inspector::Action::BlockProcess(preset) => {
+            inspector::Action::IgnoreProcess => {
                 if let Some(info) = selected_info {
                     if has_known_location(&info) {
                         self.response_confirm = Some(PendingResponse::BlockProcess {
                             pid: info.pid,
-                            path: info.proc_path,
-                            preset,
+                            path: info.proc_path.clone(),
+                            preset: active_response::DurationPreset::Persistent,
+                        });
+                    }
+                }
+            }
+            inspector::Action::UnignoreProcess => {
+                if let Some(info) = selected_info {
+                    if has_known_location(&info) {
+                        self.response_confirm = Some(PendingResponse::UnblockProcess {
+                            pid: info.pid,
+                            path: info.proc_path.clone(),
                         });
                     }
                 }
@@ -727,608 +718,255 @@ impl VigilApp {
             inspector::Action::KillConnection => {
                 if let Some(info) = selected_info {
                     if let Some(conn) = info.selected_connection {
-                        self.response_confirm =
-                            Some(PendingResponse::KillConnection(Box::new(conn)));
+                        self.response_confirm = Some(PendingResponse::KillConnection(Box::new(conn)));
                     }
                 }
             }
-            inspector::Action::UnblockRemote => {
-                if let Some(info) = selected_info {
-                    if let Some(conn) = info.selected_connection.as_ref() {
-                        if let Some(target) =
-                            active_response::extract_remote_target(&conn.remote_addr)
-                        {
-                            self.response_confirm = Some(PendingResponse::UnblockRemote(target));
-                        }
-                    }
-                }
-            }
-            inspector::Action::UnblockDomain => {
-                if let Some(info) = selected_info {
-                    if let Some(conn) = info.selected_connection.as_ref() {
-                        if let Some(domain) = active_response::extract_domain_target(conn) {
-                            self.response_confirm = Some(PendingResponse::UnblockDomain(domain));
-                        }
-                    }
-                }
-            }
-            inspector::Action::UnblockProcess => {
+            inspector::Action::SuspendProcess => {
                 if let Some(info) = selected_info {
                     if has_known_location(&info) {
-                        self.response_confirm = Some(PendingResponse::UnblockProcess {
+                        self.response_confirm = Some(PendingResponse::SuspendProcess {
                             pid: info.pid,
-                            path: info.proc_path,
+                            path: info.proc_path.clone(),
+                            proc_name: info.proc_name.clone(),
                         });
                     }
                 }
             }
-            inspector::Action::IsolateMachine => {
-                self.start_network_operation(NetworkOperationKind::Isolate);
-            }
-            inspector::Action::RestoreNetwork => {
-                self.start_network_operation(NetworkOperationKind::Restore);
-            }
-            inspector::Action::RequestAdmin => match crate::autostart::relaunch_as_admin() {
-                Ok(()) => {
-                    // Exit immediately after spawning the elevated instance.
-                    // This avoids teardown races between egui shutdown and Tokio worker threads.
-                    std::process::exit(0);
+            inspector::Action::ResumeProcess => {
+                if let Some(info) = selected_info {
+                    if has_known_location(&info) {
+                        self.response_confirm = Some(PendingResponse::ResumeProcess {
+                            pid: info.pid,
+                            path: info.proc_path.clone(),
+                        });
+                    }
                 }
-                Err(err) => {
-                    self.push_notification(
-                        NotificationKind::Error,
-                        format!("Could not elevate: {err}"),
+            }
+            inspector::Action::FreezeAutoruns => {
+                self.response_confirm = Some(PendingResponse::FreezeAutoruns);
+            }
+            inspector::Action::RevertAutoruns => {
+                self.response_confirm = Some(PendingResponse::RevertAutoruns);
+            }
+            inspector::Action::QuarantineProfile => {
+                if let Some(info) = selected_info {
+                    if has_known_location(&info) {
+                        self.response_confirm = Some(PendingResponse::QuarantineProfile {
+                            pid: info.pid,
+                            path: info.proc_path.clone(),
+                            proc_name: info.proc_name.clone(),
+                        });
+                    }
+                }
+            }
+            inspector::Action::ClearQuarantineProfile => {
+                if let Some(info) = selected_info {
+                    if has_known_location(&info) {
+                        self.response_confirm = Some(PendingResponse::ClearQuarantineProfile {
+                            pid: info.pid,
+                            path: info.proc_path.clone(),
+                        });
+                    }
+                }
+            }
+            inspector::Action::None => {}
+        }
+    }
+
+    fn show_kill_confirm_window(&mut self, ctx: &egui::Context) {
+        let selected_info: Option<ProcessSelection> = match self.active_tab {
+            Tab::Activity => self.selected_activity.clone(),
+            Tab::Alerts => self.selected_alert.clone(),
+            _ => None,
+        };
+        if !self.kill_confirm {
+            return;
+        }
+        let Some(info) = selected_info else {
+            self.kill_confirm = false;
+            return;
+        };
+        egui::Window::new("Confirm Kill")
+            .id(egui::Id::new("kill_confirm_window"))
+            .resizable(false)
+            .collapsible(false)
+            .title_bar(true)
+            .default_width(340.0)
+            .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
+            .frame(
+                egui::Frame::NONE
+                    .fill(theme::SURFACE2)
+                    .stroke(egui::Stroke::new(1.0, theme::BORDER))
+                    .corner_radius(12.0),
+            )
+            .show(ctx, |ui| {
+                ui.set_min_width(340.0);
+                ui.label(
+                    egui::RichText::new(format!(
+                        "Kill process {} (PID {})?",
+                        info.proc_name, info.pid
+                    ))
+                    .color(theme::TEXT2)
+                    .size(11.5),
+                );
+                if !info.proc_path.is_empty() {
+                    ui.add_space(6.0);
+                    ui.label(
+                        egui::RichText::new(info.proc_path.clone())
+                            .color(theme::TEXT3)
+                            .size(10.0),
                     );
                 }
-            },
-            inspector::Action::KillConfirmed => {
-                if let Some(info) = selected_info {
-                    if !is_ghost_process_name(&info.proc_name) {
+                ui.add_space(12.0);
+                ui.horizontal(|ui| {
+                    if ui
+                        .add(
+                            egui::Button::new(
+                                egui::RichText::new("Kill")
+                                    .color(theme::DANGER)
+                                    .size(11.0),
+                            )
+                            .fill(theme::DANGER_BG)
+                            .stroke(egui::Stroke::new(1.0, theme::DANGER))
+                            .corner_radius(6.0),
+                        )
+                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                        .on_hover_text("Terminate this process immediately.")
+                        .clicked()
+                    {
                         kill_process(info.pid);
                         remove_pid(&mut self.activity, info.pid);
                         remove_pid(&mut self.alerts, info.pid);
-                        if self
-                            .selected_activity
-                            .as_ref()
-                            .is_some_and(|sel| sel.pid == info.pid)
-                        {
-                            self.selected_activity = None;
-                        }
-                        if self
-                            .selected_alert
-                            .as_ref()
-                            .is_some_and(|sel| sel.pid == info.pid)
-                        {
-                            self.selected_alert = None;
-                        }
-                        if self.alerts.is_empty() {
-                            self.unseen_alerts = 0;
-                            let _ = self.tray_tx.try_send(TrayCmd::ResetOk);
-                        }
-                    }
-                }
-                self.kill_confirm = false;
-            }
-            inspector::Action::KillCancelled => self.kill_confirm = false,
-        }
-    }
-    fn show_header(&mut self, ui: &mut egui::Ui) -> Option<inspector::Action> {
-        let mut action = None;
-        let network_busy = self.network_operation.is_some();
-
-        ui.horizontal_centered(|ui| {
-            ui.add_space(8.0);
-            if let Some(logo) = &self.vigil_logo {
-                let (logo_rect, _) =
-                    ui.allocate_exact_size(egui::vec2(24.0, 24.0), egui::Sense::hover());
-                let logo_rect = logo_rect.translate(egui::vec2(0.0, -4.0));
-                ui.painter().image(
-                    logo.id(),
-                    logo_rect,
-                    egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1.0, 1.0)),
-                    egui::Color32::WHITE,
-                );
-                ui.add_space(6.0);
-            }
-            ui.label(egui::RichText::new("Vigil").color(theme::TEXT).size(15.5).strong());
-            ui.add_space(8.0);
-
-            let admin = crate::autostart::is_elevated();
-            let (label, color, filled) = if self.paused {
-                ("Paused", theme::TEXT2, false)
-            } else {
-                ("Monitoring", theme::ACCENT, true)
-            };
-
-            ui.horizontal_wrapped(|ui| {
-                let (dot_rect, _) = ui.allocate_exact_size(egui::vec2(8.0, 8.0), egui::Sense::hover());
-                if filled {
-                    ui.painter().circle_filled(dot_rect.center(), 4.0, color);
-                } else {
-                    ui.painter()
-                        .circle_stroke(dot_rect.center(), 4.0, egui::Stroke::new(1.4, color));
-                }
-
-                ui.add_space(4.0);
-                ui.label(egui::RichText::new(label).color(color).size(11.5));
-                ui.add_space(6.0);
-
-                if admin {
-                    admin_chip(ui);
-                } else {
-                    let btn_label = "Run as Admin";
-                    let hover = "Relaunch Vigil with elevated privileges so restricted monitoring and response features are available.";
-                    let relaunch = ui
-                        .add(admin_btn(btn_label))
-                        .on_hover_cursor(egui::CursorIcon::PointingHand)
-                        .on_hover_text(hover);
-                    if relaunch.clicked() {
-                        action = Some(inspector::Action::RequestAdmin);
-                    }
-                }
-
-                if self.settings.scheduled_lockdown_enabled {
-                    let schedule_label = if self.scheduled_lockdown_active {
-                        format!(
-                            " Scheduled {:02}:{:02}-{:02}:{:02} ",
-                            self.settings.scheduled_lockdown_start_hour,
-                            self.settings.scheduled_lockdown_start_minute,
-                            self.settings.scheduled_lockdown_end_hour,
-                            self.settings.scheduled_lockdown_end_minute
-                        )
-                    } else {
-                        format!(
-                            " Schedule {:02}:{:02}-{:02}:{:02} ",
-                            self.settings.scheduled_lockdown_start_hour,
-                            self.settings.scheduled_lockdown_start_minute,
-                            self.settings.scheduled_lockdown_end_hour,
-                            self.settings.scheduled_lockdown_end_minute
-                        )
-                    };
-                    ui.label(
-                        egui::RichText::new(schedule_label)
-                            .color(if self.scheduled_lockdown_active {
-                                theme::DANGER
-                            } else {
-                                theme::TEXT2
-                            })
-                            .background_color(if self.scheduled_lockdown_active {
-                                theme::DANGER_BG
-                            } else {
-                                theme::SURFACE2
-                            })
-                            .size(10.0)
-                            .strong(),
-                    );
-                }
-
-                if self.response_status.frozen_autoruns {
-                    ui.label(
-                        egui::RichText::new(" Autoruns frozen ")
-                            .color(theme::WARN)
-                            .background_color(theme::WARN_BG)
-                            .size(10.0)
-                            .strong(),
-                    );
-                }
-            });
-
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                ui.add_space(12.0);
-
-                let btn_label = if self.paused { "Resume" } else { "Pause" };
-                let btn = egui::Button::new(
-                    egui::RichText::new(btn_label)
-                        .color(theme::TEXT2)
-                        .size(11.0),
-                )
-                .fill(theme::SURFACE2)
-                .stroke(egui::Stroke::new(1.0, theme::BORDER))
-                .corner_radius(4.0);
-                let resp = ui
-                    .add_enabled(!network_busy, btn)
-                    .on_hover_cursor(egui::CursorIcon::PointingHand);
-                let resp = if network_busy {
-                    resp.on_hover_text("A network action is already in progress.")
-                } else if self.paused {
-                    resp.on_hover_text("Resume live monitoring and detection updates.")
-                } else {
-                    resp.on_hover_text("Pause live monitoring and automatic response actions.")
-                };
-                if resp.clicked() {
-                    self.paused = !self.paused;
-                    self.paused_flag.store(self.paused, Ordering::Relaxed);
-                    if !self.paused {
-                        let _ = self.tray_tx.try_send(TrayCmd::ResetOk);
-                    }
-                }
-
-                ui.add_space(8.0);
-
-                let isolate_label = if self.response_status.isolated {
-                    "Restore Net"
-                } else {
-                    "Isolate Net"
-                };
-                let (net_fg, net_bg, net_border) = if self.response_status.isolated {
-                    (theme::ACCENT, theme::ACCENT_BG, theme::ACCENT)
-                } else {
-                    (theme::DANGER, theme::DANGER_BG, theme::DANGER)
-                };
-                let can_act = active_response::can_isolate_network();
-                let resp_btn = ui.add_enabled(
-                    can_act && !network_busy,
-                    egui::Button::new(
-                        egui::RichText::new(isolate_label)
-                            .color(net_fg)
-                            .size(11.0),
-                    )
-                    .fill(net_bg)
-                    .stroke(egui::Stroke::new(1.0, net_border))
-                    .corner_radius(4.0),
-                );
-                let resp_btn = if network_busy {
-                    resp_btn.on_hover_text("A network action is already in progress.")
-                } else if can_act {
-                    resp_btn
-                        .on_hover_cursor(egui::CursorIcon::PointingHand)
-                        .on_hover_text(if self.response_status.isolated {
-                            "Restore network connectivity and remove temporary isolation controls."
-                        } else {
-                            "Immediately isolate network traffic using active-response controls."
-                        })
-                } else {
-                    resp_btn.on_hover_text("Administrator privileges are required for network isolation.")
-                };
-                if resp_btn.clicked() {
-                    action = Some(if self.response_status.isolated {
-                        inspector::Action::RestoreNetwork
-                    } else {
-                        inspector::Action::IsolateMachine
-                    });
-                }
-            });
-        });
-        action
-    }
-}
-
-impl eframe::App for VigilApp {
-    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        let ctx = ui.ctx().clone();
-        self.handle_font_zoom_shortcut(&ctx);
-        self.sync_ui_scale(&ctx);
-        self.refresh_active_response_state();
-        self.poll_network_operation();
-        self.sync_tray_state();
-        self.trim_history_buffers();
-        if self.show_window.swap(false, Ordering::Relaxed) {
-            ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
-            ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
-            ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
-        }
-        if let Some(nav) = self.pending_nav.lock().unwrap().take() {
-            ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
-            ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
-            ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
-            self.active_tab = Tab::Alerts;
-            self.kill_confirm = false;
-            self.unseen_alerts = 0;
-            let _ = self.tray_tx.try_send(TrayCmd::ResetOk);
-            self.selected_alert = process_list::selection_for_pid(
-                &self.alerts,
-                nav.pid,
-                self.alerts.iter().find(|a| {
-                    a.timestamp == nav.timestamp
-                        && a.proc_name == nav.proc_name
-                        && a.remote_addr == nav.remote_addr
-                }),
-                process_list::Kind::Alerts,
-            );
-        }
-        if ctx.input(|i| i.viewport().close_requested()) && !self.exit_requested {
-            #[cfg(target_os = "linux")]
-            ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(true));
-            #[cfg(not(target_os = "linux"))]
-            ctx.send_viewport_cmd(egui::ViewportCommand::Visible(false));
-            ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose);
-        }
-        let handled_events = self.drain_events(UI_EVENT_BUDGET);
-        if handled_events {
-            ctx.request_repaint();
-        }
-        if self.active_tab == Tab::Alerts && self.unseen_alerts > 0 {
-            self.unseen_alerts = 0;
-            let _ = self.tray_tx.try_send(TrayCmd::ResetOk);
-        }
-        let header_action = egui::Panel::top("header")
-            .exact_size(48.0)
-            .frame(egui::Frame::NONE.fill(theme::SURFACE))
-            .show_inside(ui, |ui| self.show_header(ui));
-        if let Some(action) = header_action.inner {
-            self.handle_inspector_action(action, &ctx);
-        }
-        let new_tab = egui::Panel::top("tabs")
-            .exact_size(36.0)
-            .frame(egui::Frame::NONE.fill(theme::SURFACE))
-            .show_inside(ui, |ui| {
-                tab_bar::tab_bar(
-                    ui,
-                    self.active_tab,
-                    self.cached_activity_process_count,
-                    self.cached_alerts_process_count,
-                )
-            })
-            .inner;
-        if new_tab != self.active_tab {
-            self.active_tab = new_tab;
-            self.kill_confirm = false;
-        }
-        let mut inspector_action: Option<inspector::Action> = None;
-        if matches!(self.active_tab, Tab::Activity | Tab::Alerts) {
-            let selected_info: Option<&ProcessSelection> = match self.active_tab {
-                Tab::Activity => self.selected_activity.as_ref(),
-                Tab::Alerts => self.selected_alert.as_ref(),
-                _ => None,
-            };
-            let kill_confirm = self.kill_confirm;
-            inspector_action = egui::Panel::right("inspector")
-                .exact_size(320.0)
-                .resizable(false)
-                .frame(
-                    egui::Frame::NONE
-                        .fill(theme::SURFACE)
-                        .stroke(egui::Stroke::new(1.0, theme::BORDER))
-                        .inner_margin(egui::Margin::symmetric(12, 0)),
-                )
-                .show_inside(ui, |ui| inspector::show(ui, selected_info, kill_confirm))
-                .inner;
-        }
-        if let Some(action) = inspector_action {
-            self.handle_inspector_action(action, &ctx);
-        }
-        self.show_response_confirm(ctx.clone());
-        egui::CentralPanel::default()
-            .frame(
-                egui::Frame::NONE
-                    .fill(theme::BG)
-                    .inner_margin(egui::Margin::same(12)),
-            )
-            .show_inside(ui, |ui| match self.active_tab {
-                Tab::Activity => {
-                    if activity::show(
-                        ui,
-                        &self.activity,
-                        &mut self.selected_activity,
-                        &mut self.activity_table,
-                        self.data_version,
-                        &mut self.activity_cache,
-                    ) {
-                        self.activity.clear();
                         self.selected_activity = None;
-                    }
-                }
-                Tab::Alerts => {
-                    if alerts::show(
-                        ui,
-                        &self.alerts,
-                        &mut self.selected_alert,
-                        &mut self.alerts_table,
-                        self.data_version,
-                        &mut self.alerts_cache,
-                    ) {
-                        self.alerts.clear();
                         self.selected_alert = None;
-                        self.unseen_alerts = 0;
-                        let _ = self.tray_tx.try_send(TrayCmd::ResetOk);
+                        self.cached_activity_process_count =
+                            process_list::count_distinct_processes(&self.activity);
+                        self.cached_alerts_process_count =
+                            process_list::count_distinct_processes(&self.alerts);
+                        self.activity_cache = None;
+                        self.alerts_cache = None;
+                        self.data_version = self.data_version.wrapping_add(1);
+                        self.kill_confirm = false;
                     }
-                }
-                Tab::Settings => {
-                    let elevated = crate::autostart::is_elevated();
-                    let changed = settings::show(ui, &mut self.settings, elevated);
-                    if self.settings.grant_capabilities_requested {
-                        self.settings.grant_capabilities_requested = false;
-                        match crate::autostart::relaunch_as_admin() {
-                            Ok(()) => {
-                                std::process::exit(0);
-                            }
-                            Err(err) => {
-                                self.push_notification(
-                                    NotificationKind::Error,
-                                    format!("Could not elevate: {err}"),
-                                );
-                            }
-                        }
+                    if ui
+                        .add(
+                            egui::Button::new(
+                                egui::RichText::new("Cancel").color(theme::TEXT2).size(11.0),
+                            )
+                            .fill(theme::SURFACE3)
+                            .stroke(egui::Stroke::new(1.0, theme::BORDER))
+                            .corner_radius(6.0),
+                        )
+                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                        .on_hover_text("Close this dialog without killing the process.")
+                        .clicked()
+                    {
+                        self.kill_confirm = false;
                     }
-                    if self.settings.uninstall_requested {
-                        self.settings.uninstall_requested = false;
-                        self.execute_uninstall_from_settings();
-                    }
-                    if changed {
-                        let locked_policy_changes;
-                        {
-                            let mut cfg = self.cfg.write().unwrap();
-                            locked_policy_changes =
-                                !elevated && self.settings.policy_edits_pending(&cfg);
-                            self.settings.apply_to(&mut cfg, elevated);
-                            if cfg.autostart {
-                                if crate::autostart::enable() {
-                                    cfg.autostart = true;
-                                }
-                            } else {
-                                crate::autostart::disable();
-                            }
-                            cfg.save();
-                            self.settings = settings::SettingsDraft::from_config(&cfg);
-                        }
-                        if locked_policy_changes {
-                            self.settings.status_msg = Some((
-                                "Admin Mode is required to save policy changes; only non-sensitive preferences were persisted.".into(),
-                                std::time::Instant::now(),
-                            ));
-                            self.push_notification(
-                                NotificationKind::Warning,
-                                "Policy edits require Admin Mode. Only non-sensitive preferences were saved.",
-                            );
-                        }
-                        self.sync_ui_scale(&ctx);
-                        if self.settings.status_msg.is_none() {
-                            self.settings.status_msg =
-                                Some(("Settings auto-saved.".into(), std::time::Instant::now()));
-                        }
-                    }
-                }
-                Tab::Help => help::show(ui),
+                });
             });
-        self.show_notifications_overlay(&ctx);
-        self.show_network_operation_overlay(&ctx);
-        ctx.request_repaint_after(
-            if self.network_operation.is_some() || !self.notifications.is_empty() {
-                UI_BUSY_REPAINT
-            } else {
-                UI_IDLE_REPAINT
-            },
-        );
     }
-    fn clear_color(&self, _visuals: &egui::Visuals) -> [f32; 4] {
-        [
-            0x14 as f32 / 255.0,
-            0x15 as f32 / 255.0,
-            0x1A as f32 / 255.0,
-            1.0,
-        ]
-    }
-    fn save(&mut self, storage: &mut dyn eframe::Storage) {
-        let state = UiState {
-            active_tab: self.active_tab,
-            activity_table: self.activity_table.clone(),
-            alerts_table: self.alerts_table.clone(),
-        };
-        eframe::set_value(storage, "ui", &state);
-    }
-}
 
-fn admin_chip(ui: &mut egui::Ui) {
-    ui.label(
-        egui::RichText::new(" Admin Mode ")
-            .color(theme::ACCENT)
-            .background_color(theme::ACCENT_BG)
-            .size(10.5)
-            .strong(),
-    );
-}
-fn admin_btn(text: &str) -> egui::Button<'_> {
-    egui::Button::new(egui::RichText::new(text).color(theme::ACCENT).size(11.0))
-        .fill(theme::ACCENT_BG)
-        .stroke(egui::Stroke::new(1.0, theme::ACCENT))
-        .corner_radius(4.0)
-}
-
-impl VigilApp {
-    fn sync_tray_state(&mut self) {
-        let isolated = self.response_status.isolated;
-        if isolated != self.tray_lockdown_sent
-            && self
-                .tray_tx
-                .try_send(TrayCmd::SetLockdown(isolated))
-                .is_ok()
-        {
-            self.tray_lockdown_sent = isolated;
-        }
-    }
-    fn refresh_active_response_state(&mut self) {
-        if let Some(rx) = self.reconcile_rx.as_ref() {
-            match rx.try_recv() {
-                Ok(status) => {
-                    self.response_status = status;
-                    self.reconcile_rx = None;
-                }
-                Err(mpsc::TryRecvError::Disconnected) => {
-                    self.reconcile_rx = None;
-                }
-                Err(mpsc::TryRecvError::Empty) => {}
-            }
-        }
-        if self.last_response_reconcile.elapsed().as_secs() >= 1 {
-            if self.reconcile_rx.is_none() {
-                let (tx, rx) = mpsc::channel();
-                match std::thread::Builder::new()
-                    .name("vigil-active-response-reconcile".into())
-                    .spawn(move || {
-                        active_response::reconcile();
-                        let _ = tx.send(active_response::status());
-                    }) {
-                    Ok(_) => {
-                        self.reconcile_rx = Some(rx);
-                    }
-                    Err(err) => {
-                        self.push_notification(
-                            NotificationKind::Error,
-                            format!("Could not start reconcile worker: {err}"),
-                        );
-                    }
-                }
-            }
-            self.last_response_reconcile = std::time::Instant::now();
-        }
-        if self.last_schedule_check.elapsed().as_secs() >= 30 {
-            self.apply_scheduled_lockdown();
-            self.last_schedule_check = std::time::Instant::now();
-        }
-    }
-    fn apply_scheduled_lockdown(&mut self) {
-        if self.network_operation.is_some() {
-            return;
-        }
-        let cfg = self.cfg.read().unwrap().clone();
-        if !cfg.scheduled_lockdown_enabled {
-            self.scheduled_lockdown_active = false;
-            return;
-        }
-        if !active_response::can_isolate_network() {
-            return;
-        }
-        let now = Local::now();
-        let minute_of_day = now.hour() * 60 + now.minute();
-        let start = u32::from(cfg.scheduled_lockdown_start_hour.min(23)) * 60
-            + u32::from(cfg.scheduled_lockdown_start_minute.min(59));
-        let end = u32::from(cfg.scheduled_lockdown_end_hour.min(23)) * 60
-            + u32::from(cfg.scheduled_lockdown_end_minute.min(59));
-        let should_lock = if start == end {
-            false
-        } else if start < end {
-            minute_of_day >= start && minute_of_day < end
-        } else {
-            minute_of_day >= start || minute_of_day < end
-        };
-        if should_lock && !self.scheduled_lockdown_active {
-            if self.start_network_operation(NetworkOperationKind::Isolate) {
-                self.scheduled_target = Some(true);
-                self.push_notification(
-                    NotificationKind::Info,
-                    "Scheduled lockdown started: isolating network…",
-                );
-            }
-        } else if !should_lock
-            && self.scheduled_lockdown_active
-            && self.start_network_operation(NetworkOperationKind::Restore)
-        {
-            self.scheduled_target = Some(false);
-            self.push_notification(
-                NotificationKind::Info,
-                "Scheduled lockdown window ended: restoring network…",
-            );
-        }
-    }
-    fn show_response_confirm(&mut self, ctx: egui::Context) {
+    fn show_response_confirm_window(&mut self, ctx: &egui::Context) {
         let Some(pending) = self.response_confirm.clone() else {
             return;
         };
-        let (title, body, confirm_label)=match &pending { PendingResponse::BlockRemote { target, preset } => { let (duration,label)=match preset { active_response::DurationPreset::OneHour => ("1 hour","Block 1h"), active_response::DurationPreset::OneDay => ("24 hours","Block 24h"), active_response::DurationPreset::Permanent => ("an unlimited duration","Block permanent") }; ("Block remote IP", format!("Temporarily block outbound traffic to {target} for {duration}?"), label.to_string()) } PendingResponse::BlockDomain { domain } => ("Block domain", format!("Redirect {domain} to the local machine through the Windows hosts file?"), "Block domain".to_string()), PendingResponse::BlockProcess { path, preset, .. } => { let (duration,label)=match preset { active_response::DurationPreset::OneHour => ("1 hour","Block process"), active_response::DurationPreset::OneDay => ("24 hours","Block process"), active_response::DurationPreset::Permanent => ("an unlimited duration","Block process") }; ("Block process", format!("Temporarily block inbound and outbound traffic for {path} for {duration}?"), label.to_string()) } PendingResponse::SuspendProcess { pid, path, .. } => ("Suspend process", if path.is_empty() { format!("Freeze PID {pid} until you explicitly resume it?") } else { format!("Freeze PID {pid} ({path}) until you explicitly resume it?") }, "Suspend".to_string()), PendingResponse::ResumeProcess { pid, path } => ("Resume process", if path.is_empty() { format!("Resume every suspended thread in PID {pid}?") } else { format!("Resume every suspended thread in PID {pid} ({path})?") }, "Resume".to_string()), PendingResponse::FreezeAutoruns => ("Freeze autoruns", "Capture the current Run and RunOnce autorun keys as a baseline so Vigil can later remove additions and restore baseline values.".to_string(), "Freeze".to_string()), PendingResponse::RevertAutoruns => ("Revert autoruns", "Remove autorun entries added after the baseline and restore any baseline Run / RunOnce values that changed?".to_string(), "Revert".to_string()), PendingResponse::QuarantineProfile { pid, path, .. } => ("Quarantine profile", if path.is_empty() { format!("Apply the quarantine preset to PID {pid}? This isolates the network and suspends the process when possible.") } else { format!("Apply the quarantine preset to PID {pid} ({path})? This isolates the network, blocks the executable path, and suspends the process when possible.") }, "Quarantine".to_string()), PendingResponse::ClearQuarantineProfile { pid, path } => ("Clear quarantine", if path.is_empty() { format!("Undo the quarantine preset for PID {pid}? This restores the network and resumes the process when possible.") } else { format!("Undo the quarantine preset for PID {pid} ({path})? This restores the network, removes the process block, and resumes the process when possible.") }, "Clear".to_string()), PendingResponse::KillConnection(conn) => ("Kill connection", format!("Immediately terminate the live TCP connection {} -> {}?", conn.local_addr, conn.remote_addr), "Kill connection".to_string()), PendingResponse::UnblockRemote(target) => ("Remove remote block", format!("Remove the temporary firewall rule for {target}?"), "Unblock".to_string()), PendingResponse::UnblockDomain(domain) => ("Remove domain block", format!("Remove the local hosts-file block for {domain}?"), "Unblock domain".to_string()), PendingResponse::UnblockProcess { path, .. } => ("Remove process block", format!("Remove the temporary firewall rules for {path}?"), "Unblock".to_string()), PendingResponse::IsolateMachine => ("Isolate machine", "Temporarily block inbound and outbound traffic with reversible firewall rules.".to_string(), "Isolate".to_string()), PendingResponse::RestoreNetwork => ("Restore network", "Remove the temporary network-isolation firewall rules?".to_string(), "Restore".to_string()) };
+        let (title, body, confirm_label) = match &pending {
+            PendingResponse::BlockRemote { target, preset } => (
+                "Confirm Remote Block",
+                format!(
+                    "Block outbound network access to {target} for the {} duration?",
+                    preset.label()
+                ),
+                "Block",
+            ),
+            PendingResponse::BlockDomain { domain } => (
+                "Confirm Domain Block",
+                format!("Block domain {domain} until you remove it from Active Response?"),
+                "Block",
+            ),
+            PendingResponse::BlockProcess { path, preset, .. } => (
+                "Confirm Process Block",
+                format!(
+                    "Block process path {path} for the {} duration?",
+                    preset.label()
+                ),
+                "Block",
+            ),
+            PendingResponse::SuspendProcess { pid, proc_name, .. } => (
+                "Confirm Process Suspend",
+                format!("Suspend {proc_name} (PID {pid}) until you resume it?"),
+                "Suspend",
+            ),
+            PendingResponse::ResumeProcess { pid, .. } => (
+                "Confirm Process Resume",
+                format!("Resume PID {pid} if it is currently suspended?"),
+                "Resume",
+            ),
+            PendingResponse::FreezeAutoruns => (
+                "Confirm Autorun Freeze",
+                "Temporarily disable startup persistence entries until you revert them?".into(),
+                "Freeze",
+            ),
+            PendingResponse::RevertAutoruns => (
+                "Confirm Autorun Restore",
+                "Restore previously disabled startup persistence entries?".into(),
+                "Restore",
+            ),
+            PendingResponse::QuarantineProfile { proc_name, .. } => (
+                "Confirm Quarantine Profile",
+                format!(
+                    "Apply a quarantine profile to {proc_name} and tighten related controls?"
+                ),
+                "Apply",
+            ),
+            PendingResponse::ClearQuarantineProfile { pid, .. } => (
+                "Confirm Quarantine Clear",
+                format!("Remove quarantine profile controls for PID {pid}?"),
+                "Clear",
+            ),
+            PendingResponse::KillConnection(conn) => (
+                "Confirm Connection Kill",
+                format!(
+                    "Force-close the live connection from {} to {}?",
+                    conn.local_addr, conn.remote_addr
+                ),
+                "Kill",
+            ),
+            PendingResponse::UnblockRemote(target) => (
+                "Confirm Remote Unblock",
+                format!("Remove the remote block for {target}?"),
+                "Unblock",
+            ),
+            PendingResponse::UnblockDomain(domain) => (
+                "Confirm Domain Unblock",
+                format!("Remove the domain block for {domain}?"),
+                "Unblock",
+            ),
+            PendingResponse::UnblockProcess { path, .. } => (
+                "Confirm Process Unblock",
+                format!("Remove the process block for {path}?"),
+                "Unblock",
+            ),
+            PendingResponse::IsolateMachine => (
+                "Confirm Isolation",
+                "Disconnect this machine from the network except for approved exceptions?".into(),
+                "Isolate",
+            ),
+            PendingResponse::RestoreNetwork => (
+                "Confirm Network Restore",
+                "Restore normal network access for this machine?".into(),
+                "Restore",
+            ),
+        };
+
         egui::Window::new(title)
-            .id(egui::Id::new("active_response_confirm"))
-            .collapsible(false)
+            .id(egui::Id::new("response_confirm_window"))
             .resizable(false)
+            .collapsible(false)
+            .title_bar(true)
+            .default_width(360.0)
             .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
             .frame(
                 egui::Frame::NONE

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -578,8 +578,18 @@ impl VigilApp {
     }
     fn trim_history_buffers(&mut self) {
         let (activity_cap, alerts_cap) = self.history_caps();
+        let mut trimmed = false;
+        if self.activity.len() > activity_cap {
+            trimmed = true;
+        }
         truncate_deque(&mut self.activity, activity_cap);
+        if self.alerts.len() > alerts_cap {
+            trimmed = true;
+        }
         truncate_deque(&mut self.alerts, alerts_cap);
+        if trimmed {
+            self.data_version = self.data_version.wrapping_add(1);
+        }
     }
 
     fn sync_tray_state(&mut self) {

--- a/src/ui/process_list.rs
+++ b/src/ui/process_list.rs
@@ -3,6 +3,7 @@
 //! One process becomes one card. Each card shows summary metadata up top and
 //! then groups repeated sockets by remote endpoint so the UI stays useful even
 //! when a process opens many connections to the same destination.
+#![allow(dead_code)]
 
 use crate::types::ConnInfo;
 use crate::ui::{theme, ProcessSelection, TableState};

--- a/src/ui/process_list_fast.rs
+++ b/src/ui/process_list_fast.rs
@@ -1,0 +1,763 @@
+//! Faster cached renderer for the process-grouped Activity and Alerts tabs.
+//!
+//! The existing `process_list` module exposes the public cache metadata type that
+//! the rest of the UI already stores. This module keeps the same cache contract
+//! but adds an internal owned render-model cache so normal repaints reuse grouped
+//! process and endpoint rows instead of rebuilding them every frame.
+
+use crate::types::ConnInfo;
+use crate::ui::{process_list, theme, ProcessSelection, TableState};
+use egui::RichText;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::{Mutex, OnceLock};
+
+pub type CachedGroupView = process_list::CachedGroupView;
+
+const CONN_TIME_W: f32 = 84.0;
+const CONN_REMOTE_W: f32 = 216.0;
+const CONN_STATUS_W: f32 = 132.0;
+const CONN_SCORE_W: f32 = 44.0;
+const CONN_BADGE_GAP: f32 = 8.0;
+const SUMMARY_H: f32 = 60.0;
+const MAX_RENDER_CACHE_ENTRIES: usize = 8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Kind {
+    Activity,
+    Alerts,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct RenderKey {
+    kind: Kind,
+    data_version: u64,
+    filter_hash: u64,
+    sort_col: usize,
+    sort_asc: bool,
+}
+
+#[derive(Debug, Clone)]
+struct OwnedRenderView {
+    total_connections: usize,
+    total_groups: usize,
+    total_endpoints: usize,
+    process_count: usize,
+    groups: Vec<OwnedProcessGroup>,
+}
+
+#[derive(Debug, Clone)]
+struct OwnedProcessGroup {
+    pid: u32,
+    proc_name: String,
+    proc_path: String,
+    proc_user: String,
+    parent_user: String,
+    command_line: String,
+    parent_name: String,
+    parent_pid: u32,
+    service_name: String,
+    publisher: String,
+    latest_timestamp: String,
+    latest_status: String,
+    latest_remote: String,
+    score: u8,
+    conn_count: usize,
+    distinct_ports: usize,
+    distinct_remotes: usize,
+    statuses: Vec<String>,
+    reasons: Vec<String>,
+    attack_tags: Vec<String>,
+    baseline_deviation: bool,
+    script_host_suspicious: bool,
+    tls_enriched: bool,
+    endpoint_rows: Vec<OwnedEndpointRow>,
+}
+
+#[derive(Debug, Clone)]
+struct OwnedEndpointRow {
+    representative: ConnInfo,
+    latest_timestamp: String,
+    remote_addr: String,
+    conn_count: usize,
+    local_port_count: usize,
+    statuses: Vec<String>,
+    status_summary: String,
+    max_score: u8,
+    pre_login: bool,
+    reputation_hit: bool,
+    recently_dropped: bool,
+    long_lived: bool,
+    dga_like: bool,
+    script_host_suspicious: bool,
+    baseline_deviation: bool,
+    tls_enriched: bool,
+}
+
+#[derive(Default)]
+struct ProcessAccumulator {
+    pid: u32,
+    proc_name: String,
+    proc_path: String,
+    proc_user: String,
+    parent_user: String,
+    command_line: String,
+    parent_name: String,
+    parent_pid: u32,
+    service_name: String,
+    publisher: String,
+    latest_timestamp: String,
+    latest_status: String,
+    latest_remote: String,
+    score: u8,
+    conn_count: usize,
+    distinct_ports: HashSet<u16>,
+    distinct_remotes: HashSet<String>,
+    statuses: Vec<String>,
+    reasons: Vec<String>,
+    attack_tags: Vec<String>,
+    baseline_deviation: bool,
+    script_host_suspicious: bool,
+    tls_enriched: bool,
+    endpoints: HashMap<String, EndpointAccumulator>,
+}
+
+#[derive(Default)]
+struct EndpointAccumulator {
+    representative: Option<ConnInfo>,
+    latest_timestamp: String,
+    remote_addr: String,
+    conn_count: usize,
+    local_ports: HashSet<String>,
+    statuses: Vec<String>,
+    max_score: u8,
+    pre_login: bool,
+    reputation_hit: bool,
+    recently_dropped: bool,
+    long_lived: bool,
+    dga_like: bool,
+    script_host_suspicious: bool,
+    baseline_deviation: bool,
+    tls_enriched: bool,
+}
+
+fn render_cache() -> &'static Mutex<HashMap<RenderKey, OwnedRenderView>> {
+    static CACHE: OnceLock<Mutex<HashMap<RenderKey, OwnedRenderView>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[allow(deprecated)]
+pub fn show(
+    ui: &mut egui::Ui,
+    rows: &VecDeque<ConnInfo>,
+    selected: &mut Option<ProcessSelection>,
+    state: &mut TableState,
+    kind: Kind,
+    data_version: u64,
+    cache: &mut Option<CachedGroupView>,
+) -> bool {
+    ui.add_space(4.0);
+    filter_bar(ui, rows.len(), state, kind);
+
+    let filter_hash = calc_filter_hash(&state.filter);
+    let key = RenderKey {
+        kind,
+        data_version,
+        filter_hash,
+        sort_col: state.sort_col,
+        sort_asc: state.sort_asc,
+    };
+
+    let view = {
+        let mut store = render_cache().lock().unwrap();
+        if let Some(view) = store.get(&key).cloned() {
+            *cache = Some(CachedGroupView {
+                data_version,
+                filter_hash,
+                sort_col: state.sort_col,
+                sort_asc: state.sort_asc,
+                total_connections: view.total_connections,
+                total_groups: view.total_groups,
+                total_endpoints: view.total_endpoints,
+                process_count: view.process_count,
+            });
+            view
+        } else {
+            let rebuilt = build_view(rows, &state.filter, kind, state.sort_col, state.sort_asc);
+            *cache = Some(CachedGroupView {
+                data_version,
+                filter_hash,
+                sort_col: state.sort_col,
+                sort_asc: state.sort_asc,
+                total_connections: rebuilt.total_connections,
+                total_groups: rebuilt.total_groups,
+                total_endpoints: rebuilt.total_endpoints,
+                process_count: rebuilt.process_count,
+            });
+            if store.len() >= MAX_RENDER_CACHE_ENTRIES {
+                store.clear();
+            }
+            store.insert(key, rebuilt.clone());
+            rebuilt
+        }
+    };
+
+    ui.add_space(8.0);
+    header_row(ui, state);
+    ui.add_space(8.0);
+
+    egui::ScrollArea::vertical()
+        .id_salt(match kind {
+            Kind::Activity => "activity_groups_fast",
+            Kind::Alerts => "alerts_groups_fast",
+        })
+        .show(ui, |ui| {
+            if view.groups.is_empty() {
+                empty_state(ui, kind);
+                return;
+            }
+
+            for group in &view.groups {
+                let selected_in_group = selected.as_ref().is_some_and(|sel| sel.pid == group.pid);
+                let collapsed = state.is_collapsed(group.pid);
+                let frame_fill = if selected_in_group { theme::SURFACE3 } else { theme::SURFACE };
+
+                egui::Frame::NONE
+                    .fill(frame_fill)
+                    .stroke(egui::Stroke::new(1.0, theme::BORDER))
+                    .corner_radius(12.0)
+                    .inner_margin(egui::Margin::same(14))
+                    .show(ui, |ui| {
+                        let (summary_rect, summary_resp) = ui.allocate_exact_size(
+                            egui::vec2(ui.available_width(), SUMMARY_H),
+                            egui::Sense::click(),
+                        );
+                        let summary_fill = if selected_in_group { theme::SURFACE3 } else { theme::SURFACE2 };
+                        ui.painter().rect_filled(summary_rect.shrink2(egui::vec2(0.0, 1.0)), 10.0, summary_fill);
+                        ui.painter().rect_stroke(
+                            summary_rect.shrink2(egui::vec2(0.0, 1.0)),
+                            10.0,
+                            egui::Stroke::new(1.0, theme::BORDER),
+                            egui::StrokeKind::Outside,
+                        );
+
+                        ui.allocate_ui_at_rect(summary_rect.shrink2(egui::vec2(12.0, 8.0)), |ui| {
+                            ui.horizontal(|ui| {
+                                let (bar_rect, bar_resp) = ui.allocate_exact_size(
+                                    egui::vec2(4.0, 40.0),
+                                    egui::Sense::click(),
+                                );
+                                ui.painter().rect_filled(
+                                    bar_rect,
+                                    2.0,
+                                    if collapsed { theme::TEXT3 } else { summary_bar_color(group.score, kind) },
+                                );
+                                if bar_resp.on_hover_cursor(egui::CursorIcon::PointingHand)
+                                    .on_hover_text(if collapsed { "Expand this process card" } else { "Collapse this process card" })
+                                    .clicked()
+                                {
+                                    state.toggle_collapsed(group.pid);
+                                }
+                                ui.add_space(12.0);
+
+                                ui.vertical(|ui| {
+                                    ui.horizontal_wrapped(|ui| {
+                                        ui.label(RichText::new(&group.proc_name).color(theme::TEXT).size(14.0).strong().monospace());
+                                        ui.label(RichText::new(format!("PID {}", group.pid)).color(theme::TEXT3).size(10.0).monospace());
+                                        pill(ui, &format!("{} socket{}", group.conn_count, plural(group.conn_count)), theme::TEXT2, theme::SURFACE2);
+                                        pill(ui, &format!("{} endpoint{}", group.endpoint_rows.len(), plural(group.endpoint_rows.len())), theme::TEXT2, theme::SURFACE2);
+                                        if group.script_host_suspicious {
+                                            pill(ui, "Script host", theme::WARN, theme::WARN_BG);
+                                        }
+                                        if group.baseline_deviation {
+                                            pill(ui, "Baseline drift", theme::ACCENT, theme::ACCENT_BG);
+                                        }
+                                        if group.tls_enriched {
+                                            pill(ui, "TLS", theme::ACCENT, theme::ACCENT_BG);
+                                        }
+                                    });
+                                    ui.add_space(2.0);
+                                    ui.label(RichText::new(process_meta_line(group)).color(theme::TEXT2).size(10.4));
+                                    if !group.statuses.is_empty() {
+                                        ui.label(RichText::new(format!("States seen: {}", group.statuses.join(", "))).color(theme::TEXT3).size(10.0));
+                                    }
+                                });
+
+                                ui.with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {
+                                    let (fg, bg) = theme::score_colors(group.score);
+                                    ui.label(RichText::new(format!("{:>2}", group.score)).color(fg).background_color(bg).monospace().size(11.5));
+                                    ui.add_space(10.0);
+                                    ui.label(RichText::new(&group.latest_timestamp).color(theme::TEXT2).size(10.2));
+                                });
+                            });
+                        });
+
+                        if summary_resp.on_hover_cursor(egui::CursorIcon::PointingHand)
+                            .on_hover_text("Select this process card to inspect process-level details.")
+                            .clicked()
+                        {
+                            *selected = Some(selection_from_group(group, None));
+                        }
+
+                        if !collapsed {
+                            ui.add_space(10.0);
+                            ui.separator();
+                            ui.add_space(8.0);
+                            for endpoint in &group.endpoint_rows {
+                                let conn_selected = selected.as_ref()
+                                    .and_then(|sel| sel.selected_connection.as_ref())
+                                    .is_some_and(|sel_conn| crate::ui::conn_matches_selection(&endpoint.representative, Some(sel_conn)));
+                                if let Some(clicked) = endpoint_line(ui, endpoint, kind, conn_selected) {
+                                    *selected = Some(selection_from_group(group, Some(clicked)));
+                                }
+                                ui.add_space(6.0);
+                            }
+                        } else {
+                            ui.add_space(8.0);
+                            ui.label(RichText::new(format!("{} endpoint row{} hidden", group.endpoint_rows.len(), plural(group.endpoint_rows.len()))).color(theme::TEXT3).size(10.2));
+                        }
+                    });
+                ui.add_space(10.0);
+            }
+
+            let footer = match kind {
+                Kind::Activity => format!("{} processes / {} sockets / {} endpoint rows", view.total_groups, view.total_connections, view.total_endpoints),
+                Kind::Alerts => format!("{} alerting processes / {} sockets / {} endpoint rows", view.total_groups, view.total_connections, view.total_endpoints),
+            };
+            ui.add_space(4.0);
+            ui.label(RichText::new(footer).color(theme::TEXT3).size(10.5));
+        });
+
+    false
+}
+
+fn build_view(
+    rows: &VecDeque<ConnInfo>,
+    filter: &str,
+    kind: Kind,
+    sort_col: usize,
+    sort_asc: bool,
+) -> OwnedRenderView {
+    let lower = filter.to_ascii_lowercase();
+    let mut groups: HashMap<u32, ProcessAccumulator> = HashMap::new();
+    let mut order = Vec::new();
+
+    for info in rows.iter().filter(|r| matches_filter(r, &lower, kind)) {
+        let entry = groups.entry(info.pid).or_insert_with(|| {
+            order.push(info.pid);
+            ProcessAccumulator {
+                pid: info.pid,
+                proc_name: info.proc_name.clone(),
+                proc_path: info.proc_path.clone(),
+                proc_user: info.proc_user.clone(),
+                parent_user: info.parent_user.clone(),
+                command_line: info.command_line.clone(),
+                parent_name: info.parent_name.clone(),
+                parent_pid: info.parent_pid,
+                service_name: info.service_name.clone(),
+                publisher: info.publisher.clone(),
+                latest_timestamp: info.timestamp.clone(),
+                latest_status: info.status.clone(),
+                latest_remote: info.remote_addr.clone(),
+                score: info.score,
+                ..Default::default()
+            }
+        });
+        entry.conn_count += 1;
+        entry.score = entry.score.max(info.score);
+        if info.timestamp >= entry.latest_timestamp {
+            entry.latest_timestamp = info.timestamp.clone();
+            entry.latest_status = info.status.clone();
+            entry.latest_remote = info.remote_addr.clone();
+        }
+        if info.remote_addr != "LISTEN" {
+            entry.distinct_remotes.insert(info.remote_addr.clone());
+        }
+        if let Some(port) = parse_port(&info.remote_addr) {
+            entry.distinct_ports.insert(port);
+        }
+        push_unique(&mut entry.statuses, info.status.clone());
+        entry.reasons.extend(info.reasons.iter().cloned());
+        entry.attack_tags.extend(info.attack_tags.iter().cloned());
+        entry.baseline_deviation |= info.baseline_deviation;
+        entry.script_host_suspicious |= info.script_host_suspicious;
+        entry.tls_enriched |= info.tls_sni.is_some() || info.tls_ja3.is_some();
+        entry.endpoints.entry(endpoint_key(info)).or_default().add(info);
+    }
+
+    let mut out_groups = Vec::new();
+    for pid in order {
+        if let Some(group) = groups.remove(&pid) {
+            let mut endpoint_rows: Vec<OwnedEndpointRow> = group.endpoints.into_values().map(EndpointAccumulator::finish).collect();
+            sort_endpoint_rows(&mut endpoint_rows, sort_col, sort_asc);
+            let mut reasons = dedup_strings(group.reasons);
+            let attack_tags = dedup_strings(group.attack_tags);
+            if group.conn_count > 1 {
+                reasons.push(format!("{} sockets from the same process", group.conn_count));
+            }
+            if endpoint_rows.len() < group.conn_count {
+                reasons.push(format!("{} repeated sockets collapsed into {} endpoint rows", group.conn_count, endpoint_rows.len()));
+            }
+            if group.distinct_ports.len() > 1 {
+                reasons.push(format!("{} distinct remote ports", group.distinct_ports.len()));
+            }
+            if group.distinct_remotes.len() > 1 {
+                reasons.push(format!("{} distinct remote targets", group.distinct_remotes.len()));
+            }
+            out_groups.push(OwnedProcessGroup {
+                pid: group.pid,
+                proc_name: group.proc_name,
+                proc_path: group.proc_path,
+                proc_user: group.proc_user,
+                parent_user: group.parent_user,
+                command_line: group.command_line,
+                parent_name: group.parent_name,
+                parent_pid: group.parent_pid,
+                service_name: group.service_name,
+                publisher: group.publisher,
+                latest_timestamp: group.latest_timestamp,
+                latest_status: group.latest_status,
+                latest_remote: group.latest_remote,
+                score: group.score.saturating_add(fanout_bonus(group.conn_count, group.distinct_ports.len(), group.distinct_remotes.len(), group.statuses.len())),
+                conn_count: group.conn_count,
+                distinct_ports: group.distinct_ports.len(),
+                distinct_remotes: group.distinct_remotes.len(),
+                statuses: group.statuses,
+                reasons,
+                attack_tags,
+                baseline_deviation: group.baseline_deviation,
+                script_host_suspicious: group.script_host_suspicious,
+                tls_enriched: group.tls_enriched,
+                endpoint_rows,
+            });
+        }
+    }
+
+    sort_groups(&mut out_groups, sort_col, sort_asc);
+    OwnedRenderView {
+        total_connections: out_groups.iter().map(|g| g.conn_count).sum(),
+        total_groups: out_groups.len(),
+        total_endpoints: out_groups.iter().map(|g| g.endpoint_rows.len()).sum(),
+        process_count: out_groups.len(),
+        groups: out_groups,
+    }
+}
+
+impl EndpointAccumulator {
+    fn add(&mut self, conn: &ConnInfo) {
+        self.conn_count += 1;
+        if conn.timestamp >= self.latest_timestamp {
+            self.latest_timestamp = conn.timestamp.clone();
+            self.representative = Some(conn.clone());
+            self.remote_addr = conn.remote_addr.clone();
+        }
+        self.local_ports.insert(conn.local_addr.clone());
+        push_unique(&mut self.statuses, conn.status.clone());
+        self.max_score = self.max_score.max(conn.score);
+        self.pre_login |= conn.pre_login;
+        self.reputation_hit |= conn.reputation_hit.is_some();
+        self.recently_dropped |= conn.recently_dropped;
+        self.long_lived |= conn.long_lived;
+        self.dga_like |= conn.dga_like;
+        self.script_host_suspicious |= conn.script_host_suspicious;
+        self.baseline_deviation |= conn.baseline_deviation;
+        self.tls_enriched |= conn.tls_sni.is_some() || conn.tls_ja3.is_some();
+    }
+
+    fn finish(self) -> OwnedEndpointRow {
+        let representative = self.representative.unwrap_or_default();
+        let statuses = self.statuses;
+        OwnedEndpointRow {
+            representative,
+            latest_timestamp: self.latest_timestamp,
+            remote_addr: self.remote_addr,
+            conn_count: self.conn_count.max(1),
+            local_port_count: self.local_ports.len().max(1),
+            status_summary: statuses.join(" + "),
+            statuses,
+            max_score: self.max_score,
+            pre_login: self.pre_login,
+            reputation_hit: self.reputation_hit,
+            recently_dropped: self.recently_dropped,
+            long_lived: self.long_lived,
+            dga_like: self.dga_like,
+            script_host_suspicious: self.script_host_suspicious,
+            baseline_deviation: self.baseline_deviation,
+            tls_enriched: self.tls_enriched,
+        }
+    }
+}
+
+fn filter_bar(ui: &mut egui::Ui, total: usize, state: &mut TableState, kind: Kind) {
+    egui::Frame::NONE
+        .fill(theme::SURFACE2)
+        .stroke(egui::Stroke::new(1.0, theme::BORDER))
+        .corner_radius(10.0)
+        .inner_margin(egui::Margin::symmetric(12, 10))
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.label(RichText::new("Search").size(11.5).color(theme::TEXT3));
+                let hint = match kind {
+                    Kind::Activity => "filter by process, endpoint, state, reason, or TLS…",
+                    Kind::Alerts => "filter alerts by process, endpoint, state, reason, or TLS…",
+                };
+                ui.add(egui::TextEdit::singleline(&mut state.filter).hint_text(hint).desired_width(ui.available_width() - 120.0));
+                if !state.filter.is_empty()
+                    && ui.add(egui::Button::new(RichText::new("x").color(theme::TEXT3).size(11.0)).fill(egui::Color32::TRANSPARENT).stroke(egui::Stroke::NONE))
+                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                        .on_hover_text("Clear search filter.")
+                        .clicked()
+                {
+                    state.filter.clear();
+                }
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    let label = if total == 1 { "1 process".to_string() } else { format!("{total} processes") };
+                    ui.label(RichText::new(label).color(theme::TEXT3).size(11.0));
+                });
+            });
+        });
+}
+
+fn header_row(ui: &mut egui::Ui, state: &mut TableState) {
+    ui.horizontal(|ui| {
+        header_chip(ui, "Time", 0, state, 88.0);
+        header_chip(ui, "Process", 1, state, 220.0);
+        header_chip(ui, "Fan-out", 2, state, 120.0);
+        header_chip(ui, "State", 3, state, 160.0);
+        header_chip(ui, "Score", 4, state, 72.0);
+    });
+}
+
+fn header_chip(ui: &mut egui::Ui, label: &str, col: usize, state: &mut TableState, width: f32) {
+    let active = state.sort_col == col;
+    let text = format!("{label}{}", state.arrow(col));
+    let fg = if active { theme::TEXT } else { theme::TEXT2 };
+    let resp = ui.add_sized([width, 24.0], egui::Button::new(RichText::new(text).color(fg).size(11.0).strong()).fill(theme::SURFACE2).stroke(egui::Stroke::new(1.0, theme::BORDER)).corner_radius(6.0));
+    if resp.on_hover_cursor(egui::CursorIcon::PointingHand).on_hover_text(format!("Sort by {label}. Click again to reverse order.")).clicked() {
+        state.toggle(col);
+    }
+}
+
+fn selection_from_group(group: &OwnedProcessGroup, selected_connection: Option<ConnInfo>) -> ProcessSelection {
+    ProcessSelection {
+        pid: group.pid,
+        proc_name: group.proc_name.clone(),
+        proc_path: group.proc_path.clone(),
+        proc_user: group.proc_user.clone(),
+        parent_user: group.parent_user.clone(),
+        command_line: group.command_line.clone(),
+        parent_name: group.parent_name.clone(),
+        parent_pid: group.parent_pid,
+        service_name: group.service_name.clone(),
+        publisher: group.publisher.clone(),
+        score: group.score,
+        reasons: group.reasons.clone(),
+        attack_tags: group.attack_tags.clone(),
+        baseline_deviation: group.baseline_deviation,
+        script_host_suspicious: group.script_host_suspicious,
+        timestamp: group.latest_timestamp.clone(),
+        status: group.latest_status.clone(),
+        remote_addr: selected_connection.as_ref().map(|c| c.remote_addr.clone()).unwrap_or_else(|| group.latest_remote.clone()),
+        connection_count: group.conn_count,
+        distinct_ports: group.distinct_ports,
+        distinct_remotes: group.distinct_remotes,
+        statuses: group.statuses.clone(),
+        selected_connection,
+    }
+}
+
+fn endpoint_line(ui: &mut egui::Ui, endpoint: &OwnedEndpointRow, kind: Kind, selected: bool) -> Option<ConnInfo> {
+    let h = 30.0;
+    let (rect, resp) = ui.allocate_exact_size(egui::vec2(ui.available_width(), h), egui::Sense::click());
+    let fill = if selected { theme::SURFACE3 } else { theme::SURFACE2 };
+    ui.painter().rect_filled(rect.shrink2(egui::vec2(1.0, 0.5)), 8.0, fill);
+    ui.painter().rect_stroke(rect.shrink2(egui::vec2(1.0, 0.5)), 8.0, egui::Stroke::new(1.0, theme::BORDER), egui::StrokeKind::Outside);
+
+    ui.allocate_ui_at_rect(rect.shrink2(egui::vec2(10.0, 6.0)), |ui| {
+        let avail = ui.available_width();
+        let fixed = CONN_TIME_W + CONN_REMOTE_W + CONN_STATUS_W + CONN_SCORE_W;
+        let badge_area = (avail - fixed - CONN_BADGE_GAP).max(0.0);
+        ui.horizontal(|ui| {
+            ui.spacing_mut().item_spacing.x = 0.0;
+            ui.add_sized([CONN_TIME_W, 16.0], egui::Label::new(RichText::new(&endpoint.latest_timestamp).color(theme::TEXT2).size(10.5)));
+            ui.add_sized([CONN_REMOTE_W, 16.0], egui::Label::new(RichText::new(&endpoint.remote_addr).color(theme::TEXT).size(11.0)));
+            ui.add_sized([CONN_STATUS_W, 16.0], egui::Label::new(RichText::new(&endpoint.status_summary).color(status_summary_color(&endpoint.statuses)).size(10.5)));
+            if let Kind::Alerts = kind {
+                let (badge_rect, _) = ui.allocate_exact_size(egui::vec2(badge_area, 16.0), egui::Sense::hover());
+                ui.allocate_ui_at_rect(badge_rect, |ui| {
+                    badge_row(ui, endpoint);
+                    if endpoint.conn_count > 1 {
+                        ui.label(RichText::new(format!("x{}", endpoint.conn_count)).color(theme::TEXT2).background_color(theme::SURFACE3).monospace().size(9.0));
+                    }
+                });
+            } else {
+                let (meta_rect, _) = ui.allocate_exact_size(egui::vec2(badge_area, 16.0), egui::Sense::hover());
+                ui.allocate_ui_at_rect(meta_rect, |ui| {
+                    ui.label(RichText::new(format!("{} socket{} / {} local port{}", endpoint.conn_count, plural(endpoint.conn_count), endpoint.local_port_count, plural(endpoint.local_port_count))).color(theme::TEXT3).size(9.4));
+                });
+            }
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                let (fg, bg) = theme::score_colors(endpoint.max_score);
+                ui.label(RichText::new(format!("{:>2}", endpoint.max_score)).color(fg).background_color(bg).monospace().size(10.5));
+            });
+        });
+    });
+
+    if resp.on_hover_cursor(egui::CursorIcon::PointingHand)
+        .on_hover_text(if endpoint.conn_count > 1 { "Select the newest matching socket for this endpoint group." } else { "Select this connection to inspect connection-level details." })
+        .clicked()
+    {
+        return Some(endpoint.representative.clone());
+    }
+    None
+}
+
+fn empty_state(ui: &mut egui::Ui, kind: Kind) {
+    let text = match kind { Kind::Activity => "No connections yet", Kind::Alerts => "No alerts yet" };
+    ui.add_space(20.0);
+    ui.label(RichText::new(text).color(theme::TEXT3).size(12.0));
+}
+
+fn badge_row(ui: &mut egui::Ui, endpoint: &OwnedEndpointRow) {
+    fn badge(ui: &mut egui::Ui, text: &str) {
+        ui.label(RichText::new(text).color(theme::DANGER).background_color(theme::DANGER_BG).monospace().size(9.0));
+    }
+    if endpoint.pre_login { badge(ui, "PL"); }
+    if endpoint.reputation_hit { badge(ui, "REP"); }
+    if endpoint.recently_dropped { badge(ui, "DRP"); }
+    if endpoint.long_lived { badge(ui, "LL"); }
+    if endpoint.dga_like { badge(ui, "DGA"); }
+    if endpoint.script_host_suspicious { badge(ui, "SCR"); }
+    if endpoint.baseline_deviation { badge(ui, "BASE"); }
+    if endpoint.tls_enriched { badge(ui, "TLS"); }
+}
+
+fn matches_filter(info: &ConnInfo, lower: &str, kind: Kind) -> bool {
+    if lower.is_empty() {
+        return true;
+    }
+    let base = contains_lower(&info.proc_name, lower)
+        || contains_lower(&info.parent_name, lower)
+        || contains_lower(&info.remote_addr, lower)
+        || contains_lower(&info.status, lower)
+        || contains_lower(&info.proc_path, lower)
+        || contains_lower(&info.local_addr, lower)
+        || info.attack_tags.iter().any(|tag| contains_lower(tag, lower))
+        || info.reasons.iter().any(|reason| contains_lower(reason, lower))
+        || info.hostname.as_deref().is_some_and(|h| contains_lower(h, lower))
+        || info.country.as_deref().is_some_and(|c| contains_lower(c, lower))
+        || info.tls_sni.as_deref().is_some_and(|s| contains_lower(s, lower))
+        || info.tls_ja3.as_deref().is_some_and(|s| contains_lower(s, lower));
+    match kind { Kind::Activity | Kind::Alerts => base }
+}
+
+fn contains_lower(haystack: &str, needle_lower: &str) -> bool {
+    haystack.to_ascii_lowercase().contains(needle_lower)
+}
+
+fn process_meta_line(group: &OwnedProcessGroup) -> String {
+    let publisher = if group.publisher.is_empty() {
+        if group.service_name.is_empty() { &group.parent_name } else { &group.service_name }
+    } else {
+        &group.publisher
+    };
+    format!("{} | {} | {}", if group.proc_path.is_empty() { "No path" } else { &group.proc_path }, if group.proc_user.is_empty() { "Unknown user" } else { &group.proc_user }, publisher)
+}
+
+fn endpoint_key(conn: &ConnInfo) -> String {
+    format!("{}|{}", conn.remote_addr, conn.hostname.as_deref().unwrap_or_default())
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if !values.iter().any(|existing| existing == &value) {
+        values.push(value);
+    }
+}
+
+fn dedup_strings(mut values: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    values.drain(..).filter(|v| seen.insert(v.to_ascii_lowercase())).collect()
+}
+
+fn sort_groups(groups: &mut [OwnedProcessGroup], sort_col: usize, sort_asc: bool) {
+    groups.sort_by(|a, b| {
+        let primary = match sort_col {
+            0 => a.latest_timestamp.cmp(&b.latest_timestamp),
+            1 => a.proc_name.to_ascii_lowercase().cmp(&b.proc_name.to_ascii_lowercase()),
+            2 => a.endpoint_rows.len().cmp(&b.endpoint_rows.len()).then_with(|| a.conn_count.cmp(&b.conn_count)),
+            3 => status_rank(&a.statuses).cmp(&status_rank(&b.statuses)),
+            4 => a.score.cmp(&b.score),
+            _ => a.latest_timestamp.cmp(&b.latest_timestamp),
+        };
+        let ord = primary.then_with(|| a.pid.cmp(&b.pid));
+        if sort_asc { ord } else { ord.reverse() }
+    });
+}
+
+fn sort_endpoint_rows(rows: &mut [OwnedEndpointRow], sort_col: usize, sort_asc: bool) {
+    rows.sort_by(|a, b| {
+        let primary = match sort_col {
+            0 => a.latest_timestamp.cmp(&b.latest_timestamp),
+            1 => a.remote_addr.cmp(&b.remote_addr),
+            2 => a.conn_count.cmp(&b.conn_count).then_with(|| a.local_port_count.cmp(&b.local_port_count)),
+            3 => status_rank(&a.statuses).cmp(&status_rank(&b.statuses)),
+            4 => a.max_score.cmp(&b.max_score),
+            _ => a.max_score.cmp(&b.max_score),
+        };
+        let ord = primary.then_with(|| a.remote_addr.cmp(&b.remote_addr));
+        if sort_asc { ord } else { ord.reverse() }
+    });
+}
+
+fn status_rank(statuses: &[String]) -> u8 {
+    if statuses.iter().any(|s| s == "SYN_SENT" || s == "SYN_RECV") { 4 }
+    else if statuses.iter().any(|s| s == "ESTABLISHED") { 3 }
+    else if statuses.iter().any(|s| matches!(s.as_str(), "FIN_WAIT1" | "FIN_WAIT2" | "CLOSE_WAIT" | "TIME_WAIT" | "LAST_ACK" | "CLOSING" | "DELETE_TCB")) { 2 }
+    else if statuses.iter().any(|s| s == "LISTEN") { 1 }
+    else { 0 }
+}
+
+fn summary_bar_color(score: u8, kind: Kind) -> egui::Color32 {
+    match kind {
+        Kind::Activity => if score >= 5 { theme::DANGER } else if score >= 3 { theme::WARN } else { theme::ACCENT },
+        Kind::Alerts => theme::DANGER,
+    }
+}
+
+fn status_summary_color(statuses: &[String]) -> egui::Color32 {
+    match status_rank(statuses) {
+        4 => theme::WARN,
+        3 => theme::ACCENT,
+        2 => theme::TEXT3,
+        _ => theme::TEXT2,
+    }
+}
+
+fn parse_port(remote: &str) -> Option<u16> {
+    remote.rsplit_once(':').and_then(|(_, port)| port.parse().ok())
+}
+
+fn fanout_bonus(conns: usize, ports: usize, remotes: usize, statuses: usize) -> u8 {
+    let mut bonus = 0;
+    if conns >= 2 { bonus += 1; }
+    if conns >= 4 { bonus += 1; }
+    if ports >= 2 { bonus += 1; }
+    if ports >= 4 { bonus += 1; }
+    if remotes >= 3 { bonus += 1; }
+    if statuses >= 3 { bonus += 1; }
+    bonus.min(4)
+}
+
+fn calc_filter_hash(filter: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    filter.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn plural(n: usize) -> &'static str {
+    if n == 1 { "" } else { "s" }
+}
+
+fn pill(ui: &mut egui::Ui, text: &str, fg: egui::Color32, bg: egui::Color32) {
+    ui.label(RichText::new(format!(" {text} ")).color(fg).background_color(bg).size(10.0).strong());
+}

--- a/src/ui/process_list_fast.rs
+++ b/src/ui/process_list_fast.rs
@@ -219,7 +219,11 @@ pub fn show(
             for group in &view.groups {
                 let selected_in_group = selected.as_ref().is_some_and(|sel| sel.pid == group.pid);
                 let collapsed = state.is_collapsed(group.pid);
-                let frame_fill = if selected_in_group { theme::SURFACE3 } else { theme::SURFACE };
+                let frame_fill = if selected_in_group {
+                    theme::SURFACE3
+                } else {
+                    theme::SURFACE
+                };
 
                 egui::Frame::NONE
                     .fill(frame_fill)
@@ -231,8 +235,16 @@ pub fn show(
                             egui::vec2(ui.available_width(), SUMMARY_H),
                             egui::Sense::click(),
                         );
-                        let summary_fill = if selected_in_group { theme::SURFACE3 } else { theme::SURFACE2 };
-                        ui.painter().rect_filled(summary_rect.shrink2(egui::vec2(0.0, 1.0)), 10.0, summary_fill);
+                        let summary_fill = if selected_in_group {
+                            theme::SURFACE3
+                        } else {
+                            theme::SURFACE2
+                        };
+                        ui.painter().rect_filled(
+                            summary_rect.shrink2(egui::vec2(0.0, 1.0)),
+                            10.0,
+                            summary_fill,
+                        );
                         ui.painter().rect_stroke(
                             summary_rect.shrink2(egui::vec2(0.0, 1.0)),
                             10.0,
@@ -249,10 +261,19 @@ pub fn show(
                                 ui.painter().rect_filled(
                                     bar_rect,
                                     2.0,
-                                    if collapsed { theme::TEXT3 } else { summary_bar_color(group.score, kind) },
+                                    if collapsed {
+                                        theme::TEXT3
+                                    } else {
+                                        summary_bar_color(group.score, kind)
+                                    },
                                 );
-                                if bar_resp.on_hover_cursor(egui::CursorIcon::PointingHand)
-                                    .on_hover_text(if collapsed { "Expand this process card" } else { "Collapse this process card" })
+                                if bar_resp
+                                    .on_hover_cursor(egui::CursorIcon::PointingHand)
+                                    .on_hover_text(if collapsed {
+                                        "Expand this process card"
+                                    } else {
+                                        "Collapse this process card"
+                                    })
                                     .clicked()
                                 {
                                     state.toggle_collapsed(group.pid);
@@ -261,38 +282,99 @@ pub fn show(
 
                                 ui.vertical(|ui| {
                                     ui.horizontal_wrapped(|ui| {
-                                        ui.label(RichText::new(&group.proc_name).color(theme::TEXT).size(14.0).strong().monospace());
-                                        ui.label(RichText::new(format!("PID {}", group.pid)).color(theme::TEXT3).size(10.0).monospace());
-                                        pill(ui, &format!("{} socket{}", group.conn_count, plural(group.conn_count)), theme::TEXT2, theme::SURFACE2);
-                                        pill(ui, &format!("{} endpoint{}", group.endpoint_rows.len(), plural(group.endpoint_rows.len())), theme::TEXT2, theme::SURFACE2);
+                                        ui.label(
+                                            RichText::new(&group.proc_name)
+                                                .color(theme::TEXT)
+                                                .size(14.0)
+                                                .strong()
+                                                .monospace(),
+                                        );
+                                        ui.label(
+                                            RichText::new(format!("PID {}", group.pid))
+                                                .color(theme::TEXT3)
+                                                .size(10.0)
+                                                .monospace(),
+                                        );
+                                        pill(
+                                            ui,
+                                            &format!(
+                                                "{} socket{}",
+                                                group.conn_count,
+                                                plural(group.conn_count)
+                                            ),
+                                            theme::TEXT2,
+                                            theme::SURFACE2,
+                                        );
+                                        pill(
+                                            ui,
+                                            &format!(
+                                                "{} endpoint{}",
+                                                group.endpoint_rows.len(),
+                                                plural(group.endpoint_rows.len())
+                                            ),
+                                            theme::TEXT2,
+                                            theme::SURFACE2,
+                                        );
                                         if group.script_host_suspicious {
                                             pill(ui, "Script host", theme::WARN, theme::WARN_BG);
                                         }
                                         if group.baseline_deviation {
-                                            pill(ui, "Baseline drift", theme::ACCENT, theme::ACCENT_BG);
+                                            pill(
+                                                ui,
+                                                "Baseline drift",
+                                                theme::ACCENT,
+                                                theme::ACCENT_BG,
+                                            );
                                         }
                                         if group.tls_enriched {
                                             pill(ui, "TLS", theme::ACCENT, theme::ACCENT_BG);
                                         }
                                     });
                                     ui.add_space(2.0);
-                                    ui.label(RichText::new(process_meta_line(group)).color(theme::TEXT2).size(10.4));
+                                    ui.label(
+                                        RichText::new(process_meta_line(group))
+                                            .color(theme::TEXT2)
+                                            .size(10.4),
+                                    );
                                     if !group.statuses.is_empty() {
-                                        ui.label(RichText::new(format!("States seen: {}", group.statuses.join(", "))).color(theme::TEXT3).size(10.0));
+                                        ui.label(
+                                            RichText::new(format!(
+                                                "States seen: {}",
+                                                group.statuses.join(", ")
+                                            ))
+                                            .color(theme::TEXT3)
+                                            .size(10.0),
+                                        );
                                     }
                                 });
 
-                                ui.with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {
-                                    let (fg, bg) = theme::score_colors(group.score);
-                                    ui.label(RichText::new(format!("{:>2}", group.score)).color(fg).background_color(bg).monospace().size(11.5));
-                                    ui.add_space(10.0);
-                                    ui.label(RichText::new(&group.latest_timestamp).color(theme::TEXT2).size(10.2));
-                                });
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Min),
+                                    |ui| {
+                                        let (fg, bg) = theme::score_colors(group.score);
+                                        ui.label(
+                                            RichText::new(format!("{:>2}", group.score))
+                                                .color(fg)
+                                                .background_color(bg)
+                                                .monospace()
+                                                .size(11.5),
+                                        );
+                                        ui.add_space(10.0);
+                                        ui.label(
+                                            RichText::new(&group.latest_timestamp)
+                                                .color(theme::TEXT2)
+                                                .size(10.2),
+                                        );
+                                    },
+                                );
                             });
                         });
 
-                        if summary_resp.on_hover_cursor(egui::CursorIcon::PointingHand)
-                            .on_hover_text("Select this process card to inspect process-level details.")
+                        if summary_resp
+                            .on_hover_cursor(egui::CursorIcon::PointingHand)
+                            .on_hover_text(
+                                "Select this process card to inspect process-level details.",
+                            )
                             .clicked()
                         {
                             *selected = Some(selection_from_group(group, None));
@@ -303,25 +385,47 @@ pub fn show(
                             ui.separator();
                             ui.add_space(8.0);
                             for endpoint in &group.endpoint_rows {
-                                let conn_selected = selected.as_ref()
+                                let conn_selected = selected
+                                    .as_ref()
                                     .and_then(|sel| sel.selected_connection.as_ref())
-                                    .is_some_and(|sel_conn| crate::ui::conn_matches_selection(&endpoint.representative, Some(sel_conn)));
-                                if let Some(clicked) = endpoint_line(ui, endpoint, kind, conn_selected) {
+                                    .is_some_and(|sel_conn| {
+                                        crate::ui::conn_matches_selection(
+                                            &endpoint.representative,
+                                            Some(sel_conn),
+                                        )
+                                    });
+                                if let Some(clicked) =
+                                    endpoint_line(ui, endpoint, kind, conn_selected)
+                                {
                                     *selected = Some(selection_from_group(group, Some(clicked)));
                                 }
                                 ui.add_space(6.0);
                             }
                         } else {
                             ui.add_space(8.0);
-                            ui.label(RichText::new(format!("{} endpoint row{} hidden", group.endpoint_rows.len(), plural(group.endpoint_rows.len()))).color(theme::TEXT3).size(10.2));
+                            ui.label(
+                                RichText::new(format!(
+                                    "{} endpoint row{} hidden",
+                                    group.endpoint_rows.len(),
+                                    plural(group.endpoint_rows.len())
+                                ))
+                                .color(theme::TEXT3)
+                                .size(10.2),
+                            );
                         }
                     });
                 ui.add_space(10.0);
             }
 
             let footer = match kind {
-                Kind::Activity => format!("{} processes / {} sockets / {} endpoint rows", view.total_groups, view.total_connections, view.total_endpoints),
-                Kind::Alerts => format!("{} alerting processes / {} sockets / {} endpoint rows", view.total_groups, view.total_connections, view.total_endpoints),
+                Kind::Activity => format!(
+                    "{} processes / {} sockets / {} endpoint rows",
+                    view.total_groups, view.total_connections, view.total_endpoints
+                ),
+                Kind::Alerts => format!(
+                    "{} alerting processes / {} sockets / {} endpoint rows",
+                    view.total_groups, view.total_connections, view.total_endpoints
+                ),
             };
             ui.add_space(4.0);
             ui.label(RichText::new(footer).color(theme::TEXT3).size(10.5));
@@ -381,27 +485,48 @@ fn build_view(
         entry.baseline_deviation |= info.baseline_deviation;
         entry.script_host_suspicious |= info.script_host_suspicious;
         entry.tls_enriched |= info.tls_sni.is_some() || info.tls_ja3.is_some();
-        entry.endpoints.entry(endpoint_key(info)).or_default().add(info);
+        entry
+            .endpoints
+            .entry(endpoint_key(info))
+            .or_default()
+            .add(info);
     }
 
     let mut out_groups = Vec::new();
     for pid in order {
         if let Some(group) = groups.remove(&pid) {
-            let mut endpoint_rows: Vec<OwnedEndpointRow> = group.endpoints.into_values().map(EndpointAccumulator::finish).collect();
+            let mut endpoint_rows: Vec<OwnedEndpointRow> = group
+                .endpoints
+                .into_values()
+                .map(EndpointAccumulator::finish)
+                .collect();
             sort_endpoint_rows(&mut endpoint_rows, sort_col, sort_asc);
             let mut reasons = dedup_strings(group.reasons);
             let attack_tags = dedup_strings(group.attack_tags);
             if group.conn_count > 1 {
-                reasons.push(format!("{} sockets from the same process", group.conn_count));
+                reasons.push(format!(
+                    "{} sockets from the same process",
+                    group.conn_count
+                ));
             }
             if endpoint_rows.len() < group.conn_count {
-                reasons.push(format!("{} repeated sockets collapsed into {} endpoint rows", group.conn_count, endpoint_rows.len()));
+                reasons.push(format!(
+                    "{} repeated sockets collapsed into {} endpoint rows",
+                    group.conn_count,
+                    endpoint_rows.len()
+                ));
             }
             if group.distinct_ports.len() > 1 {
-                reasons.push(format!("{} distinct remote ports", group.distinct_ports.len()));
+                reasons.push(format!(
+                    "{} distinct remote ports",
+                    group.distinct_ports.len()
+                ));
             }
             if group.distinct_remotes.len() > 1 {
-                reasons.push(format!("{} distinct remote targets", group.distinct_remotes.len()));
+                reasons.push(format!(
+                    "{} distinct remote targets",
+                    group.distinct_remotes.len()
+                ));
             }
             out_groups.push(OwnedProcessGroup {
                 pid: group.pid,
@@ -417,7 +542,12 @@ fn build_view(
                 latest_timestamp: group.latest_timestamp,
                 latest_status: group.latest_status,
                 latest_remote: group.latest_remote,
-                score: group.score.saturating_add(fanout_bonus(group.conn_count, group.distinct_ports.len(), group.distinct_remotes.len(), group.statuses.len())),
+                score: group.score.saturating_add(fanout_bonus(
+                    group.conn_count,
+                    group.distinct_ports.len(),
+                    group.distinct_remotes.len(),
+                    group.statuses.len(),
+                )),
                 conn_count: group.conn_count,
                 distinct_ports: group.distinct_ports.len(),
                 distinct_remotes: group.distinct_remotes.len(),
@@ -464,7 +594,9 @@ impl EndpointAccumulator {
     }
 
     fn finish(self) -> OwnedEndpointRow {
-        let representative = self.representative.unwrap_or_default();
+        let representative = self
+            .representative
+            .expect("endpoint accumulator finished without a representative");
         let statuses = self.statuses;
         OwnedEndpointRow {
             representative,
@@ -500,9 +632,18 @@ fn filter_bar(ui: &mut egui::Ui, total: usize, state: &mut TableState, kind: Kin
                     Kind::Activity => "filter by process, endpoint, state, reason, or TLS…",
                     Kind::Alerts => "filter alerts by process, endpoint, state, reason, or TLS…",
                 };
-                ui.add(egui::TextEdit::singleline(&mut state.filter).hint_text(hint).desired_width(ui.available_width() - 120.0));
+                ui.add(
+                    egui::TextEdit::singleline(&mut state.filter)
+                        .hint_text(hint)
+                        .desired_width(ui.available_width() - 120.0),
+                );
                 if !state.filter.is_empty()
-                    && ui.add(egui::Button::new(RichText::new("x").color(theme::TEXT3).size(11.0)).fill(egui::Color32::TRANSPARENT).stroke(egui::Stroke::NONE))
+                    && ui
+                        .add(
+                            egui::Button::new(RichText::new("x").color(theme::TEXT3).size(11.0))
+                                .fill(egui::Color32::TRANSPARENT)
+                                .stroke(egui::Stroke::NONE),
+                        )
                         .on_hover_cursor(egui::CursorIcon::PointingHand)
                         .on_hover_text("Clear search filter.")
                         .clicked()
@@ -510,7 +651,11 @@ fn filter_bar(ui: &mut egui::Ui, total: usize, state: &mut TableState, kind: Kin
                     state.filter.clear();
                 }
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    let label = if total == 1 { "1 process".to_string() } else { format!("{total} processes") };
+                    let label = if total == 1 {
+                        "1 process".to_string()
+                    } else {
+                        format!("{total} processes")
+                    };
                     ui.label(RichText::new(label).color(theme::TEXT3).size(11.0));
                 });
             });
@@ -531,13 +676,26 @@ fn header_chip(ui: &mut egui::Ui, label: &str, col: usize, state: &mut TableStat
     let active = state.sort_col == col;
     let text = format!("{label}{}", state.arrow(col));
     let fg = if active { theme::TEXT } else { theme::TEXT2 };
-    let resp = ui.add_sized([width, 24.0], egui::Button::new(RichText::new(text).color(fg).size(11.0).strong()).fill(theme::SURFACE2).stroke(egui::Stroke::new(1.0, theme::BORDER)).corner_radius(6.0));
-    if resp.on_hover_cursor(egui::CursorIcon::PointingHand).on_hover_text(format!("Sort by {label}. Click again to reverse order.")).clicked() {
+    let resp = ui.add_sized(
+        [width, 24.0],
+        egui::Button::new(RichText::new(text).color(fg).size(11.0).strong())
+            .fill(theme::SURFACE2)
+            .stroke(egui::Stroke::new(1.0, theme::BORDER))
+            .corner_radius(6.0),
+    );
+    if resp
+        .on_hover_cursor(egui::CursorIcon::PointingHand)
+        .on_hover_text(format!("Sort by {label}. Click again to reverse order."))
+        .clicked()
+    {
         state.toggle(col);
     }
 }
 
-fn selection_from_group(group: &OwnedProcessGroup, selected_connection: Option<ConnInfo>) -> ProcessSelection {
+fn selection_from_group(
+    group: &OwnedProcessGroup,
+    selected_connection: Option<ConnInfo>,
+) -> ProcessSelection {
     ProcessSelection {
         pid: group.pid,
         proc_name: group.proc_name.clone(),
@@ -556,7 +714,10 @@ fn selection_from_group(group: &OwnedProcessGroup, selected_connection: Option<C
         script_host_suspicious: group.script_host_suspicious,
         timestamp: group.latest_timestamp.clone(),
         status: group.latest_status.clone(),
-        remote_addr: selected_connection.as_ref().map(|c| c.remote_addr.clone()).unwrap_or_else(|| group.latest_remote.clone()),
+        remote_addr: selected_connection
+            .as_ref()
+            .map(|c| c.remote_addr.clone())
+            .unwrap_or_else(|| group.latest_remote.clone()),
         connection_count: group.conn_count,
         distinct_ports: group.distinct_ports,
         distinct_remotes: group.distinct_remotes,
@@ -565,12 +726,29 @@ fn selection_from_group(group: &OwnedProcessGroup, selected_connection: Option<C
     }
 }
 
-fn endpoint_line(ui: &mut egui::Ui, endpoint: &OwnedEndpointRow, kind: Kind, selected: bool) -> Option<ConnInfo> {
+#[allow(deprecated)]
+fn endpoint_line(
+    ui: &mut egui::Ui,
+    endpoint: &OwnedEndpointRow,
+    kind: Kind,
+    selected: bool,
+) -> Option<ConnInfo> {
     let h = 30.0;
-    let (rect, resp) = ui.allocate_exact_size(egui::vec2(ui.available_width(), h), egui::Sense::click());
-    let fill = if selected { theme::SURFACE3 } else { theme::SURFACE2 };
-    ui.painter().rect_filled(rect.shrink2(egui::vec2(1.0, 0.5)), 8.0, fill);
-    ui.painter().rect_stroke(rect.shrink2(egui::vec2(1.0, 0.5)), 8.0, egui::Stroke::new(1.0, theme::BORDER), egui::StrokeKind::Outside);
+    let (rect, resp) =
+        ui.allocate_exact_size(egui::vec2(ui.available_width(), h), egui::Sense::click());
+    let fill = if selected {
+        theme::SURFACE3
+    } else {
+        theme::SURFACE2
+    };
+    ui.painter()
+        .rect_filled(rect.shrink2(egui::vec2(1.0, 0.5)), 8.0, fill);
+    ui.painter().rect_stroke(
+        rect.shrink2(egui::vec2(1.0, 0.5)),
+        8.0,
+        egui::Stroke::new(1.0, theme::BORDER),
+        egui::StrokeKind::Outside,
+    );
 
     ui.allocate_ui_at_rect(rect.shrink2(egui::vec2(10.0, 6.0)), |ui| {
         let avail = ui.available_width();
@@ -578,32 +756,82 @@ fn endpoint_line(ui: &mut egui::Ui, endpoint: &OwnedEndpointRow, kind: Kind, sel
         let badge_area = (avail - fixed - CONN_BADGE_GAP).max(0.0);
         ui.horizontal(|ui| {
             ui.spacing_mut().item_spacing.x = 0.0;
-            ui.add_sized([CONN_TIME_W, 16.0], egui::Label::new(RichText::new(&endpoint.latest_timestamp).color(theme::TEXT2).size(10.5)));
-            ui.add_sized([CONN_REMOTE_W, 16.0], egui::Label::new(RichText::new(&endpoint.remote_addr).color(theme::TEXT).size(11.0)));
-            ui.add_sized([CONN_STATUS_W, 16.0], egui::Label::new(RichText::new(&endpoint.status_summary).color(status_summary_color(&endpoint.statuses)).size(10.5)));
+            ui.add_sized(
+                [CONN_TIME_W, 16.0],
+                egui::Label::new(
+                    RichText::new(&endpoint.latest_timestamp)
+                        .color(theme::TEXT2)
+                        .size(10.5),
+                ),
+            );
+            ui.add_sized(
+                [CONN_REMOTE_W, 16.0],
+                egui::Label::new(
+                    RichText::new(&endpoint.remote_addr)
+                        .color(theme::TEXT)
+                        .size(11.0),
+                ),
+            );
+            ui.add_sized(
+                [CONN_STATUS_W, 16.0],
+                egui::Label::new(
+                    RichText::new(&endpoint.status_summary)
+                        .color(status_summary_color(&endpoint.statuses))
+                        .size(10.5),
+                ),
+            );
             if let Kind::Alerts = kind {
-                let (badge_rect, _) = ui.allocate_exact_size(egui::vec2(badge_area, 16.0), egui::Sense::hover());
+                let (badge_rect, _) =
+                    ui.allocate_exact_size(egui::vec2(badge_area, 16.0), egui::Sense::hover());
                 ui.allocate_ui_at_rect(badge_rect, |ui| {
                     badge_row(ui, endpoint);
                     if endpoint.conn_count > 1 {
-                        ui.label(RichText::new(format!("x{}", endpoint.conn_count)).color(theme::TEXT2).background_color(theme::SURFACE3).monospace().size(9.0));
+                        ui.label(
+                            RichText::new(format!("x{}", endpoint.conn_count))
+                                .color(theme::TEXT2)
+                                .background_color(theme::SURFACE3)
+                                .monospace()
+                                .size(9.0),
+                        );
                     }
                 });
             } else {
-                let (meta_rect, _) = ui.allocate_exact_size(egui::vec2(badge_area, 16.0), egui::Sense::hover());
+                let (meta_rect, _) =
+                    ui.allocate_exact_size(egui::vec2(badge_area, 16.0), egui::Sense::hover());
                 ui.allocate_ui_at_rect(meta_rect, |ui| {
-                    ui.label(RichText::new(format!("{} socket{} / {} local port{}", endpoint.conn_count, plural(endpoint.conn_count), endpoint.local_port_count, plural(endpoint.local_port_count))).color(theme::TEXT3).size(9.4));
+                    ui.label(
+                        RichText::new(format!(
+                            "{} socket{} / {} local port{}",
+                            endpoint.conn_count,
+                            plural(endpoint.conn_count),
+                            endpoint.local_port_count,
+                            plural(endpoint.local_port_count)
+                        ))
+                        .color(theme::TEXT3)
+                        .size(9.4),
+                    );
                 });
             }
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                 let (fg, bg) = theme::score_colors(endpoint.max_score);
-                ui.label(RichText::new(format!("{:>2}", endpoint.max_score)).color(fg).background_color(bg).monospace().size(10.5));
+                ui.label(
+                    RichText::new(format!("{:>2}", endpoint.max_score))
+                        .color(fg)
+                        .background_color(bg)
+                        .monospace()
+                        .size(10.5),
+                );
             });
         });
     });
 
-    if resp.on_hover_cursor(egui::CursorIcon::PointingHand)
-        .on_hover_text(if endpoint.conn_count > 1 { "Select the newest matching socket for this endpoint group." } else { "Select this connection to inspect connection-level details." })
+    if resp
+        .on_hover_cursor(egui::CursorIcon::PointingHand)
+        .on_hover_text(if endpoint.conn_count > 1 {
+            "Select the newest matching socket for this endpoint group."
+        } else {
+            "Select this connection to inspect connection-level details."
+        })
         .clicked()
     {
         return Some(endpoint.representative.clone());
@@ -612,23 +840,48 @@ fn endpoint_line(ui: &mut egui::Ui, endpoint: &OwnedEndpointRow, kind: Kind, sel
 }
 
 fn empty_state(ui: &mut egui::Ui, kind: Kind) {
-    let text = match kind { Kind::Activity => "No connections yet", Kind::Alerts => "No alerts yet" };
+    let text = match kind {
+        Kind::Activity => "No connections yet",
+        Kind::Alerts => "No alerts yet",
+    };
     ui.add_space(20.0);
     ui.label(RichText::new(text).color(theme::TEXT3).size(12.0));
 }
 
 fn badge_row(ui: &mut egui::Ui, endpoint: &OwnedEndpointRow) {
     fn badge(ui: &mut egui::Ui, text: &str) {
-        ui.label(RichText::new(text).color(theme::DANGER).background_color(theme::DANGER_BG).monospace().size(9.0));
+        ui.label(
+            RichText::new(text)
+                .color(theme::DANGER)
+                .background_color(theme::DANGER_BG)
+                .monospace()
+                .size(9.0),
+        );
     }
-    if endpoint.pre_login { badge(ui, "PL"); }
-    if endpoint.reputation_hit { badge(ui, "REP"); }
-    if endpoint.recently_dropped { badge(ui, "DRP"); }
-    if endpoint.long_lived { badge(ui, "LL"); }
-    if endpoint.dga_like { badge(ui, "DGA"); }
-    if endpoint.script_host_suspicious { badge(ui, "SCR"); }
-    if endpoint.baseline_deviation { badge(ui, "BASE"); }
-    if endpoint.tls_enriched { badge(ui, "TLS"); }
+    if endpoint.pre_login {
+        badge(ui, "PL");
+    }
+    if endpoint.reputation_hit {
+        badge(ui, "REP");
+    }
+    if endpoint.recently_dropped {
+        badge(ui, "DRP");
+    }
+    if endpoint.long_lived {
+        badge(ui, "LL");
+    }
+    if endpoint.dga_like {
+        badge(ui, "DGA");
+    }
+    if endpoint.script_host_suspicious {
+        badge(ui, "SCR");
+    }
+    if endpoint.baseline_deviation {
+        badge(ui, "BASE");
+    }
+    if endpoint.tls_enriched {
+        badge(ui, "TLS");
+    }
 }
 
 fn matches_filter(info: &ConnInfo, lower: &str, kind: Kind) -> bool {
@@ -641,13 +894,33 @@ fn matches_filter(info: &ConnInfo, lower: &str, kind: Kind) -> bool {
         || contains_lower(&info.status, lower)
         || contains_lower(&info.proc_path, lower)
         || contains_lower(&info.local_addr, lower)
-        || info.attack_tags.iter().any(|tag| contains_lower(tag, lower))
-        || info.reasons.iter().any(|reason| contains_lower(reason, lower))
-        || info.hostname.as_deref().is_some_and(|h| contains_lower(h, lower))
-        || info.country.as_deref().is_some_and(|c| contains_lower(c, lower))
-        || info.tls_sni.as_deref().is_some_and(|s| contains_lower(s, lower))
-        || info.tls_ja3.as_deref().is_some_and(|s| contains_lower(s, lower));
-    match kind { Kind::Activity | Kind::Alerts => base }
+        || info
+            .attack_tags
+            .iter()
+            .any(|tag| contains_lower(tag, lower))
+        || info
+            .reasons
+            .iter()
+            .any(|reason| contains_lower(reason, lower))
+        || info
+            .hostname
+            .as_deref()
+            .is_some_and(|h| contains_lower(h, lower))
+        || info
+            .country
+            .as_deref()
+            .is_some_and(|c| contains_lower(c, lower))
+        || info
+            .tls_sni
+            .as_deref()
+            .is_some_and(|s| contains_lower(s, lower))
+        || info
+            .tls_ja3
+            .as_deref()
+            .is_some_and(|s| contains_lower(s, lower));
+    match kind {
+        Kind::Activity | Kind::Alerts => base,
+    }
 }
 
 fn contains_lower(haystack: &str, needle_lower: &str) -> bool {
@@ -656,15 +929,36 @@ fn contains_lower(haystack: &str, needle_lower: &str) -> bool {
 
 fn process_meta_line(group: &OwnedProcessGroup) -> String {
     let publisher = if group.publisher.is_empty() {
-        if group.service_name.is_empty() { &group.parent_name } else { &group.service_name }
+        if group.service_name.is_empty() {
+            &group.parent_name
+        } else {
+            &group.service_name
+        }
     } else {
         &group.publisher
     };
-    format!("{} | {} | {}", if group.proc_path.is_empty() { "No path" } else { &group.proc_path }, if group.proc_user.is_empty() { "Unknown user" } else { &group.proc_user }, publisher)
+    format!(
+        "{} | {} | {}",
+        if group.proc_path.is_empty() {
+            "No path"
+        } else {
+            &group.proc_path
+        },
+        if group.proc_user.is_empty() {
+            "Unknown user"
+        } else {
+            &group.proc_user
+        },
+        publisher
+    )
 }
 
 fn endpoint_key(conn: &ConnInfo) -> String {
-    format!("{}|{}", conn.remote_addr, conn.hostname.as_deref().unwrap_or_default())
+    format!(
+        "{}|{}",
+        conn.remote_addr,
+        conn.hostname.as_deref().unwrap_or_default()
+    )
 }
 
 fn push_unique(values: &mut Vec<String>, value: String) {
@@ -675,21 +969,35 @@ fn push_unique(values: &mut Vec<String>, value: String) {
 
 fn dedup_strings(mut values: Vec<String>) -> Vec<String> {
     let mut seen = HashSet::new();
-    values.drain(..).filter(|v| seen.insert(v.to_ascii_lowercase())).collect()
+    values
+        .drain(..)
+        .filter(|v| seen.insert(v.to_ascii_lowercase()))
+        .collect()
 }
 
 fn sort_groups(groups: &mut [OwnedProcessGroup], sort_col: usize, sort_asc: bool) {
     groups.sort_by(|a, b| {
         let primary = match sort_col {
             0 => a.latest_timestamp.cmp(&b.latest_timestamp),
-            1 => a.proc_name.to_ascii_lowercase().cmp(&b.proc_name.to_ascii_lowercase()),
-            2 => a.endpoint_rows.len().cmp(&b.endpoint_rows.len()).then_with(|| a.conn_count.cmp(&b.conn_count)),
+            1 => a
+                .proc_name
+                .to_ascii_lowercase()
+                .cmp(&b.proc_name.to_ascii_lowercase()),
+            2 => a
+                .endpoint_rows
+                .len()
+                .cmp(&b.endpoint_rows.len())
+                .then_with(|| a.conn_count.cmp(&b.conn_count)),
             3 => status_rank(&a.statuses).cmp(&status_rank(&b.statuses)),
             4 => a.score.cmp(&b.score),
             _ => a.latest_timestamp.cmp(&b.latest_timestamp),
         };
         let ord = primary.then_with(|| a.pid.cmp(&b.pid));
-        if sort_asc { ord } else { ord.reverse() }
+        if sort_asc {
+            ord
+        } else {
+            ord.reverse()
+        }
     });
 }
 
@@ -698,27 +1006,59 @@ fn sort_endpoint_rows(rows: &mut [OwnedEndpointRow], sort_col: usize, sort_asc: 
         let primary = match sort_col {
             0 => a.latest_timestamp.cmp(&b.latest_timestamp),
             1 => a.remote_addr.cmp(&b.remote_addr),
-            2 => a.conn_count.cmp(&b.conn_count).then_with(|| a.local_port_count.cmp(&b.local_port_count)),
+            2 => a
+                .conn_count
+                .cmp(&b.conn_count)
+                .then_with(|| a.local_port_count.cmp(&b.local_port_count)),
             3 => status_rank(&a.statuses).cmp(&status_rank(&b.statuses)),
             4 => a.max_score.cmp(&b.max_score),
             _ => a.max_score.cmp(&b.max_score),
         };
         let ord = primary.then_with(|| a.remote_addr.cmp(&b.remote_addr));
-        if sort_asc { ord } else { ord.reverse() }
+        if sort_asc {
+            ord
+        } else {
+            ord.reverse()
+        }
     });
 }
 
 fn status_rank(statuses: &[String]) -> u8 {
-    if statuses.iter().any(|s| s == "SYN_SENT" || s == "SYN_RECV") { 4 }
-    else if statuses.iter().any(|s| s == "ESTABLISHED") { 3 }
-    else if statuses.iter().any(|s| matches!(s.as_str(), "FIN_WAIT1" | "FIN_WAIT2" | "CLOSE_WAIT" | "TIME_WAIT" | "LAST_ACK" | "CLOSING" | "DELETE_TCB")) { 2 }
-    else if statuses.iter().any(|s| s == "LISTEN") { 1 }
-    else { 0 }
+    if statuses.iter().any(|s| s == "SYN_SENT" || s == "SYN_RECV") {
+        4
+    } else if statuses.iter().any(|s| s == "ESTABLISHED") {
+        3
+    } else if statuses.iter().any(|s| {
+        matches!(
+            s.as_str(),
+            "FIN_WAIT1"
+                | "FIN_WAIT2"
+                | "CLOSE_WAIT"
+                | "TIME_WAIT"
+                | "LAST_ACK"
+                | "CLOSING"
+                | "DELETE_TCB"
+        )
+    }) {
+        2
+    } else if statuses.iter().any(|s| s == "LISTEN") {
+        1
+    } else {
+        0
+    }
 }
 
 fn summary_bar_color(score: u8, kind: Kind) -> egui::Color32 {
     match kind {
-        Kind::Activity => if score >= 5 { theme::DANGER } else if score >= 3 { theme::WARN } else { theme::ACCENT },
+        Kind::Activity => {
+            if score >= 5 {
+                theme::DANGER
+            } else if score >= 3 {
+                theme::WARN
+            } else {
+                theme::ACCENT
+            }
+        }
         Kind::Alerts => theme::DANGER,
     }
 }
@@ -733,17 +1073,31 @@ fn status_summary_color(statuses: &[String]) -> egui::Color32 {
 }
 
 fn parse_port(remote: &str) -> Option<u16> {
-    remote.rsplit_once(':').and_then(|(_, port)| port.parse().ok())
+    remote
+        .rsplit_once(':')
+        .and_then(|(_, port)| port.parse().ok())
 }
 
 fn fanout_bonus(conns: usize, ports: usize, remotes: usize, statuses: usize) -> u8 {
     let mut bonus = 0;
-    if conns >= 2 { bonus += 1; }
-    if conns >= 4 { bonus += 1; }
-    if ports >= 2 { bonus += 1; }
-    if ports >= 4 { bonus += 1; }
-    if remotes >= 3 { bonus += 1; }
-    if statuses >= 3 { bonus += 1; }
+    if conns >= 2 {
+        bonus += 1;
+    }
+    if conns >= 4 {
+        bonus += 1;
+    }
+    if ports >= 2 {
+        bonus += 1;
+    }
+    if ports >= 4 {
+        bonus += 1;
+    }
+    if remotes >= 3 {
+        bonus += 1;
+    }
+    if statuses >= 3 {
+        bonus += 1;
+    }
     bonus.min(4)
 }
 
@@ -755,9 +1109,19 @@ fn calc_filter_hash(filter: &str) -> u64 {
 }
 
 fn plural(n: usize) -> &'static str {
-    if n == 1 { "" } else { "s" }
+    if n == 1 {
+        ""
+    } else {
+        "s"
+    }
 }
 
 fn pill(ui: &mut egui::Ui, text: &str, fg: egui::Color32, bg: egui::Color32) {
-    ui.label(RichText::new(format!(" {text} ")).color(fg).background_color(bg).size(10.0).strong());
+    ui.label(
+        RichText::new(format!(" {text} "))
+            .color(fg)
+            .background_color(bg)
+            .size(10.0)
+            .strong(),
+    );
 }


### PR DESCRIPTION
Consolidate the UI performance hotfix and protected startup integrity follow-up into one reviewable branch.

Validation:
- cargo fmt --all
- cargo check
- cargo test --all-targets --all-features

This keeps the cached UI rendering changes together with the startup integrity report persistence work, while preserving the current Config API expected by the rest of the app.