### PR TITLE
installer(windows): gate boot service registration to Program Files installs

### DIFF
--- a/installer/windows/setup.iss
+++ b/installer/windows/setup.iss
@@ -64,7 +64,7 @@ Name: "bootservice"; \
   Description: "Start Vigil before login (boot-time monitor service)"; \
   GroupDescription: "Startup"; \
   Flags: checked; \
-  Check: IsAdminInstallMode
+  Check: IsAdminInstallMode and IsProtectedAdminInstallPath
 
 [Files]
 ; The binary is staged next to setup.iss before ISCC runs (see release.yml).
@@ -82,7 +82,7 @@ Filename: "{app}\{#MyAppExeName}"; \
   Parameters: "--install-service"; \
   StatusMsg: "Registering the Vigil boot-time monitor service..."; \
   Flags: runhidden waituntilterminated; \
-  Check: IsAdminInstallMode and WizardIsTaskSelected('bootservice')
+  Check: IsAdminInstallMode and IsProtectedAdminInstallPath and WizardIsTaskSelected('bootservice')
 
 ; Offer to launch Vigil immediately after installation.
 ; Vigil enables login autostart on its own first run — no registry entry
@@ -90,3 +90,20 @@ Filename: "{app}\{#MyAppExeName}"; \
 Filename: "{app}\{#MyAppExeName}"; \
   Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; \
   Flags: nowait postinstall skipifsilent
+
+[Code]
+function IsProtectedAdminInstallPath: Boolean;
+var
+  AppDir, ProgramFilesDir: String;
+begin
+  if not IsAdminInstallMode then
+  begin
+    Result := False;
+    exit;
+  end;
+
+  AppDir := AddBackslash(Uppercase(ExpandConstant('{app}')));
+  ProgramFilesDir := AddBackslash(Uppercase(ExpandConstant('{autopf}')));
+
+  Result := Pos(ProgramFilesDir, AppDir) = 1;
+end;


### PR DESCRIPTION
### Motivation
- The Windows installer previously registered a SYSTEM `ONSTART` scheduled task using the installed executable path without verifying the install directory, which allows local privilege escalation if an admin/all-users install targets a user-writable location.
- The change aims to prevent automatic boot-time service registration from potentially writable custom install paths while preserving the default all-users Program Files behavior.

### Description
- Add an Inno Setup `[Code]` function `IsProtectedAdminInstallPath` that returns true only for admin/all-users installs whose `{app}` is rooted under `{autopf}` (Program Files).
- Require `IsProtectedAdminInstallPath` in the `bootservice` task `Check` so the task is only shown/selected for protected Program Files installs.
- Require `IsProtectedAdminInstallPath` in the `Run` entry that executes the installed binary with `--install-service` so the installer will only auto-register the SYSTEM task for protected Program Files installs.

### Testing
- Verified the new guard appears in `installer/windows/setup.iss` by searching for `IsProtectedAdminInstallPath` and related keys with `rg`, which returned the updated task and run checks.
- Inspected the modified `installer/windows/setup.iss` contents with `nl -ba`/`sed -n` to confirm the `Check:` lines and the new `[Code]` function were inserted as intended.
- Confirmed the produced diff shows the `bootservice` and `--install-service` checks updated and the new `IsProtectedAdminInstallPath` function added by comparing the file before/after the change with a file diff tool.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f5b62abb5c83289282f83eba9d121e)