### PR TITLE
docs: sync Phase 16 roadmap status for NCSC and BSI ingestion

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -282,7 +282,7 @@ Use free public vulnerability and advisory sources to help Vigil keep the local 
 - [x] **NVD CVE change-history ingestion** — protected local cache for NVD CVE change-history snapshots now supports offline import, live API sync, source attribution, rate-limit-aware refresh, and incremental `changeStartDate` / `changeEndDate` updates
 - [x] **EUVD ingestion foundations** — operator-supplied EUVD JSON snapshots can now be normalized into the shared advisory cache while preserving EU-specific aliases, references, mitigation guidance, exploitation indicators, and provenance
 - [x] **JVN ingestion foundations** — operator-supplied JVN / JVN iPedia JSON snapshots and JVNDBRSS XML items can now be normalized into the shared advisory cache while preserving vendor, product, advisory, remediation, and provenance metadata
-- [ ] **Public advisory ingestion for NCSC and BSI** — ingest public RSS, advisory, and malware-analysis content only; do not depend on closed, partner-only, or registration-gated feeds
+- [x] **Public advisory ingestion for NCSC and BSI** — ingest public RSS, advisory, and malware-analysis content only; do not depend on closed, partner-only, or registration-gated feeds
 
 ### Endpoint relevance and matching
 - [ ] **Local software inventory and version discovery** — broaden process, file, package, service, and installed-software collection so Vigil can reason about what is actually present on the machine, not just what is currently connecting


### PR DESCRIPTION
## Summary

- mark the Phase 16 NCSC/BSI public advisory ingestion item complete in `ROADMAP.md`
- align the roadmap with the existing implementation, tests, CLI help, and docs already present in the repository
- make the next unfinished Phase 16 task visible again without introducing duplicate feature churn

## Why this is the next task

`ROADMAP.md` is the repository's primary planning source, and the first unchecked Phase 16 item is already implemented in the current tree:

- `src/advisory_ncsc_bsi.rs` provides the NCSC and BSI/CERT-Bund importers plus parser tests
- `src/main.rs` wires `--import-ncsc` and `--import-bsi` into the CLI and help text
- `README.md` and `docs/USER-GUIDE.md` already document the workflows

That made the roadmap the stale artifact, so the smallest safe in-scope fix is to correct the roadmap rather than invent new feature work.

## Validation relied on

- inspected `ROADMAP.md`
- inspected `src/advisory_ncsc_bsi.rs`
- inspected `src/main.rs`
- inspected `README.md`
- inspected `docs/USER-GUIDE.md`

No code-path change was needed, so no new runtime validation was required for this documentation-only correction.