### PR TITLE
fix: end running task before uninstall

### DIFF
--- a/src/platform/service.rs
+++ b/src/platform/service.rs
@@ -43,7 +43,7 @@ pub fn uninstall() -> CmdResult {
 mod platform {
     use super::*;
     use crate::platform::command_paths;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::process::{Command, Output};
 
     const TASK_NAME: &str = "VigilBootMonitor";
@@ -88,6 +88,7 @@ mod platform {
 
     pub fn uninstall() -> CmdResult {
         let mut removed_any = false;
+        let task_path = task_path();
 
         let task_query = Command::new(command_paths::resolve("schtasks")?)
             .args(["/Query", "/TN", TASK_NAME])
@@ -108,7 +109,10 @@ mod platform {
                 ));
             }
             removed_any = true;
-        } else if !task_does_not_exist(&task_query) {
+        } else if task_path
+            .try_exists()
+            .map_err(|e| format!("could not inspect {}: {e}", task_path.display()))?
+        {
             return Err(format!(
                 "`schtasks /Query /TN {TASK_NAME}` failed unexpectedly: {}",
                 command_output_summary(&task_query)
@@ -149,11 +153,14 @@ mod platform {
         }
     }
 
-    fn task_does_not_exist(output: &Output) -> bool {
-        let text = command_output_text(output).to_ascii_lowercase();
-        text.contains("the system cannot find the file specified")
-            || text.contains("the specified task name")
-            || text.contains("does not exist in the system")
+    fn task_path() -> PathBuf {
+        let mut path = std::env::var_os("SystemRoot")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(r"C:\Windows"));
+        path.push("System32");
+        path.push("Tasks");
+        path.push(TASK_NAME);
+        path
     }
 
     fn service_does_not_exist(output: &Output) -> bool {
@@ -275,7 +282,7 @@ mod platform {
         text.replace('&', "&amp;")
             .replace('<', "&lt;")
             .replace('>', "&gt;")
-            .replace('\"', "&quot;")
+            .replace('"', "&quot;")
             .replace('\'', "&apos;")
     }
 }
@@ -374,7 +381,7 @@ mod platform {
     }
 
     fn systemd_quote(text: &str) -> String {
-        format!("\"{}\"", text.replace('\"', "\\\""))
+        format!("\"{}\"", text.replace('"', "\\\""))
     }
 }
 

--- a/src/platform/service.rs
+++ b/src/platform/service.rs
@@ -43,7 +43,7 @@ pub fn uninstall() -> CmdResult {
 mod platform {
     use super::*;
     use crate::platform::command_paths;
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
     use std::process::{Command, Output};
 
     const TASK_NAME: &str = "VigilBootMonitor";
@@ -89,17 +89,30 @@ mod platform {
     pub fn uninstall() -> CmdResult {
         let mut removed_any = false;
 
-        if task_path().exists() {
-            let status = Command::new(command_paths::resolve("schtasks")?)
+        let task_query = Command::new(command_paths::resolve("schtasks")?)
+            .args(["/Query", "/TN", TASK_NAME])
+            .output()
+            .map_err(|e| format!("failed to spawn `schtasks`: {e}"))?;
+        if task_query.status.success() {
+            let _ = Command::new(command_paths::resolve("schtasks")?)
+                .args(["/End", "/TN", TASK_NAME])
+                .status();
+            let delete = Command::new(command_paths::resolve("schtasks")?)
                 .args(["/Delete", "/TN", TASK_NAME, "/F"])
-                .status()
+                .output()
                 .map_err(|e| format!("failed to spawn `schtasks`: {e}"))?;
-            if !status.success() {
-                return Err(
-                    "`schtasks /Delete` failed.  Re-run from an elevated Command Prompt.".into(),
-                );
+            if !delete.status.success() {
+                return Err(format!(
+                    "`schtasks /Delete` failed unexpectedly: {}",
+                    command_output_summary(&delete)
+                ));
             }
             removed_any = true;
+        } else if !task_does_not_exist(&task_query) {
+            return Err(format!(
+                "`schtasks /Query /TN {TASK_NAME}` failed unexpectedly: {}",
+                command_output_summary(&task_query)
+            ));
         }
 
         let query = Command::new(command_paths::resolve("sc")?)
@@ -136,8 +149,11 @@ mod platform {
         }
     }
 
-    fn task_path() -> PathBuf {
-        PathBuf::from(r"C:\Windows\System32\Tasks\VigilBootMonitor")
+    fn task_does_not_exist(output: &Output) -> bool {
+        let text = command_output_text(output).to_ascii_lowercase();
+        text.contains("the system cannot find the file specified")
+            || text.contains("the specified task name")
+            || text.contains("does not exist in the system")
     }
 
     fn service_does_not_exist(output: &Output) -> bool {


### PR DESCRIPTION
## Summary
Reapplies the remaining Windows uninstall fix from #132 on top of current `master` so it can merge cleanly.

## What changed
- query Task Scheduler directly before uninstalling the Windows boot task
- treat missing tasks as absent, but surface other scheduler failures as real errors
- keep ending the running task before deleting it

## Notes
- this replaces #132, which is currently blocked by a merge conflict after `master` moved
- local validation in this environment was limited to code inspection because there is no Windows runtime or Rust toolchain here