### PR TITLE
[codex] cache selected process summary

### DIFF
--- a/src/ui/inspector.rs
+++ b/src/ui/inspector.rs
@@ -355,13 +355,13 @@ fn show_detail(ui: &mut Ui, sel: &ProcessSelection, kill_confirm: bool) -> Optio
         ui.add_space(8.0);
 
         section_header(ui, "Why it scored");
-        if sel.reasons.is_empty() {
+        if sel.reason_summary.is_empty() {
             ui.label(RichText::new("No score reasons recorded.").color(theme::TEXT3).size(11.0));
         } else {
             render_reason_block(
                 ui,
                 "process",
-                &sel.reasons,
+                &sel.reason_summary,
                 ">",
                 theme::WARN,
                 theme::TEXT2,
@@ -390,7 +390,7 @@ fn show_detail(ui: &mut Ui, sel: &ProcessSelection, kill_confirm: bool) -> Optio
                 render_reason_block(
                     ui,
                     "connection",
-                    &conn.reasons,
+                    &summarize_reasons(&conn.reasons),
                     "-",
                     theme::TEXT3,
                     theme::TEXT2,
@@ -527,14 +527,20 @@ fn section_header(ui: &mut Ui, title: &str) {
     ui.add_space(4.0);
 }
 
-#[derive(Default)]
-struct ReasonSummary {
+#[derive(Debug, Clone, Default)]
+pub struct ReasonSummary {
     plain: Vec<String>,
     unusual_ports: Vec<u16>,
     truncated_input: usize,
 }
 
-fn summarize_reasons(reasons: &[String]) -> ReasonSummary {
+impl ReasonSummary {
+    fn is_empty(&self) -> bool {
+        self.plain.is_empty() && self.unusual_ports.is_empty() && self.truncated_input == 0
+    }
+}
+
+pub fn summarize_reasons(reasons: &[String]) -> ReasonSummary {
     let mut summary = ReasonSummary::default();
     let mut ports = BTreeSet::new();
     for reason in reasons.iter().take(MAX_REASON_SCAN) {
@@ -577,14 +583,13 @@ fn render_reason_row(
 fn render_reason_block(
     ui: &mut Ui,
     id_prefix: &str,
-    reasons: &[String],
+    summary: &ReasonSummary,
     marker: &str,
     marker_color: egui::Color32,
     text_color: egui::Color32,
     text_size: f32,
     row_gap: f32,
 ) {
-    let summary = summarize_reasons(reasons);
     for reason in summary.plain.iter().take(MAX_REASON_PLAIN_ROWS) {
         render_reason_row(
             ui,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -252,7 +252,7 @@ pub struct ProcessSelection {
     pub service_name: String,
     pub publisher: String,
     pub score: u8,
-    pub reasons: Vec<String>,
+    pub reason_summary: inspector::ReasonSummary,
     pub attack_tags: Vec<String>,
     pub baseline_deviation: bool,
     pub script_host_suspicious: bool,

--- a/src/ui/process_list.rs
+++ b/src/ui/process_list.rs
@@ -6,7 +6,7 @@
 #![allow(dead_code)]
 
 use crate::types::ConnInfo;
-use crate::ui::{theme, ProcessSelection, TableState};
+use crate::ui::{inspector::summarize_reasons, theme, ProcessSelection, TableState};
 use egui::RichText;
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 
@@ -815,7 +815,7 @@ fn selection_from_group(
         service_name: group.service_name.to_string(),
         publisher: group.publisher.to_string(),
         score: group.score,
-        reasons: group.reasons.clone(),
+        reason_summary: summarize_reasons(&group.reasons),
         attack_tags: group.attack_tags.clone(),
         baseline_deviation: group.baseline_deviation,
         script_host_suspicious: group.script_host_suspicious,

--- a/src/ui/process_list_fast.rs
+++ b/src/ui/process_list_fast.rs
@@ -6,7 +6,7 @@
 //! process and endpoint rows instead of rebuilding them every frame.
 
 use crate::types::ConnInfo;
-use crate::ui::{process_list, theme, ProcessSelection, TableState};
+use crate::ui::{inspector::summarize_reasons, process_list, theme, ProcessSelection, TableState};
 use egui::RichText;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Mutex, OnceLock};
@@ -708,7 +708,7 @@ fn selection_from_group(
         service_name: group.service_name.clone(),
         publisher: group.publisher.clone(),
         score: group.score,
-        reasons: group.reasons.clone(),
+        reason_summary: summarize_reasons(&group.reasons),
         attack_tags: group.attack_tags.clone(),
         baseline_deviation: group.baseline_deviation,
         script_host_suspicious: group.script_host_suspicious,


### PR DESCRIPTION
## What changed

Cache the selected process score-reason summary when the user clicks a process row, instead of rebuilding it during every inspector repaint.

## Why

The inspector was re-scanning and deduplicating up to 1,200 reason strings on every frame after a selection. That made the UI feel extremely slow once a process was selected.

## Impact

- Process selection is now cheaper to render.
- The inspector still shows the same information, but repeated work moved out of the repaint loop.
- Connection-level reasons remain summarized on demand.

## Validation

- `cargo fmt --all`
- `cargo check`
- `cargo test --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings -A clippy::collapsible_match -A clippy::ptr_arg -A clippy::unnecessary_map_or`
- `cargo build --release`