### PR TITLE
Add software_inventory module to collect running-process inventory and log snapshot

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ mod revdns;
 mod score;
 mod security;
 mod session;
+mod software_inventory;
 mod startup_integrity;
 mod tls;
 mod tls_artifacts;
@@ -156,6 +157,9 @@ fn spawn_bootstrap(cfg_bootstrap: Arc<RwLock<Config>>, manage_login_autostart: b
             break_glass::start_heartbeat_loop(cfg_bootstrap.clone());
             advisory::refresh_nvd_in_background_if_due();
             advisory_history::refresh_nvd_in_background_if_due();
+
+            let software_count = software_inventory::collect_installed_software().len();
+            tracing::info!(software_count, "software inventory snapshot collected");
 
             if manage_login_autostart {
                 {

--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -1,0 +1,129 @@
+//! Minimal local software inventory foundations for advisory relevance.
+//!
+//! Phase 16 Task 1 starts with a conservative, low-risk inventory source:
+//! currently-running processes. This avoids package-manager-specific parsing
+//! while still giving the advisory pipeline stable product candidates.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use sysinfo::System;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstalledSoftware {
+    pub product_key: String,
+    pub display_name: String,
+    pub executable_path: String,
+    pub publisher_hint: Option<String>,
+    pub source: InventorySource,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum InventorySource {
+    RunningProcess,
+}
+
+pub fn collect_installed_software() -> Vec<InstalledSoftware> {
+    let mut sys = System::new_all();
+    sys.refresh_all();
+
+    let entries = sys.processes().values().map(|process| {
+        let display_name = process.name().to_string_lossy().trim().to_string();
+        let executable_path = process
+            .exe()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default();
+        (display_name, executable_path)
+    });
+    collect_from_entries(entries)
+}
+
+fn collect_from_entries<I>(entries: I) -> Vec<InstalledSoftware>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    let mut by_key: BTreeMap<String, InstalledSoftware> = BTreeMap::new();
+    for (display_name, executable_path) in entries {
+        if display_name.is_empty() && executable_path.is_empty() {
+            continue;
+        }
+        let product_key = derive_product_key(&display_name, &executable_path);
+        by_key.entry(product_key.clone()).or_insert(InstalledSoftware {
+            product_key,
+            display_name,
+            executable_path,
+            publisher_hint: None,
+            source: InventorySource::RunningProcess,
+        });
+    }
+    by_key.into_values().collect()
+}
+
+fn derive_product_key(display_name: &str, executable_path: &str) -> String {
+    let normalized_name = normalize_name(display_name);
+    if !normalized_name.is_empty() {
+        return normalized_name;
+    }
+
+    if let Some(file_name) = std::path::Path::new(executable_path).file_name() {
+        let candidate = normalize_name(&file_name.to_string_lossy());
+        if !candidate.is_empty() {
+            return candidate;
+        }
+    }
+
+    "unknown-product".to_string()
+}
+
+fn normalize_name(input: &str) -> String {
+    let lower = input.trim().to_lowercase();
+    let no_ext = lower.strip_suffix(".exe").unwrap_or(&lower);
+    no_ext
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { '-' })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_name_strips_case_and_extension() {
+        assert_eq!(normalize_name("PowerShell.EXE"), "powershell");
+    }
+
+
+    #[test]
+    fn normalize_name_preserves_unicode_letters() {
+        assert_eq!(normalize_name("Программа.EXE"), "программа");
+        assert_eq!(normalize_name("監視ツール.exe"), "監視ツール");
+    }
+
+    #[test]
+    fn derive_product_key_prefers_display_name() {
+        let key = derive_product_key("Google Chrome", "/opt/chrome/chrome");
+        assert_eq!(key, "google-chrome");
+    }
+
+    #[test]
+    fn derive_product_key_uses_path_when_name_missing() {
+        let key = derive_product_key("", "/usr/bin/curl");
+        assert_eq!(key, "curl");
+    }
+
+    #[test]
+    fn derive_product_key_unknown_when_name_and_path_missing() {
+        let key = derive_product_key("", "");
+        assert_eq!(key, "unknown-product");
+    }
+
+    #[test]
+    fn collect_from_entries_keeps_empty_name_when_path_present() {
+        let entries = vec![("".to_string(), "/opt/vendor/agentd".to_string())];
+        let inventory = collect_from_entries(entries);
+        assert_eq!(inventory.len(), 1);
+        assert_eq!(inventory[0].product_key, "agentd");
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a conservative local software inventory source derived from currently running processes to feed advisory relevance without parsing package managers.
- Provide a low-risk Phase 16 foundation that produces stable product candidates for downstream advisory pipelines.
- Record a snapshot count during bootstrap so the service can surface that inventory collection occurred.

### Description
- Add `src/software_inventory.rs` implementing `InstalledSoftware`, `InventorySource`, `collect_installed_software`, `collect_from_entries`, `derive_product_key`, and `normalize_name` to produce a deduplicated inventory from running processes using `sysinfo`.
- Integrate the new module in `src/main.rs` by adding `mod software_inventory;` and logging the collected snapshot count with `software_inventory::collect_installed_software().len()` during bootstrap.
- Implement normalization logic that strips case and `.exe` extensions and maps non-alphanumeric characters to `-` when deriving product keys.
- Include unit tests covering `normalize_name`, `derive_product_key`, and `collect_from_entries` behaviors.

### Testing
- Ran `cargo test` which executed the unit tests in `software_inventory` (6 tests) and they all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f6807b9d9c83288e9ac4f9a47a4626)