### PR TITLE
fix(service): force service-mode to use shared Vigil data directory

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -386,6 +386,10 @@ impl Default for Config {
 }
 
 pub fn data_dir() -> PathBuf {
+    if let Some(dir) = std::env::var_os("VIGIL_DATA_DIR") {
+        return PathBuf::from(dir);
+    }
+
     #[cfg(target_os = "windows")]
     {
         if let Some(dir) = std::env::var_os("LOCALAPPDATA") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,7 +279,10 @@ fn main() {
     let mut elevated_relaunch = false;
     let mut elevated_launcher = false;
     let mut service_mode = false;
-    for a in &args[1..] {
+    let mut data_dir_override: Option<String> = None;
+    let mut i = 1usize;
+    while i < args.len() {
+        let a = &args[i];
         match a.as_str() {
             "--install-service" => std::process::exit(service::run_cmd("install")),
             "--uninstall-service" => std::process::exit(service::run_cmd("uninstall")),
@@ -293,12 +296,25 @@ fn main() {
             autostart::ELEVATED_LAUNCHER_FLAG => {
                 elevated_launcher = true;
             }
+            service::DATA_DIR_FLAG => {
+                let Some(path) = args.get(i + 1) else {
+                    eprintln!("Missing path after {}", service::DATA_DIR_FLAG);
+                    std::process::exit(1);
+                };
+                data_dir_override = Some(path.clone());
+                i += 1;
+            }
             "--help" | "-h" => {
-                println!("Vigil v{} — real-time network threat monitor\n\nUsage:  vigil [flags]\n\nFlags:\n  --install-service         register Vigil as a boot-time service\n  --uninstall-service       remove the boot-time service\n  --break-glass-recover     watchdog entrypoint for network recovery\n  --verify-update-manifest  MANIFEST SIG\n                           verify a signed release manifest against the embedded trust anchor\n  --import-nvd-snapshot     SNAPSHOT.json [MORE.json ...]\n                           import or merge one or more NVD CVE JSON snapshots into the protected advisory cache\n  --sync-nvd [--force]      fetch or incrementally refresh the protected NVD CVE cache from the live API\n  --advisory-cache-status   show advisory cache status and source health\n  --service-mode            internal headless service entrypoint\n  -h, --help                show this help and exit\n\nRun with no flags to launch the GUI.", env!("CARGO_PKG_VERSION"));
+                println!("Vigil v{} — real-time network threat monitor\n\nUsage:  vigil [flags]\n\nFlags:\n  --install-service         register Vigil as a boot-time service\n  --uninstall-service       remove the boot-time service\n  --break-glass-recover     watchdog entrypoint for network recovery\n  --verify-update-manifest  MANIFEST SIG\n                           verify a signed release manifest against the embedded trust anchor\n  --import-nvd-snapshot     SNAPSHOT.json [MORE.json ...]\n                           import or merge one or more NVD CVE JSON snapshots into the protected advisory cache\n  --sync-nvd [--force]      fetch or incrementally refresh the protected NVD CVE cache from the live API\n  --advisory-cache-status   show advisory cache status and source health\n  --service-mode            internal headless service entrypoint\n  --data-dir PATH           override Vigil data/config directory\n  -h, --help                show this help and exit\n\nRun with no flags to launch the GUI.", env!("CARGO_PKG_VERSION"));
                 std::process::exit(0);
             }
             _ => {}
         }
+        i += 1;
+    }
+
+    if let Some(path) = data_dir_override {
+        std::env::set_var("VIGIL_DATA_DIR", path);
     }
 
     if elevated_launcher {

--- a/src/platform/service.rs
+++ b/src/platform/service.rs
@@ -26,6 +26,7 @@ pub type CmdResult = Result<String, String>;
 
 /// Internal headless entrypoint used by OS services / daemons.
 pub const SERVICE_MODE_FLAG: &str = "--service-mode";
+pub const DATA_DIR_FLAG: &str = "--data-dir";
 
 pub fn install() -> CmdResult {
     let exe =
@@ -50,7 +51,17 @@ mod platform {
     const LEGACY_SERVICE_NAME: &str = "Vigil";
 
     pub fn install(exe: &Path) -> CmdResult {
-        let task_command = format!(r#""{}" {}"#, exe.display(), SERVICE_MODE_FLAG);
+        let shared_data_dir = exe
+            .parent()
+            .map(|d| d.join("vigil-data"))
+            .ok_or_else(|| format!("could not determine parent directory for {}", exe.display()))?;
+        let task_command = format!(
+            r#""{}" {} {} "{}""#,
+            exe.display(),
+            SERVICE_MODE_FLAG,
+            DATA_DIR_FLAG,
+            shared_data_dir.display()
+        );
         let status = Command::new(command_paths::resolve("schtasks")?)
             .args([
                 "/Create",
@@ -209,6 +220,10 @@ mod platform {
                 .into());
         }
 
+        let shared_data_dir = exe
+            .parent()
+            .map(|d| d.join("vigil-data"))
+            .ok_or_else(|| format!("could not determine parent directory for {}", exe.display()))?;
         let exe = xml_escape(&exe.display().to_string());
         let plist = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -216,7 +231,7 @@ mod platform {
 <plist version="1.0">
 <dict>
     <key>Label</key>             <string>{LABEL}</string>
-    <key>ProgramArguments</key>  <array><string>{exe}</string><string>{service_flag}</string></array>
+    <key>ProgramArguments</key>  <array><string>{exe}</string><string>{service_flag}</string><string>{data_dir_flag}</string><string>{shared_data_dir}</string></array>
     <key>RunAtLoad</key>         <true/>
     <key>KeepAlive</key>         <true/>
     <key>StandardOutPath</key>   <string>/var/log/vigil.log</string>
@@ -226,6 +241,8 @@ mod platform {
 "#,
             exe = exe,
             service_flag = SERVICE_MODE_FLAG,
+            data_dir_flag = DATA_DIR_FLAG,
+            shared_data_dir = xml_escape(&shared_data_dir.display().to_string()),
         );
         let path = plist_path();
         std::fs::write(&path, plist.as_bytes())
@@ -310,6 +327,10 @@ mod platform {
                 .into());
         }
 
+        let shared_data_dir = exe
+            .parent()
+            .map(|d| d.join("vigil-data"))
+            .ok_or_else(|| format!("could not determine parent directory for {}", exe.display()))?;
         let exe = systemd_quote(&exe.display().to_string());
         let unit = format!(
             "[Unit]\n\
@@ -318,7 +339,7 @@ mod platform {
              \n\
              [Service]\n\
              Type=simple\n\
-             ExecStart={exe} {service_flag}\n\
+             ExecStart={exe} {service_flag} {data_dir_flag} {shared_data_dir}\n\
              Restart=on-failure\n\
              RestartSec=5\n\
              StandardOutput=journal\n\
@@ -328,6 +349,8 @@ mod platform {
              WantedBy=multi-user.target\n",
             exe = exe,
             service_flag = SERVICE_MODE_FLAG,
+            data_dir_flag = DATA_DIR_FLAG,
+            shared_data_dir = systemd_quote(&shared_data_dir.display().to_string()),
         );
         let path = unit_path();
         std::fs::write(&path, unit.as_bytes())


### PR DESCRIPTION
### Motivation
- Service/daemon installs started the monitor with `--service-mode` but still resolved config and logs from per-user environment variables, causing service-mode to run with a different (service account) policy and log location than the operator GUI.
- The change is intended to ensure boot-time monitoring uses a deterministic shared data/config directory so pre-login detections and operator policy remain consistent.

### Description
- Added a new internal CLI flag `--data-dir` (`service::DATA_DIR_FLAG`) and made installers pass `--data-dir <exe_dir>/vigil-data` together with `--service-mode` for Windows, macOS, and Linux service/unit installation code in `src/platform/service.rs`.
- Updated startup argument parsing in `src/main.rs` to accept `--data-dir` early, set `VIGIL_DATA_DIR` before logger and config initialization, and keep GUI behavior unchanged when the flag is not provided.
- Modified `src/config.rs::data_dir()` to honor the `VIGIL_DATA_DIR` environment variable first and fall back to the existing per-user lookup logic otherwise.
- The change is minimal and preserves existing behavior for normal desktop runs while forcing a shared data/log/config path when services are installed and launched with the new flag.

### Testing
- Ran `cargo fmt --all` successfully to format changes.
- Ran `cargo check` successfully and the project compiles in the `dev` profile (no compilation errors reported).
- No automated unit tests were added or modified by this patch and existing build checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f4adc4debc832889784754def6b6fc)