### PR TITLE
phase16: surface advisory cache source error state

### DIFF
--- a/src/advisory_status.rs
+++ b/src/advisory_status.rs
@@ -35,20 +35,17 @@ pub fn run_cli() -> Result<(), String> {
     }
 
     let now = unix_now();
-    let stale_sources = cache
+    let attention_sources = cache
         .sources
         .iter()
-        .filter(|source| {
-            is_source_stale(source.expires_unix, now)
-                || matches!(source.status, SourceHealth::Stale)
-        })
+        .filter(|source| source_needs_attention(source, now))
         .count();
 
     println!(
-        "Advisory cache: {} records, {} sources ({} stale)",
+        "Advisory cache: {} records, {} sources ({} stale/error)",
         cache.records.len(),
         cache.sources.len(),
-        stale_sources
+        attention_sources
     );
 
     for source in &cache.sources {
@@ -103,6 +100,11 @@ fn source_state(source: &AdvisorySourceCache, now: u64) -> &'static str {
         SourceHealth::Stale => "stale",
         SourceHealth::Error => "error",
     }
+}
+
+fn source_needs_attention(source: &AdvisorySourceCache, now: u64) -> bool {
+    is_source_stale(source.expires_unix, now)
+        || matches!(source.status, SourceHealth::Stale | SourceHealth::Error)
 }
 
 fn source_attribution(source: &AdvisorySourceCache) -> Option<&'static str> {
@@ -166,6 +168,26 @@ mod tests {
         };
 
         assert_eq!(source_state(&source, 30), "error");
+    }
+
+    #[test]
+    fn source_needs_attention_for_error_sources_before_expiry() {
+        let source = AdvisorySourceCache {
+            source_key: "nvd-cve".into(),
+            source_kind: "nvd".into(),
+            source_url: String::new(),
+            imported_from: None,
+            imported_from_batch: vec![],
+            fetched_unix: 10,
+            expires_unix: 100,
+            snapshot_sha256: String::new(),
+            total_results: 1,
+            status: SourceHealth::Error,
+            last_attempt_unix: 0,
+            last_error: Some("rate limit".into()),
+        };
+
+        assert!(source_needs_attention(&source, 30));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- count advisory sources in `error` state in the cache summary instead of only counting expired or explicitly stale entries
- update the CLI summary wording to report `stale/error` sources so operator output matches the per-source state lines
- add focused unit coverage for the new helper that treats pre-expiry error states as actionable source-health degradation

## Why this task
There were no open agent pull requests, unresolved review threads, requested changes, or failing CI checks to follow up on.

The next explicit roadmap item is Phase 16 EUVD ingestion, but that slice is broader than I could land safely in one scheduled pass from this environment. While inspecting the current Phase 16 foundations, I found a concrete operator-visibility bug: `vigil --advisory-cache-status` only counted stale sources in its summary, even though the detailed per-source lines can show `error`. That can hide a failed live source refresh until the cache also expires.

This is the smallest safe in-scope fix because it improves source-health visibility in the existing advisory foundations without inventing the larger EUVD ingestion design.

## Validation
- inspected `src/advisory_status.rs` and the existing Phase 16 advisory cache/source-health model
- added a focused unit test covering the pre-expiry `error` case through the new helper
- no full Rust toolchain run was available in this scheduled environment, so validation here is limited to the narrow logic change and existing test pattern in the touched file

## Remaining follow-up
- the next explicit unfinished roadmap item remains EUVD ingestion
- startup advisory cache logging in `src/advisory.rs` still only reports a stale-source count, so a later pass could align that summary with the CLI output if the project wants one shared source-health metric