### PR TITLE
Add minimal software inventory collection from running processes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ mod revdns;
 mod score;
 mod security;
 mod session;
+mod software_inventory;
 mod startup_integrity;
 mod tls;
 mod tls_artifacts;
@@ -156,6 +157,9 @@ fn spawn_bootstrap(cfg_bootstrap: Arc<RwLock<Config>>, manage_login_autostart: b
             break_glass::start_heartbeat_loop(cfg_bootstrap.clone());
             advisory::refresh_nvd_in_background_if_due();
             advisory_history::refresh_nvd_in_background_if_due();
+
+            let software_count = software_inventory::collect_installed_software().len();
+            tracing::info!(software_count, "software inventory snapshot collected");
 
             if manage_login_autostart {
                 {

--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -49,10 +49,29 @@ pub fn collect_installed_software() -> Vec<InstalledSoftware> {
             source: InventorySource::RunningProcess,
         };
 
-        by_key.entry(product_key).or_insert(entry);
+        match by_key.get_mut(&product_key) {
+            Some(existing) if should_replace_existing(existing, &entry) => *existing = entry,
+            Some(_) => {}
+            None => {
+                by_key.insert(product_key, entry);
+            }
+        }
     }
 
     by_key.into_values().collect()
+}
+
+fn should_replace_existing(existing: &InstalledSoftware, candidate: &InstalledSoftware) -> bool {
+    entry_rank(candidate) > entry_rank(existing)
+}
+
+fn entry_rank(entry: &InstalledSoftware) -> (bool, bool, &str, &str) {
+    (
+        !entry.executable_path.is_empty(),
+        !entry.display_name.is_empty(),
+        entry.executable_path.as_str(),
+        entry.display_name.as_str(),
+    )
 }
 
 fn derive_product_key(display_name: &str, executable_path: &str) -> String {
@@ -91,11 +110,34 @@ mod tests {
         assert_eq!(normalize_name("PowerShell.EXE"), "powershell");
     }
 
-
     #[test]
     fn normalize_name_preserves_unicode_letters() {
         assert_eq!(normalize_name("Программа.EXE"), "программа");
         assert_eq!(normalize_name("監視ツール.exe"), "監視ツール");
+    }
+
+    #[test]
+    fn prefers_richer_duplicate_entry() {
+        let mut existing = InstalledSoftware {
+            product_key: "curl".into(),
+            display_name: "curl".into(),
+            executable_path: String::new(),
+            publisher_hint: None,
+            source: InventorySource::RunningProcess,
+        };
+        let candidate = InstalledSoftware {
+            product_key: "curl".into(),
+            display_name: "curl".into(),
+            executable_path: "/usr/bin/curl".into(),
+            publisher_hint: None,
+            source: InventorySource::RunningProcess,
+        };
+
+        if should_replace_existing(&existing, &candidate) {
+            existing = candidate;
+        }
+
+        assert_eq!(existing.executable_path, "/usr/bin/curl");
     }
 
     #[test]

--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -1,0 +1,118 @@
+//! Minimal local software inventory foundations for advisory relevance.
+//!
+//! Phase 16 Task 1 starts with a conservative, low-risk inventory source:
+//! currently-running processes. This avoids package-manager-specific parsing
+//! while still giving the advisory pipeline stable product candidates.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use sysinfo::System;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstalledSoftware {
+    pub product_key: String,
+    pub display_name: String,
+    pub executable_path: String,
+    pub publisher_hint: Option<String>,
+    pub source: InventorySource,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum InventorySource {
+    RunningProcess,
+}
+
+pub fn collect_installed_software() -> Vec<InstalledSoftware> {
+    let mut sys = System::new_all();
+    sys.refresh_all();
+
+    let mut by_key: BTreeMap<String, InstalledSoftware> = BTreeMap::new();
+
+    for process in sys.processes().values() {
+        let display_name = process.name().to_string_lossy().trim().to_string();
+
+        let executable_path = process
+            .exe()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default();
+
+        if display_name.is_empty() && executable_path.is_empty() {
+            continue;
+        }
+
+        let product_key = derive_product_key(&display_name, &executable_path);
+        let entry = InstalledSoftware {
+            product_key: product_key.clone(),
+            display_name,
+            executable_path,
+            publisher_hint: None,
+            source: InventorySource::RunningProcess,
+        };
+
+        by_key.entry(product_key).or_insert(entry);
+    }
+
+    by_key.into_values().collect()
+}
+
+fn derive_product_key(display_name: &str, executable_path: &str) -> String {
+    let normalized_name = normalize_name(display_name);
+    if !normalized_name.is_empty() {
+        return normalized_name;
+    }
+
+    if let Some(file_name) = std::path::Path::new(executable_path).file_name() {
+        let candidate = normalize_name(&file_name.to_string_lossy());
+        if !candidate.is_empty() {
+            return candidate;
+        }
+    }
+
+    "unknown-product".to_string()
+}
+
+fn normalize_name(input: &str) -> String {
+    let lower = input.trim().to_lowercase();
+    let no_ext = lower.strip_suffix(".exe").unwrap_or(&lower);
+    no_ext
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { '-' })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_name_strips_case_and_extension() {
+        assert_eq!(normalize_name("PowerShell.EXE"), "powershell");
+    }
+
+
+    #[test]
+    fn normalize_name_preserves_unicode_letters() {
+        assert_eq!(normalize_name("Программа.EXE"), "программа");
+        assert_eq!(normalize_name("監視ツール.exe"), "監視ツール");
+    }
+
+    #[test]
+    fn derive_product_key_prefers_display_name() {
+        let key = derive_product_key("Google Chrome", "/opt/chrome/chrome");
+        assert_eq!(key, "google-chrome");
+    }
+
+    #[test]
+    fn derive_product_key_uses_path_when_name_missing() {
+        let key = derive_product_key("", "/usr/bin/curl");
+        assert_eq!(key, "curl");
+    }
+
+    #[test]
+    fn derive_product_key_unknown_when_name_and_path_missing() {
+        let key = derive_product_key("", "");
+        assert_eq!(key, "unknown-product");
+    }
+}

--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -75,16 +75,16 @@ fn entry_rank(entry: &InstalledSoftware) -> (bool, bool, &str, &str) {
 }
 
 fn derive_product_key(display_name: &str, executable_path: &str) -> String {
-    let normalized_name = normalize_name(display_name);
-    if !normalized_name.is_empty() {
-        return normalized_name;
-    }
-
     if let Some(file_name) = std::path::Path::new(executable_path).file_name() {
         let candidate = normalize_name(&file_name.to_string_lossy());
         if !candidate.is_empty() {
             return candidate;
         }
+    }
+
+    let normalized_name = normalize_name(display_name);
+    if !normalized_name.is_empty() {
+        return normalized_name;
     }
 
     "unknown-product".to_string()
@@ -141,15 +141,15 @@ mod tests {
     }
 
     #[test]
-    fn derive_product_key_prefers_display_name() {
-        let key = derive_product_key("Google Chrome", "/opt/chrome/chrome");
-        assert_eq!(key, "google-chrome");
+    fn derive_product_key_prefers_executable_basename() {
+        let key = derive_product_key("google-chrome-sta", "/opt/google/chrome/google-chrome-stable");
+        assert_eq!(key, "google-chrome-stable");
     }
 
     #[test]
-    fn derive_product_key_uses_path_when_name_missing() {
-        let key = derive_product_key("", "/usr/bin/curl");
-        assert_eq!(key, "curl");
+    fn derive_product_key_uses_display_name_when_path_missing() {
+        let key = derive_product_key("Google Chrome", "");
+        assert_eq!(key, "google-chrome");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Introduce a low-risk local software inventory source to seed advisory relevance using currently-running processes.
- Provide a conservative Phase 16 foundation that produces stable product candidates without parsing package-manager artifacts.

### Description

- Add a new module `src/software_inventory.rs` that defines `InstalledSoftware` and `InventorySource` and implements `collect_installed_software` using `sysinfo`.
- Implement helper functions `derive_product_key` and `normalize_name` to produce stable product keys from process names or executable file names.
- Integrate the inventory snapshot into startup by adding `mod software_inventory;` to `main.rs` and logging the snapshot size with a call to `software_inventory::collect_installed_software()` in `spawn_bootstrap`.
- Include unit tests for `normalize_name` and `derive_product_key` in the new module.

### Testing

- Ran `cargo test`, and the unit tests in `software_inventory` (5 tests) passed.
- Ran `cargo build` during verification and the project built successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f6807b9d9c83288e9ac4f9a47a4626)