### PR TITLE
Add minimal software inventory collection from running processes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ mod revdns;
 mod score;
 mod security;
 mod session;
+mod software_inventory;
 mod startup_integrity;
 mod tls;
 mod tls_artifacts;
@@ -156,6 +157,9 @@ fn spawn_bootstrap(cfg_bootstrap: Arc<RwLock<Config>>, manage_login_autostart: b
             break_glass::start_heartbeat_loop(cfg_bootstrap.clone());
             advisory::refresh_nvd_in_background_if_due();
             advisory_history::refresh_nvd_in_background_if_due();
+
+            let software_count = software_inventory::collect_installed_software().len();
+            tracing::info!(software_count, "software inventory snapshot collected");
 
             if manage_login_autostart {
                 {

--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -71,11 +71,11 @@ fn derive_product_key(display_name: &str, executable_path: &str) -> String {
 }
 
 fn normalize_name(input: &str) -> String {
-    let lower = input.trim().to_ascii_lowercase();
+    let lower = input.trim().to_lowercase();
     let no_ext = lower.strip_suffix(".exe").unwrap_or(&lower);
     no_ext
         .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .map(|c| if c.is_alphanumeric() { c } else { '-' })
         .collect::<String>()
         .trim_matches('-')
         .to_string()
@@ -88,6 +88,13 @@ mod tests {
     #[test]
     fn normalize_name_strips_case_and_extension() {
         assert_eq!(normalize_name("PowerShell.EXE"), "powershell");
+    }
+
+
+    #[test]
+    fn normalize_name_preserves_unicode_letters() {
+        assert_eq!(normalize_name("Программа.EXE"), "программа");
+        assert_eq!(normalize_name("監視ツール.exe"), "監視ツール");
     }
 
     #[test]

--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -1,0 +1,104 @@
+//! Minimal local software inventory foundations for advisory relevance.
+//!
+//! Phase 16 Task 1 starts with a conservative, low-risk inventory source:
+//! currently-running processes. This avoids package-manager-specific parsing
+//! while still giving the advisory pipeline stable product candidates.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use sysinfo::System;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstalledSoftware {
+    pub product_key: String,
+    pub display_name: String,
+    pub executable_path: String,
+    pub publisher_hint: Option<String>,
+    pub source: InventorySource,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum InventorySource {
+    RunningProcess,
+}
+
+pub fn collect_installed_software() -> Vec<InstalledSoftware> {
+    let mut sys = System::new_all();
+    sys.refresh_all();
+
+    let mut by_key: BTreeMap<String, InstalledSoftware> = BTreeMap::new();
+
+    for process in sys.processes().values() {
+        let display_name = process.name().to_string_lossy().trim().to_string();
+        if display_name.is_empty() {
+            continue;
+        }
+
+        let executable_path = process
+            .exe()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default();
+
+        let product_key = derive_product_key(&display_name, &executable_path);
+        let entry = InstalledSoftware {
+            product_key: product_key.clone(),
+            display_name,
+            executable_path,
+            publisher_hint: None,
+            source: InventorySource::RunningProcess,
+        };
+
+        by_key.entry(product_key).or_insert(entry);
+    }
+
+    by_key.into_values().collect()
+}
+
+fn derive_product_key(display_name: &str, executable_path: &str) -> String {
+    let normalized_name = normalize_name(display_name);
+    if !normalized_name.is_empty() {
+        return normalized_name;
+    }
+
+    if let Some(file_name) = std::path::Path::new(executable_path).file_name() {
+        let candidate = normalize_name(&file_name.to_string_lossy());
+        if !candidate.is_empty() {
+            return candidate;
+        }
+    }
+
+    "unknown-product".to_string()
+}
+
+fn normalize_name(input: &str) -> String {
+    let lower = input.trim().to_ascii_lowercase();
+    let no_ext = lower.strip_suffix(".exe").unwrap_or(&lower);
+    no_ext
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_name_strips_case_and_extension() {
+        assert_eq!(normalize_name("PowerShell.EXE"), "powershell");
+    }
+
+    #[test]
+    fn derive_product_key_prefers_display_name() {
+        let key = derive_product_key("Google Chrome", "/opt/chrome/chrome");
+        assert_eq!(key, "google-chrome");
+    }
+
+    #[test]
+    fn derive_product_key_uses_path_when_name_missing() {
+        let key = derive_product_key("", "/usr/bin/curl");
+        assert_eq!(key, "curl");
+    }
+}


### PR DESCRIPTION
### Motivation

- Introduce a low-risk local software inventory source to seed advisory relevance using currently-running processes instead of package-manager parsing.

### Description

- Add a new module `src/software_inventory.rs` that exposes `collect_installed_software()` and types `InstalledSoftware` and `InventorySource` to represent discovered products.
- Implement collection using the `sysinfo` crate to enumerate running processes, derive a stable `product_key` with `derive_product_key()` and `normalize_name()`, and deduplicate results into a `Vec<InstalledSoftware>`.
- Wire the module into `src/main.rs` by adding `mod software_inventory;` and logging a snapshot count in `spawn_bootstrap` via `software_inventory::collect_installed_software().len()`.
- Add unit tests for `normalize_name()` and `derive_product_key()` in the new module to validate normalization and key selection logic.

### Testing

- Built the project with `cargo build` to ensure the new module compiles and the binary links successfully, and the build completed successfully.
- Ran unit tests for the new module with `cargo test` and the added tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f6807b9d9c83288e9ac4f9a47a4626)