### PR TITLE
[codex] advisory: enrich software inventory version hints

### DIFF
--- a/src/process/publisher.rs
+++ b/src/process/publisher.rs
@@ -85,7 +85,7 @@ fn query_string_file_info(path: &str, value_names: &[&str]) -> String {
         }
 
         for value_name in value_names {
-            let sub_block = format!(r"\StringFileInfo\040904B0\{value_name}");
+            let sub_block = format!("\\StringFileInfo\\040904B0\\{}", value_name);
             let sub_block: Vec<u16> = OsStr::new(&sub_block)
                 .encode_wide()
                 .chain(std::iter::once(0))

--- a/src/process/publisher.rs
+++ b/src/process/publisher.rs
@@ -80,7 +80,14 @@ fn query_string_file_info(path: &str, value_names: &[&str]) -> String {
         }
 
         let mut buf: Vec<u8> = vec![0u8; size as usize];
-        if GetFileVersionInfoW(pcwstr, Some(0), size, buf.as_mut_ptr() as *mut _).is_err() {
+        if GetFileVersionInfoW(
+            pcwstr,
+            Some(0),
+            size,
+            buf.as_mut_ptr() as *mut _,
+        )
+        .is_err()
+        {
             return String::new();
         }
 
@@ -102,7 +109,10 @@ fn query_string_file_info(path: &str, value_names: &[&str]) -> String {
             .as_bool()
                 && p_len > 1
             {
-                let chars = std::slice::from_raw_parts(p_val as *const u16, (p_len - 1) as usize);
+                let chars = std::slice::from_raw_parts(
+                    p_val as *const u16,
+                    (p_len - 1) as usize,
+                );
                 let value = String::from_utf16_lossy(chars).trim().to_string();
                 if !value.is_empty() {
                     return value;

--- a/src/process/publisher.rs
+++ b/src/process/publisher.rs
@@ -1,36 +1,65 @@
-//! Windows-only: extract the CompanyName from a PE file's version resources.
+//! Windows-only: extract selected PE version-resource strings.
 //! Results are cached for the lifetime of the process.
 
 use dashmap::DashMap;
 use std::sync::OnceLock;
 
-static CACHE: OnceLock<DashMap<String, String>> = OnceLock::new();
+static PUBLISHER_CACHE: OnceLock<DashMap<String, String>> = OnceLock::new();
+static VERSION_CACHE: OnceLock<DashMap<String, String>> = OnceLock::new();
 
-fn cache() -> &'static DashMap<String, String> {
-    CACHE.get_or_init(DashMap::new)
+fn publisher_cache() -> &'static DashMap<String, String> {
+    PUBLISHER_CACHE.get_or_init(DashMap::new)
+}
+
+fn version_cache() -> &'static DashMap<String, String> {
+    VERSION_CACHE.get_or_init(DashMap::new)
 }
 
 /// Return the `CompanyName` string from the PE version info of `path`.
 /// Returns an empty string if unavailable, inaccessible, or not on Windows.
 pub fn get_publisher(path: &str) -> String {
+    cached_lookup(path, publisher_cache(), query_publisher)
+}
+
+/// Return the `ProductVersion` or `FileVersion` string from the PE version
+/// info of `path`. Returns an empty string if unavailable, inaccessible, or
+/// not on Windows.
+pub fn get_file_version(path: &str) -> String {
+    cached_lookup(path, version_cache(), query_file_version)
+}
+
+fn cached_lookup(
+    path: &str,
+    cache: &'static DashMap<String, String>,
+    query: fn(&str) -> String,
+) -> String {
     if path.is_empty() {
         return String::new();
     }
 
-    // Fast path: cached
-    if let Some(v) = cache().get(path) {
-        return v.clone();
+    if let Some(value) = cache.get(path) {
+        return value.clone();
     }
 
-    let result = query_publisher(path);
-    cache().insert(path.to_string(), result.clone());
+    let result = query(path);
+    cache.insert(path.to_string(), result.clone());
     result
 }
 
-// ── Windows implementation ────────────────────────────────────────────────────
+// -- Windows implementation -------------------------------------------------
 
 #[cfg(windows)]
 fn query_publisher(path: &str) -> String {
+    query_string_file_info(path, &["CompanyName"])
+}
+
+#[cfg(windows)]
+fn query_file_version(path: &str) -> String {
+    query_string_file_info(path, &["ProductVersion", "FileVersion"])
+}
+
+#[cfg(windows)]
+fn query_string_file_info(path: &str, value_names: &[&str]) -> String {
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
     use windows::core::PCWSTR;
@@ -38,7 +67,6 @@ fn query_publisher(path: &str) -> String {
         GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW,
     };
 
-    // Encode path as wide string
     let wide: Vec<u16> = OsStr::new(path)
         .encode_wide()
         .chain(std::iter::once(0))
@@ -46,39 +74,40 @@ fn query_publisher(path: &str) -> String {
     let pcwstr = PCWSTR(wide.as_ptr());
 
     unsafe {
-        // 1. Get size of version info block
         let size = GetFileVersionInfoSizeW(pcwstr, None);
         if size == 0 {
             return String::new();
         }
 
-        // 2. Read version info block
         let mut buf: Vec<u8> = vec![0u8; size as usize];
         if GetFileVersionInfoW(pcwstr, Some(0), size, buf.as_mut_ptr() as *mut _).is_err() {
             return String::new();
         }
 
-        // 3. Query CompanyName (English/Unicode codepage 040904B0)
-        let sub_block: Vec<u16> = OsStr::new("\\StringFileInfo\\040904B0\\CompanyName")
-            .encode_wide()
-            .chain(std::iter::once(0))
-            .collect();
+        for value_name in value_names {
+            let sub_block = format!(r"\StringFileInfo\040904B0\{value_name}");
+            let sub_block: Vec<u16> = OsStr::new(&sub_block)
+                .encode_wide()
+                .chain(std::iter::once(0))
+                .collect();
+            let mut p_val: *mut std::ffi::c_void = std::ptr::null_mut();
+            let mut p_len: u32 = 0;
 
-        let mut p_val: *mut std::ffi::c_void = std::ptr::null_mut();
-        let mut p_len: u32 = 0;
-
-        if VerQueryValueW(
-            buf.as_ptr() as *const _,
-            PCWSTR(sub_block.as_ptr()),
-            &mut p_val,
-            &mut p_len,
-        )
-        .as_bool()
-            && p_len > 1
-        {
-            // p_val points into buf; p_len includes the null terminator
-            let chars = std::slice::from_raw_parts(p_val as *const u16, (p_len - 1) as usize);
-            return String::from_utf16_lossy(chars).trim().to_string();
+            if VerQueryValueW(
+                buf.as_ptr() as *const _,
+                PCWSTR(sub_block.as_ptr()),
+                &mut p_val,
+                &mut p_len,
+            )
+            .as_bool()
+                && p_len > 1
+            {
+                let chars = std::slice::from_raw_parts(p_val as *const u16, (p_len - 1) as usize);
+                let value = String::from_utf16_lossy(chars).trim().to_string();
+                if !value.is_empty() {
+                    return value;
+                }
+            }
         }
     }
 
@@ -87,5 +116,10 @@ fn query_publisher(path: &str) -> String {
 
 #[cfg(not(windows))]
 fn query_publisher(_path: &str) -> String {
+    String::new()
+}
+
+#[cfg(not(windows))]
+fn query_file_version(_path: &str) -> String {
     String::new()
 }

--- a/src/process/publisher.rs
+++ b/src/process/publisher.rs
@@ -80,14 +80,7 @@ fn query_string_file_info(path: &str, value_names: &[&str]) -> String {
         }
 
         let mut buf: Vec<u8> = vec![0u8; size as usize];
-        if GetFileVersionInfoW(
-            pcwstr,
-            Some(0),
-            size,
-            buf.as_mut_ptr() as *mut _,
-        )
-        .is_err()
-        {
+        if GetFileVersionInfoW(pcwstr, Some(0), size, buf.as_mut_ptr() as *mut _).is_err() {
             return String::new();
         }
 
@@ -109,10 +102,7 @@ fn query_string_file_info(path: &str, value_names: &[&str]) -> String {
             .as_bool()
                 && p_len > 1
             {
-                let chars = std::slice::from_raw_parts(
-                    p_val as *const u16,
-                    (p_len - 1) as usize,
-                );
+                let chars = std::slice::from_raw_parts(p_val as *const u16, (p_len - 1) as usize);
                 let value = String::from_utf16_lossy(chars).trim().to_string();
                 if !value.is_empty() {
                     return value;

--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -81,7 +81,11 @@ where
             .and_modify(|existing| {
                 if canonical_inventory_sort_key(&candidate) < canonical_inventory_sort_key(existing)
                 {
-                    *existing = candidate.clone();
+                    let mut preferred = candidate.clone();
+                    merge_missing_inventory_hints(&mut preferred, existing);
+                    *existing = preferred;
+                } else {
+                    merge_missing_inventory_hints(existing, &candidate);
                 }
             })
             .or_insert(candidate);
@@ -97,6 +101,15 @@ fn canonical_inventory_sort_key(entry: &InstalledSoftware) -> (bool, bool, bool,
         entry.display_name.to_lowercase(),
         entry.executable_path.to_lowercase(),
     )
+}
+
+fn merge_missing_inventory_hints(target: &mut InstalledSoftware, source: &InstalledSoftware) {
+    if target.publisher_hint.is_none() {
+        target.publisher_hint = source.publisher_hint.clone();
+    }
+    if target.version_hint.is_none() {
+        target.version_hint = source.version_hint.clone();
+    }
 }
 
 fn derive_product_key(display_name: &str, executable_path: &str) -> String {
@@ -232,5 +245,29 @@ mod tests {
             inventory[0].executable_path,
             "/Applications/Example Agent.app"
         );
+    }
+
+    #[test]
+    fn collect_from_entries_merges_complementary_metadata_for_duplicate_key() {
+        let entries = vec![
+            seed(
+                "Example Agent",
+                "/opt/example/agent",
+                Some("Example Corp"),
+                None,
+            ),
+            seed(
+                "Example Agent",
+                "/Applications/Example Agent.app",
+                None,
+                Some("2.4.1"),
+            ),
+        ];
+        let inventory = collect_from_entries(entries);
+        assert_eq!(inventory.len(), 1);
+        assert_eq!(inventory[0].product_key, "example-agent");
+        assert_eq!(inventory[0].publisher_hint.as_deref(), Some("Example Corp"));
+        assert_eq!(inventory[0].version_hint.as_deref(), Some("2.4.1"));
+        assert_eq!(inventory[0].executable_path, "/opt/example/agent");
     }
 }

--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -1,8 +1,9 @@
 //! Minimal local software inventory foundations for advisory relevance.
 //!
-//! Phase 16 Task 1 starts with a conservative, low-risk inventory source:
+//! Phase 16 starts with a conservative, low-risk inventory source:
 //! currently-running processes. This avoids package-manager-specific parsing
-//! while still giving the advisory pipeline stable product candidates.
+//! while still giving the advisory pipeline stable product candidates plus
+//! lightweight publisher/version hints for later matching.
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -13,13 +14,24 @@ pub struct InstalledSoftware {
     pub product_key: String,
     pub display_name: String,
     pub executable_path: String,
+    #[serde(default)]
     pub publisher_hint: Option<String>,
+    #[serde(default)]
+    pub version_hint: Option<String>,
     pub source: InventorySource,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum InventorySource {
     RunningProcess,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InventorySeed {
+    display_name: String,
+    executable_path: String,
+    publisher_hint: Option<String>,
+    version_hint: Option<String>,
 }
 
 pub fn collect_installed_software() -> Vec<InstalledSoftware> {
@@ -32,26 +44,36 @@ pub fn collect_installed_software() -> Vec<InstalledSoftware> {
             .exe()
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or_default();
-        (display_name, executable_path)
+        InventorySeed {
+            display_name,
+            publisher_hint: inventory_hint(crate::process::publisher::get_publisher(
+                &executable_path,
+            )),
+            version_hint: inventory_hint(crate::process::publisher::get_file_version(
+                &executable_path,
+            )),
+            executable_path,
+        }
     });
     collect_from_entries(entries)
 }
 
 fn collect_from_entries<I>(entries: I) -> Vec<InstalledSoftware>
 where
-    I: IntoIterator<Item = (String, String)>,
+    I: IntoIterator<Item = InventorySeed>,
 {
     let mut by_key: BTreeMap<String, InstalledSoftware> = BTreeMap::new();
-    for (display_name, executable_path) in entries {
-        if display_name.is_empty() && executable_path.is_empty() {
+    for entry in entries {
+        if entry.display_name.is_empty() && entry.executable_path.is_empty() {
             continue;
         }
-        let product_key = derive_product_key(&display_name, &executable_path);
+        let product_key = derive_product_key(&entry.display_name, &entry.executable_path);
         let candidate = InstalledSoftware {
             product_key: product_key.clone(),
-            display_name,
-            executable_path,
-            publisher_hint: None,
+            display_name: entry.display_name,
+            executable_path: entry.executable_path,
+            publisher_hint: entry.publisher_hint,
+            version_hint: entry.version_hint,
             source: InventorySource::RunningProcess,
         };
         by_key
@@ -67,9 +89,11 @@ where
     by_key.into_values().collect()
 }
 
-fn canonical_inventory_sort_key(entry: &InstalledSoftware) -> (bool, String, String) {
+fn canonical_inventory_sort_key(entry: &InstalledSoftware) -> (bool, bool, bool, String, String) {
     (
         entry.display_name.trim().is_empty(),
+        entry.publisher_hint.is_none(),
+        entry.version_hint.is_none(),
         entry.display_name.to_lowercase(),
         entry.executable_path.to_lowercase(),
     )
@@ -102,9 +126,32 @@ fn normalize_name(input: &str) -> String {
         .to_string()
 }
 
+fn inventory_hint(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn seed(
+        display_name: &str,
+        executable_path: &str,
+        publisher_hint: Option<&str>,
+        version_hint: Option<&str>,
+    ) -> InventorySeed {
+        InventorySeed {
+            display_name: display_name.to_string(),
+            executable_path: executable_path.to_string(),
+            publisher_hint: publisher_hint.map(str::to_string),
+            version_hint: version_hint.map(str::to_string),
+        }
+    }
 
     #[test]
     fn normalize_name_strips_case_and_extension() {
@@ -137,7 +184,7 @@ mod tests {
 
     #[test]
     fn collect_from_entries_keeps_empty_name_when_path_present() {
-        let entries = vec![("".to_string(), "/opt/vendor/agentd".to_string())];
+        let entries = vec![seed("", "/opt/vendor/agentd", None, None)];
         let inventory = collect_from_entries(entries);
         assert_eq!(inventory.len(), 1);
         assert_eq!(inventory[0].product_key, "agentd");
@@ -146,15 +193,14 @@ mod tests {
     #[test]
     fn collect_from_entries_prefers_stable_named_entry_for_duplicate_key() {
         let entries = vec![
-            ("".to_string(), "/opt/vendor/chrome".to_string()),
-            (
-                "Google Chrome".to_string(),
-                "/Applications/Google Chrome.app".to_string(),
+            seed("", "/opt/vendor/chrome", None, None),
+            seed(
+                "Google Chrome",
+                "/Applications/Google Chrome.app",
+                None,
+                None,
             ),
-            (
-                "google chrome".to_string(),
-                "/opt/google/chrome".to_string(),
-            ),
+            seed("google chrome", "/opt/google/chrome", None, None),
         ];
         let inventory = collect_from_entries(entries);
         assert_eq!(inventory.len(), 1);
@@ -163,6 +209,28 @@ mod tests {
         assert_eq!(
             inventory[0].executable_path,
             "/Applications/Google Chrome.app"
+        );
+    }
+
+    #[test]
+    fn collect_from_entries_prefers_richer_metadata_for_duplicate_key() {
+        let entries = vec![
+            seed("Example Agent", "/opt/example/agent", None, None),
+            seed(
+                "Example Agent",
+                "/Applications/Example Agent.app",
+                Some("Example Corp"),
+                Some("2.4.1"),
+            ),
+        ];
+        let inventory = collect_from_entries(entries);
+        assert_eq!(inventory.len(), 1);
+        assert_eq!(inventory[0].product_key, "example-agent");
+        assert_eq!(inventory[0].publisher_hint.as_deref(), Some("Example Corp"));
+        assert_eq!(inventory[0].version_hint.as_deref(), Some("2.4.1"));
+        assert_eq!(
+            inventory[0].executable_path,
+            "/Applications/Example Agent.app"
         );
     }
 }

--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -46,12 +46,12 @@ pub fn collect_installed_software() -> Vec<InstalledSoftware> {
             .unwrap_or_default();
         InventorySeed {
             display_name,
-            publisher_hint: inventory_hint(crate::process::publisher::get_publisher(
-                &executable_path,
-            )),
-            version_hint: inventory_hint(crate::process::publisher::get_file_version(
-                &executable_path,
-            )),
+            publisher_hint: inventory_hint(
+                crate::process::publisher::get_publisher(&executable_path),
+            ),
+            version_hint: inventory_hint(
+                crate::process::publisher::get_file_version(&executable_path),
+            ),
             executable_path,
         }
     });
@@ -79,7 +79,8 @@ where
         by_key
             .entry(product_key)
             .and_modify(|existing| {
-                if canonical_inventory_sort_key(&candidate) < canonical_inventory_sort_key(existing)
+                if canonical_inventory_sort_key(&candidate)
+                    < canonical_inventory_sort_key(existing)
                 {
                     *existing = candidate.clone();
                 }
@@ -89,7 +90,9 @@ where
     by_key.into_values().collect()
 }
 
-fn canonical_inventory_sort_key(entry: &InstalledSoftware) -> (bool, bool, bool, String, String) {
+fn canonical_inventory_sort_key(
+    entry: &InstalledSoftware,
+) -> (bool, bool, bool, String, String) {
     (
         entry.display_name.trim().is_empty(),
         entry.publisher_hint.is_none(),

--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -46,12 +46,12 @@ pub fn collect_installed_software() -> Vec<InstalledSoftware> {
             .unwrap_or_default();
         InventorySeed {
             display_name,
-            publisher_hint: inventory_hint(
-                crate::process::publisher::get_publisher(&executable_path),
-            ),
-            version_hint: inventory_hint(
-                crate::process::publisher::get_file_version(&executable_path),
-            ),
+            publisher_hint: inventory_hint(crate::process::publisher::get_publisher(
+                &executable_path,
+            )),
+            version_hint: inventory_hint(crate::process::publisher::get_file_version(
+                &executable_path,
+            )),
             executable_path,
         }
     });
@@ -79,8 +79,7 @@ where
         by_key
             .entry(product_key)
             .and_modify(|existing| {
-                if canonical_inventory_sort_key(&candidate)
-                    < canonical_inventory_sort_key(existing)
+                if canonical_inventory_sort_key(&candidate) < canonical_inventory_sort_key(existing)
                 {
                     *existing = candidate.clone();
                 }
@@ -90,9 +89,7 @@ where
     by_key.into_values().collect()
 }
 
-fn canonical_inventory_sort_key(
-    entry: &InstalledSoftware,
-) -> (bool, bool, bool, String, String) {
+fn canonical_inventory_sort_key(entry: &InstalledSoftware) -> (bool, bool, bool, String, String) {
     (
         entry.display_name.trim().is_empty(),
         entry.publisher_hint.is_none(),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -100,12 +100,15 @@ mod tests {
             product_key: "curl".into(),
             display_name: "curl".into(),
             executable_path: "/usr/bin/curl".into(),
-            publisher_hint: None,
+            publisher_hint: Some("curl project".into()),
+            version_hint: Some("8.8.0".into()),
             source: crate::software_inventory::InventorySource::RunningProcess,
         }];
         store.replace_inventory(&rows).unwrap();
         let loaded = store.load_inventory().unwrap();
         assert!(loaded.iter().any(|r| r.product_key == "curl"));
+        assert_eq!(loaded[0].publisher_hint.as_deref(), Some("curl project"));
+        assert_eq!(loaded[0].version_hint.as_deref(), Some("8.8.0"));
         std::fs::remove_dir_all(dir).unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- extend the existing Phase 16 software inventory foundations with optional `publisher_hint` and `version_hint` fields
- populate those hints from running-process executable metadata, reusing the existing Windows PE version-resource path conservatively and leaving non-Windows behavior unchanged
- prefer richer duplicate inventory rows when multiple running processes normalize to the same product key, and keep storage tests covering the persisted protected inventory format

## Why This Task
The roadmap still lists both NCSC/BSI ingestion and local software inventory as open, but `master` already contains merged NCSC/BSI import foundations plus a first-pass running-process inventory snapshot. Rather than redoing those slices or jumping ahead to broader product matching, this PR takes the smallest safe next step inside the partially completed software-inventory item: preserve publisher/version hints that later vendor aliasing and version comparison will need.

## Validation
- added focused unit coverage in `src/software_inventory.rs` for duplicate-key selection when one candidate carries richer metadata
- updated the protected inventory store round-trip test in `src/storage/mod.rs` to cover the new optional version field
- full `cargo` validation was not run from this scheduled environment