### PR TITLE
Add software inventory collection, protected JSON inventory store, and local storage migration plan

### DIFF
--- a/docs/LOCAL-STORAGE-MIGRATION.md
+++ b/docs/LOCAL-STORAGE-MIGRATION.md
@@ -1,0 +1,76 @@
+# Local storage migration plan (non-backward-compatible)
+
+This document defines the big-push migration from protected JSON cache files to a
+single local SQLite-backed state store while preserving Vigil's integrity model.
+
+## Goals
+
+- Faster indexed lookups and joins for advisory matching and software inventory.
+- Keep integrity/tamper evidence and rollback-safe recovery semantics.
+- Accept a non-backward-compatible cutover (young project, no user migration burden).
+
+## Scope
+
+1. Replace advisory JSON cache persistence in `src/advisory.rs` with DB-backed persistence.
+2. Replace advisory change-history JSON cache persistence in `src/advisory_history.rs`.
+3. Add DB-backed software inventory persistence and indexed product lookup.
+4. Keep security checks by signing/verifying DB checkpoint manifests.
+
+## Proposed storage layout
+
+- Database file: `data_dir()/vigil-state.db`
+- Manifest file: `data_dir()/vigil-state.manifest.json` + integrity sidecar/backup
+- Secret handling: reuse `security::policy` secret file and sidecar model
+
+### Core tables
+
+- `meta(schema_version, generated_unix, last_integrity_ok_unix, ...)`
+- `advisory_source(source_key, source_kind, source_url, fetched_unix, expires_unix, status, last_error, ... )`
+- `advisory_record(primary_id, source_key, source_kind, published_unix, updated_unix, severity, exploited, payload_json, ... )`
+- `advisory_change_event(change_id, cve_id, source_key, change_unix, event_name, details_json, ... )`
+- `software_inventory(product_key, display_name, executable_path, publisher_hint, source, updated_unix)`
+
+### Required indexes
+
+- advisory: `(primary_id)`, `(source_kind, source_key)`, `(updated_unix)`
+- change history: `(cve_id, change_unix)`, `(source_key)`
+- software inventory: `(product_key)`, `(executable_path)`
+
+## Integrity strategy
+
+1. Quiesce writes and checkpoint DB.
+2. Compute deterministic digest over checkpoint artifacts.
+3. Save signed manifest via `security::policy::save_struct_with_integrity`.
+4. On startup, verify manifest/digest before using DB.
+5. If verification fails, restore last known-good DB artifact set and record audit event.
+
+## Performance guardrails
+
+- Use batched inserts/upserts in transactions.
+- Keep all DB I/O off the UI/render thread.
+- Bound query results for inspector/activity UI surfaces.
+- Prefer incremental updates over full table rewrites for periodic sync.
+
+## Rollout plan
+
+### PR 1
+- Add storage abstraction and schema bootstrap.
+- Keep reads/writes dual-pathed (JSON + DB mirror) for internal validation only.
+
+### PR 2
+- Switch advisory and change-history reads to DB.
+- Keep JSON writes disabled by default.
+
+### PR 3
+- Migrate software inventory to DB + indexes.
+- Add query helpers for advisory relevance joins.
+
+### PR 4
+- Remove legacy JSON cache code paths.
+- Keep only DB + signed manifest integrity checks.
+
+## Definition of done
+
+- No advisory or inventory hot-path reads from legacy JSON cache files.
+- Startup fails closed to last trusted DB artifacts on integrity mismatch.
+- UI remains responsive under burst updates and large advisory sets.

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,9 @@ mod revdns;
 mod score;
 mod security;
 mod session;
+mod software_inventory;
 mod startup_integrity;
+mod storage;
 mod tls;
 mod tls_artifacts;
 mod types;
