### PR TITLE
chore(release): record v1.3.18 version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4547,7 +4547,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vigil"
-version = "1.3.17"
+version = "1.3.18"
 dependencies = [
  "auto-launch",
  "aya",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "vigil"
-version     = "1.3.17"
+version     = "1.3.18"
 edition     = "2021"
 description = "Real-time network threat monitor"
 license     = "MIT"


### PR DESCRIPTION
## Summary
- preserve the latest unmerged release bookkeeping branch in a normal reviewable path
- update `Cargo.toml` and `Cargo.lock` from `1.3.17` to `1.3.18`

## Why
The repository currently has no open pull requests, but `release/v1.3.18` contains one meaningful unmerged commit with no PR attached. Preserving that branch through a small PR keeps the latest release version bump reviewable instead of leaving it stranded outside `master`.

## Validation
- compared `release/v1.3.18` against `master`
- confirmed the diff is limited to the package version bump in `Cargo.toml` and `Cargo.lock`
- confirmed there was no existing pull request for `release/v1.3.18`

## Notes
This is intentionally scoped to bookkeeping only. I did not merge it automatically because it still needs the usual review and checks in the normal PR path.