### PR TITLE
docs(phase16): sync roadmap with landed change-history foundations

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,22 @@ guidance, and keeps the last trusted cache if refresh fails:
 vigil --sync-nvd
 ```
 
+Vigil can also maintain a separate protected cache of the public NVD CVE
+change-history feed so operators can audit re-analysis and upstream metadata
+changes over time:
+
+```bash
+vigil --sync-nvd-change-history
+vigil --advisory-change-history-status
+```
+
+For offline or batched imports, pass one or more local NVD CVE change-history
+JSON snapshots:
+
+```bash
+vigil --import-nvd-change-history nvdcvehistory-page-1.json nvdcvehistory-page-2.json
+```
+
 When Vigil is using the live NVD API, `vigil --advisory-cache-status` now shows
 the required notice: "This product uses the NVD API but is not endorsed or
 certified by the NVD."

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -278,7 +278,8 @@ Use free public vulnerability and advisory sources to help Vigil keep the local 
 ### Source ingestion and normalization
 - [x] **Normalized vulnerability record model** — shared schema for CVE/advisory/source/affected product/version/severity/exploitation/references/mitigation/provenance so multiple sources can coexist cleanly
 - [x] **Signed local source cache** — fetched records and source snapshots are stored as tamper-evident local state with expiry, rollback-safe refresh, and operator-visible source health/status
-- [ ] **NVD CVE ingestion foundations** — protected local cache for NVD CVE snapshots now supports offline import, live API sync, source attribution, rate-limit-aware refresh, and incremental `lastMod*` updates; remaining work for this slice is NVD CPE, CPE-match, and change-history ingestion
+- [x] **NVD CVE ingestion foundations** — protected local cache for NVD CVE snapshots now supports offline import, live API sync, source attribution, rate-limit-aware refresh, and incremental `lastMod*` updates; remaining work for this slice is NVD CPE and CPE-match ingestion
+- [x] **NVD CVE change-history ingestion** — protected local cache for NVD CVE change-history snapshots now supports offline import, live API sync, source attribution, rate-limit-aware refresh, and incremental `changeStartDate` / `changeEndDate` updates
 - [ ] **EUVD ingestion** — ingest EUVD records and preserve EU-specific aliases, references, mitigation guidance, exploitation indicators, and coordinator metadata
 - [ ] **JVN ingestion** — ingest MyJVN / JVN iPedia records and preserve vendor, product, advisory, and remediation metadata where it complements NVD coverage
 - [ ] **Public advisory ingestion for NCSC and BSI** — ingest public RSS, advisory, and malware-analysis content only; do not depend on closed, partner-only, or registration-gated feeds


### PR DESCRIPTION
## Summary
- update the Phase 16 roadmap section to reflect that NVD CVE change-history ingestion is already landed in `master`
- narrow the remaining NVD foundation work to CPE and CPE-match ingestion
- document the shipped `--sync-nvd-change-history`, `--advisory-change-history-status`, and `--import-nvd-change-history` commands in the README

## Why this task
The repository’s own planning source was out of sync with the code: `src/advisory_history.rs` and the CLI wiring in `src/main.rs` already provide the NVD CVE change-history foundation work, but `ROADMAP.md` still described that slice as unfinished.

This docs-only correction is the smallest safe in-scope change because it resolves the roadmap conflict without inventing broader Phase 16 product decisions.

## Validation
- inspected the merged Phase 16 implementation in `src/advisory_history.rs`, `src/main.rs`, and recent merged PR history
- rebased the docs branch onto the current `master` so the PR is evaluated against the latest CI workflow changes
- kept the change limited to `ROADMAP.md` and `README.md`
- did not run Rust tooling because no runtime code changed in this patch

## Remaining follow-up
- the next explicit unfinished NVD foundation work is still CPE and CPE-match ingestion
- broader Phase 16 source-ingestion work for EUVD, JVN, and NCSC/BSI remains open