### PR TITLE
ci: skip Rust jobs for PRs without Rust-related changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
-    paths-ignore:
-      - '**/*.md'
 
 env:
   CARGO_TERM_COLOR: always
@@ -18,9 +16,38 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect Rust-related changes
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 1
+
+      - id: filter
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          changed_files=$(git diff --name-only FETCH_HEAD...HEAD)
+
+          if printf '%s\n' "$changed_files" | grep -Eq '(^|/).*\.rs$|^Cargo\.(toml|lock)$|(^|/)build\.rs$'; then
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "rust=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # ── Format + lint (fast gate) ────────────────────────────────────────────────
   check:
     name: Format & lint
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -45,7 +72,8 @@ jobs:
   # ── Build + test matrix ──────────────────────────────────────────────────────
   build:
     name: Build & test (${{ matrix.target }})
-    needs: check
+    needs: [changes, check]
+    if: needs.changes.outputs.rust == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths-ignore:
+      - '**/*.md'
 
 env:
   CARGO_TERM_COLOR: always
@@ -23,10 +25,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - name: Install Rust 1.94.1
+      - name: Install Rust stable
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
-          toolchain: 1.94.1
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - name: Install Rust stable
+      - name: Install Rust 1.94.1
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
+          toolchain: 1.94.1
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           git fetch --no-tags origin "${{ github.base_ref }}"
           changed_files=$(git diff --name-only FETCH_HEAD...HEAD)
 
-          if printf '%s\n' "$changed_files" | grep -Eq '(^|/).*\.rs$|^Cargo\.(toml|lock)$|(^|/)build\.rs$'; then
+          if printf '%s\n' "$changed_files" | grep -Eq '(^|/).*\.rs$|(^|/)Cargo\.(toml|lock)$|(^|/)build\.rs$'; then
             echo "rust=true" >> "$GITHUB_OUTPUT"
           else
             echo "rust=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - id: filter
         shell: bash
@@ -34,7 +34,7 @@ jobs:
             exit 0
           fi
 
-          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          git fetch --no-tags origin "${{ github.base_ref }}"
           changed_files=$(git diff --name-only FETCH_HEAD...HEAD)
 
           if printf '%s\n' "$changed_files" | grep -Eq '(^|/).*\.rs$|^Cargo\.(toml|lock)$|(^|/)build\.rs$'; then


### PR DESCRIPTION
## Summary
- detect whether a pull request touches Rust-related files before running the Rust `CI` jobs
- keep the existing Rust checks on `master` pushes and on pull requests that change Rust sources or Cargo/build inputs
- stop blocking docs-only and workflow-only pull requests on unrelated formatter drift in `src/advisory_history.rs`

## Why
PR #150 is a Markdown-only docs update, but its merge ref currently fails `cargo fmt --check` because `src/advisory_history.rs` needs a formatter-only refresh under the current Rust stable toolchain.

That formatter drift is real, but it is unrelated to pull requests that do not touch Rust build or source files. This change keeps the repository honest about code changes while avoiding avoidable CI failures on non-Rust maintenance work.

## Follow-up
- `src/advisory_history.rs` should still be reformatted under the current stable toolchain
- once that lands, the repository can decide whether this targeted PR-change detection still earns its keep

Closes #151.