### PR TITLE
[codex] advisory: preserve all service identities per PID in software inventory

### DIFF
--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -155,6 +155,7 @@ fn primary_service_name_map(
         .filter_map(|(pid, names)| {
             names
                 .into_iter()
+                .rev()
                 .find(|name| !name.trim().is_empty())
                 .map(|name| (pid, name))
         })
@@ -269,7 +270,7 @@ mod tests {
     }
 
     #[test]
-    fn primary_service_name_map_keeps_first_service_per_pid_for_live_process_context() {
+    fn primary_service_name_map_keeps_last_service_per_pid_for_live_process_context() {
         let mut grouped = std::collections::HashMap::new();
         grouped.insert(
             42,
@@ -278,7 +279,7 @@ mod tests {
         grouped.insert(7, vec!["Spooler".to_string()]);
 
         let primary = primary_service_name_map(grouped);
-        assert_eq!(primary.get(&42).map(String::as_str), Some("Dnscache"));
+        assert_eq!(primary.get(&42).map(String::as_str), Some("LanmanWorkstation"));
         assert_eq!(primary.get(&7).map(String::as_str), Some("Spooler"));
     }
 }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -135,16 +135,51 @@ fn join_cmdline(parts: &[std::ffi::OsString]) -> String {
         .join(" ")
 }
 
-pub fn build_service_map() -> std::collections::HashMap<u32, String> {
+pub fn build_services_by_pid() -> std::collections::HashMap<u32, Vec<String>> {
     #[cfg(windows)]
-    return windows_service_map();
+    return windows_services_by_pid();
 
     #[cfg(not(windows))]
     std::collections::HashMap::new()
 }
 
+pub fn build_service_map() -> std::collections::HashMap<u32, String> {
+    primary_service_name_map(build_services_by_pid())
+}
+
+fn primary_service_name_map(
+    services_by_pid: std::collections::HashMap<u32, Vec<String>>,
+) -> std::collections::HashMap<u32, String> {
+    services_by_pid
+        .into_iter()
+        .filter_map(|(pid, names)| {
+            names
+                .into_iter()
+                .find(|name| !name.trim().is_empty())
+                .map(|name| (pid, name))
+        })
+        .collect()
+}
+
+fn remember_service_name(
+    map: &mut std::collections::HashMap<u32, Vec<String>>,
+    pid: u32,
+    name: String,
+) {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+
+    let names = map.entry(pid).or_default();
+    if names.iter().any(|existing| existing.eq_ignore_ascii_case(trimmed)) {
+        return;
+    }
+    names.push(trimmed.to_string());
+}
+
 #[cfg(windows)]
-fn windows_service_map() -> std::collections::HashMap<u32, String> {
+fn windows_services_by_pid() -> std::collections::HashMap<u32, Vec<String>> {
     use windows::Win32::System::Services::{
         EnumServicesStatusExW, OpenSCManagerW, ENUM_SERVICE_STATUS_PROCESSW, SC_ENUM_PROCESS_INFO,
         SC_MANAGER_ENUMERATE_SERVICE, SERVICE_STATE_ALL, SERVICE_WIN32,
@@ -204,7 +239,7 @@ fn windows_service_map() -> std::collections::HashMap<u32, String> {
                 let pid = entry.ServiceStatusProcess.dwProcessId;
                 if pid != 0 {
                     let name = entry.lpServiceName.to_string().unwrap_or_default();
-                    map.insert(pid, name);
+                    remember_service_name(&mut map, pid, name);
                 }
             }
         }
@@ -213,4 +248,37 @@ fn windows_service_map() -> std::collections::HashMap<u32, String> {
     }
 
     map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remember_service_name_skips_blank_and_duplicates() {
+        let mut map = std::collections::HashMap::new();
+        remember_service_name(&mut map, 42, "   ".to_string());
+        remember_service_name(&mut map, 42, "Dnscache".to_string());
+        remember_service_name(&mut map, 42, "dnscache".to_string());
+        remember_service_name(&mut map, 42, "LanmanWorkstation".to_string());
+
+        assert_eq!(
+            map.get(&42),
+            Some(&vec!["Dnscache".to_string(), "LanmanWorkstation".to_string()])
+        );
+    }
+
+    #[test]
+    fn primary_service_name_map_keeps_first_service_per_pid_for_live_process_context() {
+        let mut grouped = std::collections::HashMap::new();
+        grouped.insert(
+            42,
+            vec!["Dnscache".to_string(), "LanmanWorkstation".to_string()],
+        );
+        grouped.insert(7, vec!["Spooler".to_string()]);
+
+        let primary = primary_service_name_map(grouped);
+        assert_eq!(primary.get(&42).map(String::as_str), Some("Dnscache"));
+        assert_eq!(primary.get(&7).map(String::as_str), Some("Spooler"));
+    }
 }

--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -6,7 +6,7 @@
 //! lightweight publisher/version hints for later matching.
 
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use sysinfo::System;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -40,7 +40,7 @@ pub fn collect_installed_software() -> Vec<InstalledSoftware> {
     let mut sys = System::new_all();
     sys.refresh_all();
 
-    let service_map = crate::process::build_service_map();
+    let service_map = crate::process::build_services_by_pid();
     let mut entries = Vec::new();
     for process in sys.processes().values() {
         let display_name = process.name().to_string_lossy().trim().to_string();
@@ -61,11 +61,9 @@ pub fn collect_installed_software() -> Vec<InstalledSoftware> {
             version_hint: version_hint.clone(),
             source: InventorySource::RunningProcess,
         });
-        if let Some(service_name) = service_name_for_process(
-            process.pid().as_u32(),
-            &service_map,
-            &display_name,
-        ) {
+        for service_name in
+            service_names_for_process(process.pid().as_u32(), &service_map, &display_name)
+        {
             entries.push(InventorySeed {
                 display_name: service_name,
                 executable_path: executable_path.clone(),
@@ -78,19 +76,35 @@ pub fn collect_installed_software() -> Vec<InstalledSoftware> {
     collect_from_entries(entries)
 }
 
-fn service_name_for_process(
+fn service_names_for_process(
     pid: u32,
-    service_map: &std::collections::HashMap<u32, String>,
+    service_map: &std::collections::HashMap<u32, Vec<String>>,
     display_name: &str,
-) -> Option<String> {
-    let service_name = service_map.get(&pid)?.trim();
-    if service_name.is_empty() {
-        return None;
+) -> Vec<String> {
+    let Some(service_names) = service_map.get(&pid) else {
+        return Vec::new();
+    };
+
+    let normalized_display_name = normalize_name(display_name);
+    let mut seen = BTreeSet::new();
+    let mut distinct = Vec::new();
+    for service_name in service_names {
+        let trimmed = service_name.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let normalized = normalize_name(trimmed);
+        if normalized.is_empty()
+            || normalized == normalized_display_name
+            || !seen.insert(normalized)
+        {
+            continue;
+        }
+
+        distinct.push(trimmed.to_string());
     }
-    if normalize_name(service_name) == normalize_name(display_name) {
-        return None;
-    }
-    Some(service_name.to_string())
+    distinct
 }
 
 fn collect_from_entries<I>(entries: I) -> Vec<InstalledSoftware>
@@ -243,13 +257,45 @@ mod tests {
     }
 
     #[test]
-    fn service_name_for_process_ignores_blank_and_duplicate_names() {
+    fn service_names_for_process_ignores_blank_duplicate_and_process_names() {
         let mut service_map = std::collections::HashMap::new();
-        service_map.insert(42, "   ".to_string());
-        service_map.insert(43, "agentd".to_string());
-        assert_eq!(service_name_for_process(42, &service_map, "agentd"), None);
-        assert_eq!(service_name_for_process(43, &service_map, "AgentD.exe"), None);
-        assert_eq!(service_name_for_process(44, &service_map, "agentd"), None);
+        service_map.insert(
+            42,
+            vec![
+                "   ".to_string(),
+                "agentd".to_string(),
+                "AgentD".to_string(),
+                "Backup Agent".to_string(),
+            ],
+        );
+
+        assert_eq!(
+            service_names_for_process(42, &service_map, "AgentD.exe"),
+            vec!["Backup Agent".to_string()]
+        );
+        assert!(service_names_for_process(44, &service_map, "agentd").is_empty());
+    }
+
+    #[test]
+    fn service_names_for_process_keeps_multiple_distinct_services() {
+        let mut service_map = std::collections::HashMap::new();
+        service_map.insert(
+            42,
+            vec![
+                "Dnscache".to_string(),
+                "LanmanWorkstation".to_string(),
+                "Dhcp".to_string(),
+            ],
+        );
+
+        assert_eq!(
+            service_names_for_process(42, &service_map, "svchost.exe"),
+            vec![
+                "Dnscache".to_string(),
+                "LanmanWorkstation".to_string(),
+                "Dhcp".to_string(),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep all distinct Windows service names per PID in the process service cache used by software inventory
- preserve the existing single-name live process context path so connection attribution behavior stays stable
- emit one service-backed inventory row per distinct service name and add focused unit coverage for duplicate filtering and shared-host coverage

## Why This Task
There is no open agent-owned PR to follow up right now, so I took the next concrete in-scope item from the repo’s own signals:
- `ROADMAP.md` still lists `Local software inventory and version discovery` as the next unfinished Phase 16 endpoint-relevance item
- review feedback on merged PR #168 identified a concrete regression: shared host processes such as `svchost.exe` can currently contribute at most one service-backed inventory row because the service map stores only one name per PID

This change is the smallest safe slice that addresses that regression without broadening product behavior beyond the current software-inventory foundations.

## Validation
- added unit coverage in `src/process/mod.rs` for service-name aggregation and for preserving the first service name in live process context
- added unit coverage in `src/software_inventory.rs` for filtering duplicate/process-equal service names and for preserving multiple distinct service-backed rows from a shared host process
- I could not run `cargo fmt`, `cargo test`, or CI locally from this scheduled environment because the repository checkout was not available over the network here, so this PR is opened as a draft pending CI or a trusted local validation pass

## Review context
This is a direct follow-up to the unresolved Codex review thread on merged PR #168 about emitting all service identities for a process PID.