### PR TITLE
[codex] cache inspector active-response snapshot

### DIFF
--- a/src/security/active_response.rs
+++ b/src/security/active_response.rs
@@ -351,14 +351,12 @@ pub fn inspector_snapshot(
             .and_then(|expires_at_unix| expires_at_unix.checked_sub(now))
             .map(Duration::from_secs)
     });
-    let process_suspended = state_ref
-        .zip(normalized_path.as_ref())
-        .is_some_and(|(state, path)| {
-            state
-                .suspended_processes
-                .iter()
-                .any(|entry| suspended_process_matches(entry, pid, path))
-        });
+    let process_suspended = state_ref.is_some_and(|state| {
+        state
+            .suspended_processes
+            .iter()
+            .any(|entry| suspended_process_matches(entry, pid, path))
+    });
     let connection_kill_enabled = selected_connection.is_some_and(can_kill_connection);
     InspectorSnapshot {
         status,

--- a/src/security/active_response.rs
+++ b/src/security/active_response.rs
@@ -39,6 +39,25 @@ pub struct Status {
     pub isolated: bool,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct InspectorSnapshot {
+    pub status: Status,
+    pub remote_target: Option<String>,
+    pub remote_blocked: bool,
+    pub remote_remaining: Option<Duration>,
+    pub domain_target: Option<String>,
+    pub domain_blocked: bool,
+    pub process_blocked: bool,
+    pub process_remaining: Option<Duration>,
+    pub process_suspended: bool,
+    pub connection_kill_enabled: bool,
+    pub quarantine_ready: bool,
+    pub suspend_enabled: bool,
+    pub firewall_modifiable: bool,
+    pub network_isolation_modifiable: bool,
+    pub domain_modifiable: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct State {
     blocked: Vec<BlockedTarget>,
@@ -247,6 +266,117 @@ pub fn can_block_domain() -> bool {
 }
 pub fn can_apply_quarantine_profile(pid: u32, path: &str) -> bool {
     platform::is_supported() && platform::is_elevated() && (pid != 0 || !path.trim().is_empty())
+}
+
+pub fn inspector_snapshot(
+    pid: u32,
+    path: &str,
+    selected_connection: Option<&ConnInfo>,
+) -> InspectorSnapshot {
+    let state = load_state_for_query("inspector_snapshot");
+    let state_ref = state.as_ref();
+    let now = unix_now();
+    let status = state_ref.map_or_else(
+        || Status {
+            isolated: platform::isolation_controls_active(&State::default()).unwrap_or(false),
+            ..Status::default()
+        },
+        |state| Status {
+            blocked_rules: state.blocked.len() + state.blocked_processes.len(),
+            blocked_processes: state.blocked_processes.len(),
+            blocked_domains: state.blocked_domains.len(),
+            suspended_processes: state.suspended_processes.len(),
+            frozen_autoruns: state.autorun_snapshot.is_some(),
+            isolated: isolation_effective_now(state, now),
+        },
+    );
+    let firewall_modifiable = can_modify_firewall();
+    let network_isolation_modifiable = can_isolate_network();
+    let domain_modifiable = can_block_domain();
+    let suspend_enabled = can_suspend_process(pid);
+    let quarantine_ready = can_apply_quarantine_profile(pid, path);
+    let (remote_target, remote_blocked, remote_remaining, domain_target, domain_blocked) =
+        if let Some(conn) = selected_connection {
+            let remote_target = extract_remote_target(&conn.remote_addr);
+            let domain_target = extract_domain_target(conn);
+            let remote_blocked = remote_target.as_deref().is_some_and(|target| {
+                state_ref
+                    .is_some_and(|state| state.blocked.iter().any(|rule| rule.target == target))
+            });
+            let remote_remaining = remote_target.as_deref().and_then(|target| {
+                state_ref.and_then(|state| {
+                    state
+                        .blocked
+                        .iter()
+                        .find(|rule| rule.target == target)
+                        .and_then(|rule| rule.expires_at_unix)
+                        .and_then(|expires_at_unix| expires_at_unix.checked_sub(now))
+                        .map(Duration::from_secs)
+                })
+            });
+            let domain_blocked = domain_target.as_deref().is_some_and(|domain| {
+                state_ref.is_some_and(|state| {
+                    state
+                        .blocked_domains
+                        .iter()
+                        .any(|entry| entry.domain == domain)
+                })
+            });
+            (
+                remote_target,
+                remote_blocked,
+                remote_remaining,
+                domain_target,
+                domain_blocked,
+            )
+        } else {
+            (None, false, None, None, false)
+        };
+    let normalized_path = normalise_target(path).ok();
+    let process_blocked = state_ref
+        .zip(normalized_path.as_ref())
+        .is_some_and(|(state, path)| {
+            state
+                .blocked_processes
+                .iter()
+                .any(|rule| process_block_matches(rule, path))
+        });
+    let process_remaining = state_ref.and_then(|state| {
+        let path = normalise_target(path).ok()?;
+        state
+            .blocked_processes
+            .iter()
+            .find(|rule| process_block_matches(rule, &path))
+            .and_then(|rule| rule.expires_at_unix)
+            .and_then(|expires_at_unix| expires_at_unix.checked_sub(now))
+            .map(Duration::from_secs)
+    });
+    let process_suspended = state_ref
+        .zip(normalized_path.as_ref())
+        .is_some_and(|(state, path)| {
+            state
+                .suspended_processes
+                .iter()
+                .any(|entry| suspended_process_matches(entry, pid, path))
+        });
+    let connection_kill_enabled = selected_connection.is_some_and(can_kill_connection);
+    InspectorSnapshot {
+        status,
+        remote_target,
+        remote_blocked,
+        remote_remaining,
+        domain_target,
+        domain_blocked,
+        process_blocked,
+        process_remaining,
+        process_suspended,
+        connection_kill_enabled,
+        quarantine_ready,
+        suspend_enabled,
+        firewall_modifiable,
+        network_isolation_modifiable,
+        domain_modifiable,
+    }
 }
 
 pub fn freeze_autoruns() -> Result<String, String> {

--- a/src/ui/inspector.rs
+++ b/src/ui/inspector.rs
@@ -72,40 +72,29 @@ fn show_detail(ui: &mut Ui, sel: &ProcessSelection, kill_confirm: bool) -> Optio
     let trust_enabled = known_location;
     let open_location_enabled = known_location;
     let kill_enabled = !ghost;
-    let suspend_enabled = active_response::can_suspend_process(sel.pid) && !ghost;
-    let response_enabled = active_response::can_modify_firewall();
-    let isolation_enabled = active_response::can_isolate_network();
-    let domain_enabled = active_response::can_block_domain();
-    let response_status = active_response::status();
-    let remote_target = sel
-        .selected_connection
-        .as_ref()
-        .and_then(|conn| active_response::extract_remote_target(&conn.remote_addr));
-    let remote_blocked = remote_target
-        .as_deref()
-        .is_some_and(active_response::is_blocked);
-    let remote_remaining = remote_target
-        .as_deref()
-        .and_then(active_response::remote_block_remaining);
-    let domain_target = sel
-        .selected_connection
-        .as_ref()
-        .and_then(active_response::extract_domain_target);
-    let domain_blocked = domain_target
-        .as_deref()
-        .is_some_and(active_response::is_domain_blocked);
-    let process_blocked = active_response::is_process_blocked(sel.pid, &sel.proc_path);
-    let process_remaining = active_response::process_block_remaining(sel.pid, &sel.proc_path);
-    let process_suspended = active_response::is_process_suspended(sel.pid, &sel.proc_path);
-    let connection_kill_enabled = sel
-        .selected_connection
-        .as_ref()
-        .is_some_and(active_response::can_kill_connection);
+    let inspector_state = active_response::inspector_snapshot(
+        sel.pid,
+        &sel.proc_path,
+        sel.selected_connection.as_ref(),
+    );
+    let suspend_enabled = inspector_state.suspend_enabled && !ghost;
+    let response_enabled = inspector_state.firewall_modifiable;
+    let isolation_enabled = inspector_state.network_isolation_modifiable;
+    let domain_enabled = inspector_state.domain_modifiable;
+    let response_status = inspector_state.status;
+    let remote_target = inspector_state.remote_target;
+    let remote_blocked = inspector_state.remote_blocked;
+    let remote_remaining = inspector_state.remote_remaining;
+    let domain_target = inspector_state.domain_target;
+    let domain_blocked = inspector_state.domain_blocked;
+    let process_blocked = inspector_state.process_blocked;
+    let process_remaining = inspector_state.process_remaining;
+    let process_suspended = inspector_state.process_suspended;
+    let connection_kill_enabled = inspector_state.connection_kill_enabled;
     let isolated = response_status.isolated;
-    let quarantine_ready =
-        active_response::can_apply_quarantine_profile(sel.pid, &sel.proc_path) && !ghost;
+    let quarantine_ready = inspector_state.quarantine_ready && !ghost;
     let quarantine_active = isolated || process_blocked || process_suspended;
-    let autoruns_frozen = active_response::has_frozen_autoruns();
+    let autoruns_frozen = response_status.frozen_autoruns;
 
     egui::ScrollArea::vertical().id_salt("help_scroll").show(ui, |ui| {
         ui.add_space(8.0);

--- a/src/ui/inspector.rs
+++ b/src/ui/inspector.rs
@@ -12,8 +12,9 @@ use egui::{RichText, Ui};
 use std::collections::BTreeSet;
 
 const MAX_REASON_SCAN: usize = 1_200;
-const MAX_REASON_PLAIN_ROWS: usize = 140;
-const MAX_REASON_PORT_ROWS: usize = 80;
+const MAX_REASON_PLAIN_ROWS: usize = 40;
+const MAX_REASON_PORT_ROWS: usize = 24;
+const MAX_INSPECTOR_VALUE_CHARS: usize = 600;
 
 #[derive(Debug, Clone)]
 pub enum Action {
@@ -44,9 +45,10 @@ pub fn show(
     ui: &mut Ui,
     selection: Option<&ProcessSelection>,
     kill_confirm: bool,
+    inspector_state: &active_response::InspectorSnapshot,
 ) -> Option<Action> {
     match selection {
-        Some(selection) => show_detail(ui, selection, kill_confirm),
+        Some(selection) => show_detail(ui, selection, kill_confirm, inspector_state),
         None => {
             show_placeholder(ui);
             None
@@ -65,27 +67,27 @@ fn show_placeholder(ui: &mut Ui) {
     );
 }
 
-fn show_detail(ui: &mut Ui, sel: &ProcessSelection, kill_confirm: bool) -> Option<Action> {
+fn show_detail(
+    ui: &mut Ui,
+    sel: &ProcessSelection,
+    kill_confirm: bool,
+    inspector_state: &active_response::InspectorSnapshot,
+) -> Option<Action> {
     let mut action: Option<Action> = None;
     let ghost = is_ghost_process_name(&sel.proc_name);
     let known_location = has_known_location(sel);
     let trust_enabled = known_location;
     let open_location_enabled = known_location;
     let kill_enabled = !ghost;
-    let inspector_state = active_response::inspector_snapshot(
-        sel.pid,
-        &sel.proc_path,
-        sel.selected_connection.as_ref(),
-    );
     let suspend_enabled = inspector_state.suspend_enabled && !ghost;
     let response_enabled = inspector_state.firewall_modifiable;
     let isolation_enabled = inspector_state.network_isolation_modifiable;
     let domain_enabled = inspector_state.domain_modifiable;
     let response_status = inspector_state.status;
-    let remote_target = inspector_state.remote_target;
+    let remote_target = inspector_state.remote_target.as_ref();
     let remote_blocked = inspector_state.remote_blocked;
     let remote_remaining = inspector_state.remote_remaining;
-    let domain_target = inspector_state.domain_target;
+    let domain_target = inspector_state.domain_target.as_ref();
     let domain_blocked = inspector_state.domain_blocked;
     let process_blocked = inspector_state.process_blocked;
     let process_remaining = inspector_state.process_remaining;
@@ -366,20 +368,30 @@ fn show_detail(ui: &mut Ui, sel: &ProcessSelection, kill_confirm: bool) -> Optio
             section_header(ui, "Selected connection");
             kv_mono(ui, "Local", &conn.local_addr);
             kv_mono(ui, "Remote", &conn.remote_addr);
-            if let Some(host) = domain_target.as_deref() { kv(ui, "Hostname", host); }
-            if let Some(sni) = conn.tls_sni.as_deref() { kv(ui, "TLS SNI", sni); }
-            if let Some(ja3) = conn.tls_ja3.as_deref() { kv_mono(ui, "TLS JA3", ja3); }
+            if let Some(host) = domain_target {
+                kv(ui, "Hostname", host);
+            }
+            if let Some(sni) = conn.tls_sni.as_deref() {
+                kv(ui, "TLS SNI", sni);
+            }
+            if let Some(ja3) = conn.tls_ja3.as_deref() {
+                kv_mono(ui, "TLS JA3", ja3);
+            }
             kv(ui, "Status", &conn.status);
             kv(ui, "Time", &conn.timestamp);
             if !conn.attack_tags.is_empty() {
                 kv(ui, "ATT&CK", &conn.attack_tags.join(", "));
             }
-            if !conn.reasons.is_empty() {
+            if let Some(summary) = sel
+                .selected_connection_reason_summary
+                .as_ref()
+                .filter(|summary| !summary.is_empty())
+            {
                 ui.add_space(4.0);
                 render_reason_block(
                     ui,
                     "connection",
-                    &summarize_reasons(&conn.reasons),
+                    summary,
                     "-",
                     theme::TEXT3,
                     theme::TEXT2,
@@ -524,7 +536,7 @@ pub struct ReasonSummary {
 }
 
 impl ReasonSummary {
-    fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.plain.is_empty() && self.unusual_ports.is_empty() && self.truncated_input == 0
     }
 }
@@ -649,7 +661,8 @@ fn kv(ui: &mut Ui, key: &str, val: &str) {
             [88.0, 16.0],
             egui::Label::new(RichText::new(key).color(theme::TEXT3).size(11.0)),
         );
-        ui.add(egui::Label::new(RichText::new(val).color(theme::TEXT).size(11.0)).wrap());
+        let display = bounded_display(val);
+        ui.add(egui::Label::new(RichText::new(display).color(theme::TEXT).size(11.0)).wrap());
     });
     ui.add_space(2.0);
 }
@@ -659,11 +672,27 @@ fn kv_mono(ui: &mut Ui, key: &str, val: &str) {
             [88.0, 16.0],
             egui::Label::new(RichText::new(key).color(theme::TEXT3).size(11.0)),
         );
+        let display = bounded_display(val);
         ui.add(
-            egui::Label::new(RichText::new(val).color(theme::TEXT).monospace().size(10.5)).wrap(),
+            egui::Label::new(
+                RichText::new(display)
+                    .color(theme::TEXT)
+                    .monospace()
+                    .size(10.5),
+            )
+            .wrap(),
         );
     });
     ui.add_space(2.0);
+}
+
+fn bounded_display(value: &str) -> std::borrow::Cow<'_, str> {
+    if value.len() <= MAX_INSPECTOR_VALUE_CHARS {
+        std::borrow::Cow::Borrowed(value)
+    } else {
+        let truncated: String = value.chars().take(MAX_INSPECTOR_VALUE_CHARS).collect();
+        std::borrow::Cow::Owned(format!("{truncated} ..."))
+    }
 }
 fn score_badge(ui: &mut Ui, score: u8) {
     let (fg, bg) = theme::score_colors(score);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -264,6 +264,49 @@ pub struct ProcessSelection {
     pub distinct_remotes: usize,
     pub statuses: Vec<String>,
     pub selected_connection: Option<ConnInfo>,
+    pub selected_connection_reason_summary: Option<inspector::ReasonSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InspectorSnapshotKey {
+    pid: u32,
+    proc_path: String,
+    remote_addr: Option<String>,
+    hostname: Option<String>,
+    tls_sni: Option<String>,
+}
+
+#[derive(Clone)]
+struct InspectorSnapshotRequest {
+    key: InspectorSnapshotKey,
+    pid: u32,
+    proc_path: String,
+    selected_connection: Option<ConnInfo>,
+}
+
+impl InspectorSnapshotRequest {
+    fn from_selection(sel: &ProcessSelection) -> Self {
+        let selected_connection = sel.selected_connection.clone();
+        let key = InspectorSnapshotKey {
+            pid: sel.pid,
+            proc_path: sel.proc_path.clone(),
+            remote_addr: selected_connection
+                .as_ref()
+                .map(|conn| conn.remote_addr.clone()),
+            hostname: selected_connection
+                .as_ref()
+                .and_then(|conn| conn.hostname.clone()),
+            tls_sni: selected_connection
+                .as_ref()
+                .and_then(|conn| conn.tls_sni.clone()),
+        };
+        Self {
+            key,
+            pid: sel.pid,
+            proc_path: sel.proc_path.clone(),
+            selected_connection,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -343,6 +386,11 @@ pub struct VigilApp {
     kill_confirm: bool,
     response_confirm: Option<PendingResponse>,
     response_status: active_response::Status,
+    inspector_snapshot: active_response::InspectorSnapshot,
+    inspector_snapshot_key: Option<InspectorSnapshotKey>,
+    inspector_snapshot_rx:
+        Option<mpsc::Receiver<(InspectorSnapshotKey, active_response::InspectorSnapshot)>>,
+    inspector_snapshot_last_started: std::time::Instant,
     tray_lockdown_sent: bool,
     network_operation: Option<NetworkOperation>,
     reconcile_rx: Option<mpsc::Receiver<active_response::Status>>,
@@ -374,6 +422,7 @@ const UI_EVENT_BUDGET: usize = 128;
 const UI_EVENT_TIME_BUDGET: std::time::Duration = std::time::Duration::from_millis(5);
 const UI_IDLE_REPAINT: std::time::Duration = std::time::Duration::from_secs(1);
 const UI_BUSY_REPAINT: std::time::Duration = std::time::Duration::from_millis(100);
+const INSPECTOR_SNAPSHOT_REFRESH: std::time::Duration = std::time::Duration::from_secs(1);
 const NOTIFICATION_TTL: std::time::Duration = std::time::Duration::from_secs(60);
 const COLLAPSED_PIDS_CAP: usize = 256;
 #[allow(dead_code)]
@@ -473,6 +522,11 @@ impl VigilApp {
             .and_then(|storage| eframe::get_value::<UiState>(storage, "ui"))
             .unwrap_or_default();
         let response_status = active_response::status();
+        let inspector_snapshot = active_response::InspectorSnapshot {
+            status: response_status,
+            ..Default::default()
+        };
+        let tray_lockdown_sent = !response_status.isolated;
         let vigil_logo = load_vigil_logo(&cc.egui_ctx);
         cc.egui_ctx.request_repaint_after(UI_IDLE_REPAINT);
         #[cfg(target_os = "linux")]
@@ -515,7 +569,11 @@ impl VigilApp {
             kill_confirm: false,
             response_confirm: None,
             response_status,
-            tray_lockdown_sent: !response_status.isolated,
+            inspector_snapshot,
+            inspector_snapshot_key: None,
+            inspector_snapshot_rx: None,
+            inspector_snapshot_last_started: std::time::Instant::now() - INSPECTOR_SNAPSHOT_REFRESH,
+            tray_lockdown_sent,
             network_operation: None,
             reconcile_rx: None,
             scheduled_target: None,
@@ -608,7 +666,7 @@ impl VigilApp {
         if let Some(rx) = self.reconcile_rx.as_ref() {
             match rx.try_recv() {
                 Ok(status) => {
-                    self.response_status = status;
+                    self.set_response_status(status);
                     self.reconcile_rx = None;
                 }
                 Err(mpsc::TryRecvError::Disconnected) => {
@@ -642,6 +700,90 @@ impl VigilApp {
         if self.last_schedule_check.elapsed().as_secs() >= 30 {
             self.apply_scheduled_lockdown();
             self.last_schedule_check = std::time::Instant::now();
+        }
+    }
+
+    fn set_response_status(&mut self, status: active_response::Status) {
+        self.response_status = status;
+        self.inspector_snapshot.status = status;
+    }
+
+    fn current_inspector_request(&self) -> Option<InspectorSnapshotRequest> {
+        match self.active_tab {
+            Tab::Activity => self.selected_activity.as_ref(),
+            Tab::Alerts => self.selected_alert.as_ref(),
+            _ => None,
+        }
+        .map(InspectorSnapshotRequest::from_selection)
+    }
+
+    fn refresh_inspector_snapshot(&mut self, request: Option<InspectorSnapshotRequest>) {
+        if let Some(rx) = self.inspector_snapshot_rx.as_ref() {
+            match rx.try_recv() {
+                Ok((key, snapshot)) => {
+                    if self.inspector_snapshot_key.as_ref() == Some(&key) {
+                        let status = snapshot.status;
+                        self.inspector_snapshot = snapshot;
+                        self.set_response_status(status);
+                    }
+                    self.inspector_snapshot_rx = None;
+                }
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    self.inspector_snapshot_rx = None;
+                }
+                Err(mpsc::TryRecvError::Empty) => {}
+            }
+        }
+
+        let Some(request) = request else {
+            self.inspector_snapshot_key = None;
+            self.inspector_snapshot_rx = None;
+            self.inspector_snapshot = active_response::InspectorSnapshot {
+                status: self.response_status,
+                ..Default::default()
+            };
+            return;
+        };
+
+        let key_changed = self.inspector_snapshot_key.as_ref() != Some(&request.key);
+        if key_changed {
+            self.inspector_snapshot_key = Some(request.key.clone());
+            self.inspector_snapshot_rx = None;
+            self.inspector_snapshot = active_response::InspectorSnapshot {
+                status: self.response_status,
+                ..Default::default()
+            };
+        }
+
+        if self.inspector_snapshot_rx.is_some()
+            || (!key_changed
+                && self.inspector_snapshot_last_started.elapsed() < INSPECTOR_SNAPSHOT_REFRESH)
+        {
+            return;
+        }
+
+        let (tx, rx) = mpsc::channel();
+        let key = request.key.clone();
+        match std::thread::Builder::new()
+            .name("vigil-inspector-snapshot".into())
+            .spawn(move || {
+                let snapshot = active_response::inspector_snapshot(
+                    request.pid,
+                    &request.proc_path,
+                    request.selected_connection.as_ref(),
+                );
+                let _ = tx.send((key, snapshot));
+            }) {
+            Ok(_) => {
+                self.inspector_snapshot_rx = Some(rx);
+                self.inspector_snapshot_last_started = std::time::Instant::now();
+            }
+            Err(err) => {
+                self.push_notification(
+                    NotificationKind::Error,
+                    format!("Could not start inspector worker: {err}"),
+                );
+            }
         }
     }
 
@@ -722,7 +864,7 @@ impl VigilApp {
                             self.push_notification(kind, text);
                         }
                         UiMessage::ResponseStatus(status) => {
-                            self.response_status = status;
+                            self.set_response_status(status);
                         }
                     }
                 }
@@ -1333,7 +1475,7 @@ impl VigilApp {
                         let result = Self::execute_pending_response(&pending);
                         let kind = Self::kind_from_message(&result);
                         self.push_notification(kind, result);
-                        self.response_status = active_response::status();
+                        self.set_response_status(active_response::status());
                         self.response_confirm = None;
                     }
                     if ui
@@ -1498,7 +1640,7 @@ impl VigilApp {
                         matches!(operation_kind, NetworkOperationKind::Isolate);
                 }
                 self.push_notification(notification_kind, message);
-                self.response_status = result.status;
+                self.set_response_status(result.status);
             }
             Err(mpsc::TryRecvError::Empty) => {}
             Err(mpsc::TryRecvError::Disconnected) => {
@@ -1821,6 +1963,8 @@ impl eframe::App for VigilApp {
             self.kill_confirm = false;
         }
         let mut inspector_action: Option<inspector::Action> = None;
+        let inspector_request = self.current_inspector_request();
+        self.refresh_inspector_snapshot(inspector_request);
         if matches!(self.active_tab, Tab::Activity | Tab::Alerts) {
             let selected_info: Option<&ProcessSelection> = match self.active_tab {
                 Tab::Activity => self.selected_activity.as_ref(),
@@ -1837,7 +1981,9 @@ impl eframe::App for VigilApp {
                         .stroke(egui::Stroke::new(1.0, theme::BORDER))
                         .inner_margin(egui::Margin::symmetric(12, 0)),
                 )
-                .show_inside(ui, |ui| inspector::show(ui, selected_info, kill_confirm))
+                .show_inside(ui, |ui| {
+                    inspector::show(ui, selected_info, kill_confirm, &self.inspector_snapshot)
+                })
                 .inner;
         }
         if let Some(action) = inspector_action {
@@ -1940,7 +2086,10 @@ impl eframe::App for VigilApp {
         self.show_notifications_overlay(&ctx);
         self.show_network_operation_overlay(&ctx);
         ctx.request_repaint_after(
-            if self.network_operation.is_some() || !self.notifications.is_empty() {
+            if self.network_operation.is_some()
+                || self.inspector_snapshot_rx.is_some()
+                || !self.notifications.is_empty()
+            {
                 UI_BUSY_REPAINT
             } else {
                 UI_IDLE_REPAINT

--- a/src/ui/process_list.rs
+++ b/src/ui/process_list.rs
@@ -569,11 +569,11 @@ fn grouped_rows<'a>(
     filter: &str,
     kind: Kind,
 ) -> Vec<ProcessGroup<'a>> {
-    let f = filter.to_lowercase();
+    let lower = filter.to_ascii_lowercase();
     let mut groups: HashMap<u32, ProcessGroup<'a>> = HashMap::new();
     let mut order: Vec<u32> = Vec::new();
 
-    for info in rows.iter().filter(|r| matches_filter(r, &f, kind)) {
+    for info in rows.iter().filter(|info| matches_filter(info, &lower, kind)) {
         let entry = groups.entry(info.pid).or_insert_with(|| {
             order.push(info.pid);
             ProcessGroup {
@@ -656,7 +656,6 @@ fn grouped_rows<'a>(
             group.distinct_remotes = remotes.len();
             group.statuses = statuses;
             group.reasons = dedup_reasons(reasons);
-            group.reason_summary = summarize_reasons(&group.reasons);
             group.attack_tags = dedup_reasons(attack_tags);
             group.endpoint_rows = endpoint_map
                 .into_values()
@@ -686,6 +685,7 @@ fn grouped_rows<'a>(
                     group.distinct_remotes
                 ));
             }
+            group.reason_summary = summarize_reasons(&group.reasons);
             group.score = group.score.saturating_add(fanout_bonus(
                 group.conn_count,
                 group.distinct_ports,

--- a/src/ui/process_list.rs
+++ b/src/ui/process_list.rs
@@ -573,7 +573,10 @@ fn grouped_rows<'a>(
     let mut groups: HashMap<u32, ProcessGroup<'a>> = HashMap::new();
     let mut order: Vec<u32> = Vec::new();
 
-    for info in rows.iter().filter(|info| matches_filter(info, &lower, kind)) {
+    for info in rows
+        .iter()
+        .filter(|info| matches_filter(info, &lower, kind))
+    {
         let entry = groups.entry(info.pid).or_insert_with(|| {
             order.push(info.pid);
             ProcessGroup {
@@ -692,6 +695,7 @@ fn grouped_rows<'a>(
                 group.distinct_remotes,
                 group.statuses.len(),
             ));
+            group.reason_summary = summarize_reasons(&group.reasons);
             out.push(group);
         }
     }
@@ -806,6 +810,9 @@ fn selection_from_group(
     group: &ProcessGroup<'_>,
     selected_connection: Option<ConnInfo>,
 ) -> ProcessSelection {
+    let selected_connection_reason_summary = selected_connection
+        .as_ref()
+        .map(|conn| summarize_reasons(&conn.reasons));
     ProcessSelection {
         pid: group.pid,
         proc_name: group.proc_name.to_string(),
@@ -833,6 +840,7 @@ fn selection_from_group(
         distinct_remotes: group.distinct_remotes,
         statuses: group.statuses.clone(),
         selected_connection,
+        selected_connection_reason_summary,
     }
 }
 

--- a/src/ui/process_list.rs
+++ b/src/ui/process_list.rs
@@ -47,6 +47,7 @@ struct ProcessGroup<'a> {
     distinct_remotes: usize,
     statuses: Vec<String>,
     reasons: Vec<String>,
+    reason_summary: crate::ui::inspector::ReasonSummary,
     attack_tags: Vec<String>,
     baseline_deviation: bool,
     script_host_suspicious: bool,
@@ -597,6 +598,7 @@ fn grouped_rows<'a>(
                 distinct_remotes: 0,
                 statuses: Vec::new(),
                 reasons: Vec::new(),
+                reason_summary: Default::default(),
                 attack_tags: Vec::new(),
                 baseline_deviation: false,
                 script_host_suspicious: false,
@@ -654,6 +656,7 @@ fn grouped_rows<'a>(
             group.distinct_remotes = remotes.len();
             group.statuses = statuses;
             group.reasons = dedup_reasons(reasons);
+            group.reason_summary = summarize_reasons(&group.reasons);
             group.attack_tags = dedup_reasons(attack_tags);
             group.endpoint_rows = endpoint_map
                 .into_values()
@@ -815,7 +818,7 @@ fn selection_from_group(
         service_name: group.service_name.to_string(),
         publisher: group.publisher.to_string(),
         score: group.score,
-        reason_summary: summarize_reasons(&group.reasons),
+        reason_summary: group.reason_summary.clone(),
         attack_tags: group.attack_tags.clone(),
         baseline_deviation: group.baseline_deviation,
         script_host_suspicious: group.script_host_suspicious,

--- a/src/ui/process_list_fast.rs
+++ b/src/ui/process_list_fast.rs
@@ -65,7 +65,7 @@ struct OwnedProcessGroup {
     distinct_ports: usize,
     distinct_remotes: usize,
     statuses: Vec<String>,
-    reasons: Vec<String>,
+    reason_summary: crate::ui::inspector::ReasonSummary,
     attack_tags: Vec<String>,
     baseline_deviation: bool,
     script_host_suspicious: bool,
@@ -528,6 +528,7 @@ fn build_view(
                     group.distinct_remotes.len()
                 ));
             }
+            let reason_summary = summarize_reasons(&reasons);
             out_groups.push(OwnedProcessGroup {
                 pid: group.pid,
                 proc_name: group.proc_name,
@@ -552,7 +553,7 @@ fn build_view(
                 distinct_ports: group.distinct_ports.len(),
                 distinct_remotes: group.distinct_remotes.len(),
                 statuses: group.statuses,
-                reasons,
+                reason_summary,
                 attack_tags,
                 baseline_deviation: group.baseline_deviation,
                 script_host_suspicious: group.script_host_suspicious,
@@ -708,7 +709,7 @@ fn selection_from_group(
         service_name: group.service_name.clone(),
         publisher: group.publisher.clone(),
         score: group.score,
-        reason_summary: summarize_reasons(&group.reasons),
+        reason_summary: group.reason_summary.clone(),
         attack_tags: group.attack_tags.clone(),
         baseline_deviation: group.baseline_deviation,
         script_host_suspicious: group.script_host_suspicious,

--- a/src/ui/process_list_fast.rs
+++ b/src/ui/process_list_fast.rs
@@ -697,6 +697,9 @@ fn selection_from_group(
     group: &OwnedProcessGroup,
     selected_connection: Option<ConnInfo>,
 ) -> ProcessSelection {
+    let selected_connection_reason_summary = selected_connection
+        .as_ref()
+        .map(|conn| summarize_reasons(&conn.reasons));
     ProcessSelection {
         pid: group.pid,
         proc_name: group.proc_name.clone(),
@@ -724,6 +727,7 @@ fn selection_from_group(
         distinct_remotes: group.distinct_remotes,
         statuses: group.statuses.clone(),
         selected_connection,
+        selected_connection_reason_summary,
     }
 }
 


### PR DESCRIPTION
## What changed

Move the selected-process inspector and selected-row summary work out of the repaint loop.

- The process-group renderer now precomputes the process reason summary when the group cache is built.
- The inspector now consumes a single active-response snapshot instead of probing the protected state repeatedly on every frame.
- The goal is to keep rendering independent of other live system work so selecting a process does not stall the UI.

## Why

The app stayed slow after selection because the inspector kept re-reading containment state and rebuilding derived detail on every repaint.

## Impact

- Process selection should stay responsive even when the selected process has many reasons or the active-response store is busy.
- The selected process view still shows the same information, but the expensive lookups are now cached or consolidated.
- The Windows installer binary was rebuilt from this branch.

## Validation

- `cargo fmt --all`
- `cargo check`
- `cargo test --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings -A clippy::collapsible_match -A clippy::ptr_arg -A clippy::unnecessary_map_or`
- `cargo build --release`