### PR TITLE
[codex] advisory: keep registry install directories out of executable paths

### DIFF
--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -197,7 +197,32 @@ fn preferred_registry_path(display_icon: &str, install_location: &str) -> String
     if !display_icon.is_empty() {
         return display_icon;
     }
-    install_location.trim().to_string()
+
+    let install_location = install_location.trim();
+    if registry_install_location_looks_executable(install_location) {
+        return install_location.to_string();
+    }
+
+    String::new()
+}
+
+fn registry_install_location_looks_executable(value: &str) -> bool {
+    let trimmed = value.trim().trim_matches('"');
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let Some(extension) = std::path::Path::new(trimmed)
+        .extension()
+        .and_then(|ext| ext.to_str())
+    else {
+        return false;
+    };
+
+    matches!(
+        extension.to_ascii_lowercase().as_str(),
+        "exe" | "com" | "bat" | "cmd" | "scr" | "pif"
+    )
 }
 
 fn clean_display_icon_path(value: &str) -> String {
@@ -422,9 +447,21 @@ mod tests {
             ),
             "C:\\Program Files\\Vendor\\agent.exe"
         );
+    }
+
+    #[test]
+    fn preferred_registry_path_ignores_directory_install_locations() {
         assert_eq!(
             preferred_registry_path("", "C:\\Program Files\\Vendor"),
-            "C:\\Program Files\\Vendor"
+            ""
+        );
+    }
+
+    #[test]
+    fn preferred_registry_path_keeps_executable_install_locations() {
+        assert_eq!(
+            preferred_registry_path("", "C:\\Program Files\\Vendor\\agent.exe"),
+            "C:\\Program Files\\Vendor\\agent.exe"
         );
     }
 


### PR DESCRIPTION
## Summary
- stop treating Windows uninstall `InstallLocation` directories as executable paths when `DisplayIcon` is absent
- keep the Phase 16 software inventory row empty for `executable_path` unless the registry fallback still looks like an actual executable
- add focused unit coverage for directory-vs-executable `InstallLocation` handling

## Why This Task
There were no open agent-owned pull requests left to follow up on, and the just-merged `Local software inventory and version discovery` slice exposed one concrete review concern: an uninstall-registry row could win duplicate selection with richer metadata while carrying an install directory string in `executable_path`.

That is the smallest safe in-scope follow-up because later advisory correlation wants `executable_path` to remain a binary path when present, and Phase 16 should stay conservative rather than guessing that every install directory is executable material.

## Validation
- reviewed the merged `src/software_inventory.rs` path-selection and duplicate-merge logic from `master`
- added unit tests covering directory `InstallLocation` rejection and executable `InstallLocation` retention
- I could not run `cargo fmt` or `cargo test` in this scheduled environment because the Rust toolchain and full repository checkout are unavailable here, so this PR should stay draft pending CI or a trusted local validation pass

## Scope Notes
- this follow-up stays inside the current Phase 16 software-inventory foundation work
- it does not change product normalization, version comparison, or advisory matching behavior