@@ -156,6 +158,14 @@ fn spawn_bootstrap(cfg_bootstrap: Arc<RwLock<Config>>, manage_login_autostart: b
             break_glass::start_heartbeat_loop(cfg_bootstrap.clone());
             advisory::refresh_nvd_in_background_if_due();
             advisory_history::refresh_nvd_in_background_if_due();
+
+            let inventory = software_inventory::collect_installed_software();
+            let software_count = inventory.len();
+            tracing::info!(software_count, "software inventory snapshot collected");
+            let inventory_store = storage::ProtectedJsonInventoryStore::new_default();
+            if let Err(err) = storage::InventoryStore::replace_inventory(&inventory_store, &inventory) {
+                tracing::warn!(%err, "failed to persist software inventory snapshot");
+            }
 
             if manage_login_autostart {
                 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,7 +164,9 @@ fn spawn_bootstrap(cfg_bootstrap: Arc<RwLock<Config>>, manage_login_autostart: b
             let software_count = inventory.len();
             tracing::info!(software_count, "software inventory snapshot collected");
             let inventory_store = storage::ProtectedJsonInventoryStore::new_default();
-            if let Err(err) = storage::InventoryStore::replace_inventory(&inventory_store, &inventory) {
+            if let Err(err) =
+                storage::InventoryStore::replace_inventory(&inventory_store, &inventory)
+            {
                 tracing::warn!(%err, "failed to persist software inventory snapshot");
             }
 

--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -1,0 +1,129 @@
+//! Minimal local software inventory foundations for advisory relevance.
+//!
+//! Phase 16 Task 1 starts with a conservative, low-risk inventory source:
+//! currently-running processes. This avoids package-manager-specific parsing
+//! while still giving the advisory pipeline stable product candidates.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use sysinfo::System;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstalledSoftware {
+    pub product_key: String,
+    pub display_name: String,
+    pub executable_path: String,
+    pub publisher_hint: Option<String>,
+    pub source: InventorySource,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum InventorySource {
+    RunningProcess,
+}
+
+pub fn collect_installed_software() -> Vec<InstalledSoftware> {
+    let mut sys = System::new_all();
+    sys.refresh_all();
+
+    let entries = sys.processes().values().map(|process| {
+        let display_name = process.name().to_string_lossy().trim().to_string();
+        let executable_path = process
+            .exe()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default();
+        (display_name, executable_path)
+    });
+    collect_from_entries(entries)
+}
+
+fn collect_from_entries<I>(entries: I) -> Vec<InstalledSoftware>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    let mut by_key: BTreeMap<String, InstalledSoftware> = BTreeMap::new();
+    for (display_name, executable_path) in entries {
+        if display_name.is_empty() && executable_path.is_empty() {
+            continue;
+        }
+        let product_key = derive_product_key(&display_name, &executable_path);
+        by_key.entry(product_key.clone()).or_insert(InstalledSoftware {
+            product_key,
+            display_name,
+            executable_path,
+            publisher_hint: None,
+            source: InventorySource::RunningProcess,
+        });
+    }
+    by_key.into_values().collect()
+}
+
+fn derive_product_key(display_name: &str, executable_path: &str) -> String {
+    let normalized_name = normalize_name(display_name);
+    if !normalized_name.is_empty() {
+        return normalized_name;
+    }
+
+    if let Some(file_name) = std::path::Path::new(executable_path).file_name() {
+        let candidate = normalize_name(&file_name.to_string_lossy());
+        if !candidate.is_empty() {
+            return candidate;
+        }
+    }
+
+    "unknown-product".to_string()
+}
+
+fn normalize_name(input: &str) -> String {
+    let lower = input.trim().to_lowercase();
+    let no_ext = lower.strip_suffix(".exe").unwrap_or(&lower);
+    no_ext
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { '-' })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_name_strips_case_and_extension() {
+        assert_eq!(normalize_name("PowerShell.EXE"), "powershell");
+    }
+
+
+    #[test]
+    fn normalize_name_preserves_unicode_letters() {
+        assert_eq!(normalize_name("Программа.EXE"), "программа");
+        assert_eq!(normalize_name("監視ツール.exe"), "監視ツール");
+    }
+
+    #[test]
+    fn derive_product_key_prefers_display_name() {
+        let key = derive_product_key("Google Chrome", "/opt/chrome/chrome");
+        assert_eq!(key, "google-chrome");
+    }
+
+    #[test]
+    fn derive_product_key_uses_path_when_name_missing() {
+        let key = derive_product_key("", "/usr/bin/curl");
+        assert_eq!(key, "curl");
+    }
+
+    #[test]
+    fn derive_product_key_unknown_when_name_and_path_missing() {
+        let key = derive_product_key("", "");
+        assert_eq!(key, "unknown-product");
+    }
+
+    #[test]
+    fn collect_from_entries_keeps_empty_name_when_path_present() {
+        let entries = vec![("".to_string(), "/opt/vendor/agentd".to_string())];
+        let inventory = collect_from_entries(entries);
+        assert_eq!(inventory.len(), 1);
+        assert_eq!(inventory[0].product_key, "agentd");
+    }
+}

--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -47,15 +47,31 @@ where
             continue;
         }
         let product_key = derive_product_key(&display_name, &executable_path);
-        by_key.entry(product_key.clone()).or_insert(InstalledSoftware {
-            product_key,
+        let candidate = InstalledSoftware {
+            product_key: product_key.clone(),
             display_name,
             executable_path,
             publisher_hint: None,
             source: InventorySource::RunningProcess,
-        });
+        };
+        by_key
+            .entry(product_key)
+            .and_modify(|existing| {
+                if canonical_inventory_sort_key(&candidate) < canonical_inventory_sort_key(existing) {
+                    *existing = candidate.clone();
+                }
+            })
+            .or_insert(candidate);
     }
     by_key.into_values().collect()
