### PR TITLE
installer(windows): restore boot-time monitor setup for admin installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,10 @@ Vigil also runs two passive persistence watchers that raise synthetic alerts
 
 1. Download `Vigil-Setup-<version>-x86_64.exe` from the [latest release].
 2. Run the installer — by default it installs for the current user, creates a
-   Start Menu shortcut, and registers it for autostart. If you choose an
-   all-users install during setup, Vigil is installed in `Program Files`.
+   Start Menu shortcut, and enables Vigil to start when you log in.
+3. If you want monitoring to begin before login, choose an all-users install
+   during setup. On Windows, the elevated installer now registers the boot-time
+   monitor service automatically for that install mode.
 
 > **Note:** ETW-based real-time monitoring requires Administrator rights.
 > Without elevation, Vigil falls back to polling every few seconds — all
@@ -381,7 +383,9 @@ Connections captured before login get a **+2 score bump** and a red
 **`PL`** badge in the Time column, so when the first user logs in they
 immediately see everything the monitor caught during boot.
 
-From an elevated shell:
+On Windows, the all-users installer path now registers this boot-time monitor
+service automatically. You can still install or repair it manually from an
+elevated shell:
 
 | OS      | Command                                          |
 | ------- | ------------------------------------------------ |
@@ -393,7 +397,7 @@ To remove the boot-time service, replace with `--uninstall-service`.
 
 Under the hood:
 
-- Windows uses the Service Control Manager (`sc create Vigil …`).
+- Windows uses Task Scheduler with an `ONSTART` task that runs Vigil as `SYSTEM`.
 - macOS writes a launchd system daemon at
   `/Library/LaunchDaemons/com.vigil.monitor.plist` and `launchctl load`s it.
 - Linux writes a systemd unit at `/etc/systemd/system/vigil.service` and

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -20,10 +20,10 @@ Vigil is intentionally conservative about action. Scores and advisory context ar
 ### Windows
 
 1. Download the Windows installer from the latest GitHub Release.
-2. Run the installer. By default it installs for the current user; if you
-   choose an all-users install during setup, it installs to `Program Files`.
-3. Launch Vigil from the Start Menu or the installed shortcut.
-4. Use **Run as Admin** in the header when you need ETW visibility or active response actions.
+2. Run the installer. By default it installs for the current user and enables Vigil to start when you log in.
+3. If you want Vigil to start before login, choose an all-users install during setup. On Windows, that elevated installer path now registers the boot-time monitor service automatically.
+4. Launch Vigil from the Start Menu or the installed shortcut.
+5. Use **Run as Admin** in the header when you need ETW visibility or active response actions.
 
 ### macOS
 
@@ -166,7 +166,7 @@ To monitor before login, install the OS service from an elevated shell:
 | macOS | `sudo vigil --install-service` | `sudo vigil --uninstall-service` |
 | Linux | `sudo vigil --install-service` | `sudo vigil --uninstall-service` |
 
-Service mode runs the monitor without the desktop UI. The GUI/tray launches normally after login.
+On Windows, the all-users installer path now performs that service registration automatically. Service mode runs the monitor without the desktop UI. The GUI/tray launches normally after login.
 
 ## Uninstall from Settings
 

--- a/installer/windows/setup.iss
+++ b/installer/windows/setup.iss
@@ -60,6 +60,11 @@ Name: "desktopicon"; \
   Description: "{cm:CreateDesktopIcon}"; \
   GroupDescription: "{cm:AdditionalIcons}"; \
   Flags: unchecked
+Name: "bootservice"; \
+  Description: "Start Vigil before login (boot-time monitor service)"; \
+  GroupDescription: "Startup"; \
+  Flags: checked; \
+  Check: IsAdminInstallMode
 
 [Files]
 ; The binary is staged next to setup.iss before ISCC runs (see release.yml).
@@ -71,8 +76,17 @@ Name: "{group}\Uninstall {#MyAppName}"; Filename: "{uninstallexe}"
 Name: "{autodesktop}\{#MyAppName}";     Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
 [Run]
+; When Setup is already elevated for an all-users install, register the
+; monitor-only boot-time service so monitoring begins before login.
+Filename: "{app}\{#MyAppExeName}"; \
+  Parameters: "--install-service"; \
+  StatusMsg: "Registering the Vigil boot-time monitor service..."; \
+  Flags: runhidden waituntilterminated skipifsilent; \
+  Check: IsAdminInstallMode and WizardIsTaskSelected('bootservice')
+
 ; Offer to launch Vigil immediately after installation.
-; Vigil enables autostart on its own first run — no registry entry needed here.
+; Vigil enables login autostart on its own first run — no registry entry
+; needed here.
 Filename: "{app}\{#MyAppExeName}"; \
   Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; \
   Flags: nowait postinstall skipifsilent

--- a/installer/windows/setup.iss
+++ b/installer/windows/setup.iss
@@ -81,7 +81,7 @@ Name: "{autodesktop}\{#MyAppName}";     Filename: "{app}\{#MyAppExeName}"; Tasks
 Filename: "{app}\{#MyAppExeName}"; \
   Parameters: "--install-service"; \
   StatusMsg: "Registering the Vigil boot-time monitor service..."; \
-  Flags: runhidden waituntilterminated skipifsilent; \
+  Flags: runhidden waituntilterminated; \
   Check: IsAdminInstallMode and WizardIsTaskSelected('bootservice')
 
 ; Offer to launch Vigil immediately after installation.

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -485,7 +485,12 @@ fn inner(ui: &mut egui::Ui, draft: &mut SettingsDraft, changed: &mut bool) {
                 .changed();
             ui.add_space(2.0);
             ui.label(
-                RichText::new("On Windows, elevated runs use a highest-privilege scheduled task.")
+                RichText::new("This controls the desktop app after login. Before-login monitoring uses the separate boot-time service.")
+                    .color(theme::TEXT3)
+                    .size(10.2),
+            );
+            ui.label(
+                RichText::new("On Windows, all-users installs register that boot-time service during setup; you can also install it manually with vigil.exe --install-service.")
                     .color(theme::TEXT3)
                     .size(10.2),
             );


### PR DESCRIPTION
## Summary
- register the Windows boot-time monitor service during elevated all-users installs
- clarify the difference between login autostart and before-login monitoring in the installer-facing docs and Settings UI
- fix the Windows implementation note so it matches the current Task Scheduler `ONSTART` design

## Why
A fresh Windows install currently only guarantees login autostart on first run. That means the important before-login monitoring path is missing unless the operator manually runs `vigil.exe --install-service`, which is easy to miss and does not match the expected product behavior for all-users installs.

## Validation
- inspected the Windows installer script, startup bootstrap logic, service installation code, and operator docs
- confirmed `src/main.rs` only enables login autostart on first run
- confirmed `src/platform/service.rs` already provides the boot-time registration path via `--install-service`
- kept the packaging change scoped to elevated all-users installs so standard per-user installs still work without admin rights

## Remaining follow-up
- no automated validation was run here because the change is limited to installer scripting and product documentation
- if desired, a later pass could add a dedicated in-app control for boot-time service install/repair status