### PR TITLE
[codex] Align Phase 16 roadmap and docs with implemented imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,27 @@ Use `--sync-nvd --force` only when you need to override the normal 2-hour
 minimum interval. Provide an API key via `VIGIL_NVD_API_KEY` if your deployment
 needs higher NVD API headroom.
 
+Phase 16 also includes offline foundations for additional public advisory
+sources. Operators can import one or more local EUVD JSON snapshots into the
+same protected advisory cache with:
+
+```bash
+vigil --import-euvd euvd-export.json
+```
+
+JVN / JVN iPedia snapshots support either JSON exports or JVNDBRSS XML items,
+including batched imports when a feed is mirrored into multiple files:
+
+```bash
+vigil --import-jvn jvn-export.json jvndbrss.xml
+```
+
+Those EUVD and JVN import paths preserve source-specific identifiers,
+references, mitigation guidance, and provenance in the protected advisory cache.
+They are intentionally operator-supplied/offline foundations for now; live
+scheduled fetching remains future work until the upstream feed contracts are
+pinned down conservatively.
+
 ---
 
 ## What Vigil Does

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -280,8 +280,8 @@ Use free public vulnerability and advisory sources to help Vigil keep the local 
 - [x] **Signed local source cache** — fetched records and source snapshots are stored as tamper-evident local state with expiry, rollback-safe refresh, and operator-visible source health/status
 - [x] **NVD CVE ingestion foundations** — protected local cache for NVD CVE snapshots now supports offline import, live API sync, source attribution, rate-limit-aware refresh, and incremental `lastMod*` updates; remaining work for this slice is NVD CPE and CPE-match ingestion
 - [x] **NVD CVE change-history ingestion** — protected local cache for NVD CVE change-history snapshots now supports offline import, live API sync, source attribution, rate-limit-aware refresh, and incremental `changeStartDate` / `changeEndDate` updates
-- [ ] **EUVD ingestion** — ingest EUVD records and preserve EU-specific aliases, references, mitigation guidance, exploitation indicators, and coordinator metadata
-- [ ] **JVN ingestion** — ingest MyJVN / JVN iPedia records and preserve vendor, product, advisory, and remediation metadata where it complements NVD coverage
+- [x] **EUVD ingestion foundations** — operator-supplied EUVD JSON snapshots can now be normalized into the shared advisory cache while preserving EU-specific aliases, references, mitigation guidance, exploitation indicators, and provenance
+- [x] **JVN ingestion foundations** — operator-supplied JVN / JVN iPedia JSON snapshots and JVNDBRSS XML items can now be normalized into the shared advisory cache while preserving vendor, product, advisory, remediation, and provenance metadata
 - [ ] **Public advisory ingestion for NCSC and BSI** — ingest public RSS, advisory, and malware-analysis content only; do not depend on closed, partner-only, or registration-gated feeds
 
 ### Endpoint relevance and matching


### PR DESCRIPTION
## What changed
- marks the implemented EUVD and JVN offline import foundations as complete in `ROADMAP.md`
- documents the existing `--import-euvd` and `--import-jvn` CLI flows in `README.md`

## Why
The roadmap still listed EUVD and JVN ingestion as unfinished even though the codebase already includes `src/advisory_public_sources.rs` and the CLI wiring in `src/main.rs`. That made the next roadmap task look earlier than it really is and risked duplicate churn.

## Validation
- inspected the current `master` tree and confirmed the imports are already implemented and wired into the CLI
- no code-path changes were made; this PR is documentation-only, so no local runtime checks were needed beyond repository inspection

## Impact
- keeps the roadmap aligned with the shipped code
- makes the next concrete Phase 16 work easier to choose from the remaining unfinished items