+}
+
+fn canonical_inventory_sort_key(entry: &InstalledSoftware) -> (bool, String, String) {
+    (
+        entry.display_name.trim().is_empty(),
+        entry.display_name.to_lowercase(),
+        entry.executable_path.to_lowercase(),
+    )
 }
 
 fn derive_product_key(display_name: &str, executable_path: &str) -> String {
@@ -94,35 +110,49 @@ mod tests {
         assert_eq!(normalize_name("PowerShell.EXE"), "powershell");
     }
 
-#[test]
-fn normalize_name_preserves_unicode_letters() {
-    assert_eq!(normalize_name("Программа.EXE"), "программа");
-    assert_eq!(normalize_name("監視ツール.exe"), "監視ツール");
-}
+    #[test]
+    fn normalize_name_preserves_unicode_letters() {
+        assert_eq!(normalize_name("Программа.EXE"), "программа");
+        assert_eq!(normalize_name("監視ツール.exe"), "監視ツール");
+    }
 
-#[test]
-fn derive_product_key_prefers_display_name() {
-    let key = derive_product_key("Google Chrome", "/opt/chrome/chrome");
-    assert_eq!(key, "google-chrome");
-}
+    #[test]
+    fn derive_product_key_prefers_display_name() {
+        let key = derive_product_key("Google Chrome", "/opt/chrome/chrome");
+        assert_eq!(key, "google-chrome");
+    }
 
-#[test]
-fn derive_product_key_uses_path_when_name_missing() {
-    let key = derive_product_key("", "/usr/bin/curl");
-    assert_eq!(key, "curl");
-}
+    #[test]
+    fn derive_product_key_uses_path_when_name_missing() {
+        let key = derive_product_key("", "/usr/bin/curl");
+        assert_eq!(key, "curl");
+    }
 
-#[test]
-fn derive_product_key_unknown_when_name_and_path_missing() {
-    let key = derive_product_key("", "");
-    assert_eq!(key, "unknown-product");
-}
+    #[test]
+    fn derive_product_key_unknown_when_name_and_path_missing() {
+        let key = derive_product_key("", "");
+        assert_eq!(key, "unknown-product");
+    }
 
-#[test]
-fn collect_from_entries_keeps_empty_name_when_path_present() {
-    let entries = vec![("".to_string(), "/opt/vendor/agentd".to_string())];
-    let inventory = collect_from_entries(entries);
-    assert_eq!(inventory.len(), 1);
-    assert_eq!(inventory[0].product_key, "agentd");
-}
+    #[test]
+    fn collect_from_entries_keeps_empty_name_when_path_present() {
+        let entries = vec![("".to_string(), "/opt/vendor/agentd".to_string())];
+        let inventory = collect_from_entries(entries);
+        assert_eq!(inventory.len(), 1);
+        assert_eq!(inventory[0].product_key, "agentd");
+    }
+
+    #[test]
+    fn collect_from_entries_prefers_stable_named_entry_for_duplicate_key() {
+        let entries = vec![
+            ("".to_string(), "/opt/vendor/chrome".to_string()),
+            ("Google Chrome".to_string(), "/Applications/Google Chrome.app".to_string()),
+            ("google chrome".to_string(), "/opt/google/chrome".to_string()),
+        ];
+        let inventory = collect_from_entries(entries);
+        assert_eq!(inventory.len(), 1);
+        assert_eq!(inventory[0].product_key, "google-chrome");
+        assert_eq!(inventory[0].display_name, "Google Chrome");
+        assert_eq!(inventory[0].executable_path, "/Applications/Google Chrome.app");
+    }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,0 +1,87 @@
+use crate::software_inventory::InstalledSoftware;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+const SOFTWARE_INVENTORY_FILE: &str = "vigil-software-inventory.json";
+const SOFTWARE_INVENTORY_SCHEMA_VERSION: u32 = 1;
+
+pub trait InventoryStore {
+    fn replace_inventory(&self, entries: &[InstalledSoftware]) -> Result<(), String>;
+    fn load_inventory(&self) -> Result<Vec<InstalledSoftware>, String>;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SoftwareInventoryState {
+    schema_version: u32,
+    generated_unix: u64,
+    entries: Vec<InstalledSoftware>,
+}
+
+pub struct ProtectedJsonInventoryStore {
+    path: PathBuf,
+}
+
+impl ProtectedJsonInventoryStore {
+    pub fn new_default() -> Self {
+        Self {
+            path: crate::config::data_dir().join(SOFTWARE_INVENTORY_FILE),
+        }
+    }
+}
+
+impl InventoryStore for ProtectedJsonInventoryStore {
+    fn replace_inventory(&self, entries: &[InstalledSoftware]) -> Result<(), String> {
+        let state = SoftwareInventoryState {
+            schema_version: SOFTWARE_INVENTORY_SCHEMA_VERSION,
+            generated_unix: chrono::Utc::now().timestamp().max(0) as u64,
+            entries: entries.to_vec(),
+        };
+        crate::security::policy::save_struct_with_integrity(&self.path, &state).map_err(|e| {
+            format!(
+                "failed to persist protected software inventory {}: {e}",
+                self.path.display()
+            )
+        })
+    }
+
+    fn load_inventory(&self) -> Result<Vec<InstalledSoftware>, String> {
+        let loaded: Option<SoftwareInventoryState> =
+            crate::security::policy::load_struct_with_integrity(&self.path).map_err(|e| {
+                format!(
+                    "failed to load protected software inventory {}: {e}",
+                    self.path.display()
+                )
+            })?;
+        let Some(state) = loaded else {
+            return Ok(Vec::new());
+        };
+        if state.schema_version != SOFTWARE_INVENTORY_SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported software inventory schema {} in {}",
+                state.schema_version,
+                self.path.display()
+            ));
+        }
+        Ok(state.entries)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn protected_store_round_trip() {
+        let store = ProtectedJsonInventoryStore::new_default();
+        let rows = vec![InstalledSoftware {
+            product_key: "curl".into(),
+            display_name: "curl".into(),
+            executable_path: "/usr/bin/curl".into(),
+            publisher_hint: None,
+            source: crate::software_inventory::InventorySource::RunningProcess,
+        }];
+        store.replace_inventory(&rows).unwrap();
+        let loaded = store.load_inventory().unwrap();
+        assert!(loaded.iter().any(|r| r.product_key == "curl"));
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,6 +1,6 @@
 use crate::software_inventory::InstalledSoftware;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const SOFTWARE_INVENTORY_FILE: &str = "vigil-software-inventory.json";
 const SOFTWARE_INVENTORY_SCHEMA_VERSION: u32 = 1;
@@ -23,9 +23,15 @@ pub struct ProtectedJsonInventoryStore {
 
 impl ProtectedJsonInventoryStore {
     pub fn new_default() -> Self {
-        Self {
-            path: crate::config::data_dir().join(SOFTWARE_INVENTORY_FILE),
-        }
+        Self::from_path(crate::config::data_dir().join(SOFTWARE_INVENTORY_FILE))
+    }
+
+    pub fn from_path(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
     }
 }
 
@@ -36,20 +42,20 @@ impl InventoryStore for ProtectedJsonInventoryStore {
             generated_unix: chrono::Utc::now().timestamp().max(0) as u64,
             entries: entries.to_vec(),
         };
-        crate::security::policy::save_struct_with_integrity(&self.path, &state).map_err(|e| {
+        crate::security::policy::save_struct_with_integrity(self.path(), &state).map_err(|e| {
             format!(
                 "failed to persist protected software inventory {}: {e}",
-                self.path.display()
+                self.path().display()
             )
         })
     }
 
     fn load_inventory(&self) -> Result<Vec<InstalledSoftware>, String> {
         let loaded: Option<SoftwareInventoryState> =
-            crate::security::policy::load_struct_with_integrity(&self.path).map_err(|e| {
+            crate::security::policy::load_struct_with_integrity(self.path()).map_err(|e| {
                 format!(
                     "failed to load protected software inventory {}: {e}",
-                    self.path.display()
+                    self.path().display()
                 )
             })?;
         let Some(state) = loaded else {
@@ -59,7 +65,7 @@ impl InventoryStore for ProtectedJsonInventoryStore {
             return Err(format!(
                 "unsupported software inventory schema {} in {}",
                 state.schema_version,
-                self.path.display()
+                self.path().display()
             ));
         }
         Ok(state.entries)
@@ -70,9 +76,26 @@ impl InventoryStore for ProtectedJsonInventoryStore {
 mod tests {
     use super::*;
 
+    fn test_inventory_store() -> (ProtectedJsonInventoryStore, PathBuf) {
+        let unique = format!(
+            "vigil-storage-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+        let dir = std::env::temp_dir().join(unique);
+        std::fs::create_dir_all(&dir).unwrap();
+        (
+            ProtectedJsonInventoryStore::from_path(dir.join(SOFTWARE_INVENTORY_FILE)),
+            dir,
+        )
+    }
+
     #[test]
     fn protected_store_round_trip() {
-        let store = ProtectedJsonInventoryStore::new_default();
+        let (store, dir) = test_inventory_store();
         let rows = vec![InstalledSoftware {
             product_key: "curl".into(),
             display_name: "curl".into(),
@@ -83,5 +106,6 @@ mod tests {
         store.replace_inventory(&rows).unwrap();
         let loaded = store.load_inventory().unwrap();
         assert!(loaded.iter().any(|r| r.product_key == "curl"));
+        std::fs::remove_dir_all(dir).unwrap();
     }
 }


### PR DESCRIPTION
### Motivation

- Introduce a first-stage local software inventory source and a protected JSON persistence layer as part of a larger non-backward-compatible migration to a SQLite-backed state store. 
- Provide a documented migration plan outlining schema, integrity strategy, and a staged rollout toward DB-backed storage.

### Description

- Add `docs/LOCAL-STORAGE-MIGRATION.md` describing goals, schema, integrity strategy, and a multi-PR rollout plan for moving from JSON caches to a single SQLite-backed `vigil-state.db` with signed manifests. 
- Add a new `src/software_inventory.rs` module that defines `InstalledSoftware`, `InventorySource`, the runtime collector `collect_installed_software`, normalization helpers (`normalize_name`, `derive_product_key`), and unit tests for normalization and key derivation. 
- Add a new `src/storage/mod.rs` module that implements `InventoryStore` and a `ProtectedJsonInventoryStore` which persists `SoftwareInventoryState` using `security::policy::save_struct_with_integrity` and `load_struct_with_integrity`, plus a round-trip unit test. 
- Wire the new modules into `src/main.rs` to collect a software inventory snapshot at bootstrap via `collect_installed_software` and persist it with `ProtectedJsonInventoryStore::new_default()` using `InventoryStore::replace_inventory`.

### Testing

- Ran unit tests for the new modules with `cargo test` and the added tests in `software_inventory` and `storage` succeeded. 
- The protected-store round-trip persistence and the normalization/derivation unit tests passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f6807b9d9c83288e9ac4f9a47a4626)