### PR TITLE
[codex] decouple desktop notifications from tray updates

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -398,7 +398,28 @@ fn main() {
     let pending_nav_tray = pending_nav.clone();
     let pending_nav_ui = pending_nav.clone();
     let (tray_tx, tray_rx) = std::sync::mpsc::sync_channel::<tray::TrayCmd>(64);
-    let ui_rx = ui::spawn_event_worker(event_rx, cfg.clone(), tray_tx.clone(), paused_flag.clone());
+    let (notify_tx, notify_rx) = std::sync::mpsc::sync_channel::<crate::types::ConnInfo>(128);
+    let show_window_notify = show_window.clone();
+    let pending_nav_notify = pending_nav.clone();
+    std::thread::Builder::new()
+        .name("vigil-desktop-notifier".into())
+        .spawn(move || {
+            while let Ok(info) = notify_rx.recv() {
+                notifier::send_alert(
+                    &info,
+                    show_window_notify.clone(),
+                    pending_nav_notify.clone(),
+                );
+            }
+        })
+        .expect("failed to spawn desktop notifier thread");
+    let ui_rx = ui::spawn_event_worker(
+        event_rx,
+        cfg.clone(),
+        tray_tx.clone(),
+        notify_tx,
+        paused_flag.clone(),
+    );
 
     let egui_ctx: Arc<std::sync::OnceLock<egui::Context>> = Arc::new(std::sync::OnceLock::new());
     let egui_ctx_tray = egui_ctx.clone();

--- a/src/platform/tray.rs
+++ b/src/platform/tray.rs
@@ -586,11 +586,7 @@ mod imp {
             while let Ok(cmd) = cmd_rx.try_recv() {
                 match cmd {
                     TrayCmd::Alert(info) => {
-                        crate::notifier::send_alert(
-                            &info,
-                            show_window.clone(),
-                            pending_nav.clone(),
-                        );
+                        let _ = info;
                         in_alert = true;
                         alert_since = Some(std::time::Instant::now());
                         apply(&handle, in_alert, in_lockdown);

--- a/src/platform/tray.rs
+++ b/src/platform/tray.rs
@@ -8,7 +8,9 @@
 //!
 //! # Commands
 //! The caller forwards `TrayCmd` values over a `std::sync::mpsc` channel:
-//! - `Alert(Box<ConnInfo>)` — display a notification, switch icon to ⚠
+//! - `Alert(Box<ConnInfo>)` — switch icon to ⚠. Desktop notifications are
+//!   dispatched by the dedicated notifier worker so tray health cannot suppress
+//!   alert toasts.
 //! - `ResetOk`         — switch icon back to the normal ● state
 //! - `SetLockdown(bool)` — force red icon while network isolation is active
 //!
@@ -53,15 +55,13 @@ const TRAY_RED_ICO: &[u8] = include_bytes!(concat!(
 
 fn notification_only_loop(
     cmd_rx: Receiver<TrayCmd>,
-    show_window: Arc<AtomicBool>,
-    pending_nav: Arc<Mutex<Option<ConnInfo>>>,
+    _show_window: Arc<AtomicBool>,
+    _pending_nav: Arc<Mutex<Option<ConnInfo>>>,
 ) {
     loop {
         while let Ok(cmd) = cmd_rx.try_recv() {
             match cmd {
-                TrayCmd::Alert(info) => {
-                    crate::notifier::send_alert(&info, show_window.clone(), pending_nav.clone());
-                }
+                TrayCmd::Alert(_) => {}
                 TrayCmd::ResetOk | TrayCmd::SetLockdown(_) => {}
             }
         }
@@ -229,7 +229,7 @@ mod imp {
         logs_id: tray_icon::menu::MenuId,
         log_dir: PathBuf,
         show_window: Arc<AtomicBool>,
-        pending_nav: Arc<Mutex<Option<ConnInfo>>>,
+        _pending_nav: Arc<Mutex<Option<ConnInfo>>>,
         _egui_ctx: Arc<OnceLock<egui::Context>>,
     ) {
         use windows::Win32::UI::WindowsAndMessaging::{
@@ -275,11 +275,7 @@ mod imp {
             while let Ok(cmd) = cmd_rx.try_recv() {
                 match cmd {
                     TrayCmd::Alert(info) => {
-                        crate::notifier::send_alert(
-                            &info,
-                            show_window.clone(),
-                            pending_nav.clone(),
-                        );
+                        let _ = info;
                         in_alert = true;
                         apply_tray_visual_state(&tray, &icons, in_alert, in_lockdown);
                     }
@@ -340,11 +336,7 @@ mod imp {
             while let Ok(cmd) = cmd_rx.try_recv() {
                 match cmd {
                     TrayCmd::Alert(info) => {
-                        crate::notifier::send_alert(
-                            &info,
-                            show_window.clone(),
-                            pending_nav.clone(),
-                        );
+                        let _ = info;
                         in_alert = true;
                         apply_tray_visual_state(&tray, &icons, in_alert, in_lockdown);
                     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -154,6 +154,7 @@ pub fn spawn_event_worker(
     mut event_rx: tokio::sync::broadcast::Receiver<ConnEvent>,
     cfg: Arc<RwLock<Config>>,
     tray_tx: std::sync::mpsc::SyncSender<TrayCmd>,
+    notify_tx: std::sync::mpsc::SyncSender<ConnInfo>,
     paused: Arc<AtomicBool>,
 ) -> mpsc::Receiver<UiMessage> {
     let (ui_tx, ui_rx) = mpsc::channel::<UiMessage>();
@@ -170,7 +171,14 @@ pub fn spawn_event_worker(
                         }
                         match &event {
                             ConnEvent::Alert(info) => {
-                                let _ = tray_tx.try_send(TrayCmd::Alert(Box::new(info.clone())));
+                                if let Err(err) = notify_tx.try_send(info.clone()) {
+                                    tracing::warn!("desktop alert notification dropped: {err}");
+                                }
+                                if let Err(err) =
+                                    tray_tx.try_send(TrayCmd::Alert(Box::new(info.clone())))
+                                {
+                                    tracing::warn!("tray alert state update dropped: {err}");
+                                }
                                 let cfg_snapshot = cfg.read().unwrap().clone();
                                 if let Some(message) = auto_response::maybe_apply(
                                     info,


### PR DESCRIPTION
## What changed
- Adds a dedicated desktop-notifier worker for alert toasts.
- Keeps the tray command path responsible for icon state only.
- Logs dropped notification or tray update commands instead of silently ignoring them.

## Why
Windows alert toasts were coupled to the tray loop and alert commands used `try_send` with ignored errors. If the tray channel was full, disconnected, or the tray loop was unhealthy, an alert notification could be silently lost.

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings -A clippy::collapsible_match -A clippy::ptr_arg -A clippy::unnecessary_map_or
- cargo test --all-targets --all-features
- cargo build --release

Authored-by: Codex (GPT-5.4-Mini)
