### PR TITLE
[codex] inventory: ingest macOS Homebrew formula inventory

### DIFF
--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -53,9 +53,8 @@ pub fn collect_installed_software() -> Vec<InstalledSoftware> {
             .exe()
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or_default();
-        let publisher_hint = inventory_hint(crate::process::publisher::get_publisher(
-            &executable_path,
-        ));
+        let publisher_hint =
+            inventory_hint(crate::process::publisher::get_publisher(&executable_path));
         let version_hint = inventory_hint(crate::process::publisher::get_file_version(
             &executable_path,
         ));
@@ -224,7 +223,8 @@ fn collect_homebrew_entries_from_roots(
         else {
             continue;
         };
-        let version_hint = homebrew_version_hint_for_package(&display_name, &package.path(), opt_root);
+        let version_hint =
+            homebrew_version_hint_for_package(&display_name, &package.path(), opt_root);
         entries.push(InventorySeed {
             display_name,
             executable_path: String::new(),
@@ -242,11 +242,9 @@ fn homebrew_version_hint_for_package(
     opt_root: &std::path::Path,
 ) -> Option<String> {
     let canonical_package_root = std::fs::canonicalize(package_root).ok()?;
-    if let Some(active_version) = active_homebrew_version_from_opt(
-        package_name,
-        &canonical_package_root,
-        opt_root,
-    ) {
+    if let Some(active_version) =
+        active_homebrew_version_from_opt(package_name, &canonical_package_root, opt_root)
+    {
         return Some(active_version);
     }
     sole_child_directory_name(&canonical_package_root)
@@ -324,12 +322,7 @@ fn parse_dpkg_status(status: &str) -> Vec<InventorySeed> {
 }
 
 fn inventory_seed_from_dpkg_fields(fields: &BTreeMap<String, String>) -> Option<InventorySeed> {
-    if !dpkg_status_is_installed(
-        fields
-            .get("Status")
-            .map(String::as_str)
-            .unwrap_or_default(),
-    ) {
+    if !dpkg_status_is_installed(fields.get("Status").map(String::as_str).unwrap_or_default()) {
         return None;
     }
 
@@ -345,10 +338,7 @@ fn inventory_seed_from_dpkg_fields(fields: &BTreeMap<String, String>) -> Option<
     Some(InventorySeed {
         display_name: display_name.to_string(),
         executable_path: String::new(),
-        publisher_hint: fields
-            .get("Maintainer")
-            .cloned()
-            .and_then(inventory_hint),
+        publisher_hint: fields.get("Maintainer").cloned().and_then(inventory_hint),
         version_hint: fields.get("Version").cloned().and_then(inventory_hint),
         source: InventorySource::LinuxDpkgStatus,
     })
@@ -366,7 +356,9 @@ fn dpkg_status_is_installed(status: &str) -> bool {
 fn inventory_seed_from_uninstall_key(key: &winreg::RegKey) -> Option<InventorySeed> {
     let display_name = registry_string(key, "DisplayName").unwrap_or_default();
     let executable_path = preferred_registry_path(
-        registry_string(key, "DisplayIcon").as_deref().unwrap_or_default(),
+        registry_string(key, "DisplayIcon")
+            .as_deref()
+            .unwrap_or_default(),
         registry_string(key, "InstallLocation")
             .as_deref()
             .unwrap_or_default(),
@@ -433,7 +425,10 @@ fn clean_display_icon_path(value: &str) -> String {
     let candidate = if let Some(rest) = trimmed.strip_prefix('"') {
         rest.split_once('"').map(|(path, _)| path).unwrap_or(rest)
     } else {
-        trimmed.split_once(',').map(|(path, _)| path).unwrap_or(trimmed)
+        trimmed
+            .split_once(',')
+            .map(|(path, _)| path)
+            .unwrap_or(trimmed)
     };
 
     candidate.trim().trim_matches('"').to_string()
@@ -716,7 +711,9 @@ mod tests {
         assert!(dpkg_status_is_installed("install ok installed"));
         assert!(dpkg_status_is_installed("hold ok installed"));
         assert!(!dpkg_status_is_installed("deinstall ok config-files"));
-        assert!(!dpkg_status_is_installed("install reinstreq half-installed"));
+        assert!(!dpkg_status_is_installed(
+            "install reinstreq half-installed"
+        ));
     }
 
     #[test]
@@ -748,10 +745,7 @@ mod tests {
 
     #[test]
     fn preferred_registry_path_ignores_directory_install_locations() {
-        assert_eq!(
-            preferred_registry_path("", "C:\\Program Files\\Vendor"),
-            ""
-        );
+        assert_eq!(preferred_registry_path("", "C:\\Program Files\\Vendor"), "");
     }
 
     #[test]
@@ -940,7 +934,10 @@ mod tests {
         ];
         let inventory = collect_from_entries(entries);
         assert_eq!(inventory.len(), 1);
-        assert_eq!(inventory[0].source, InventorySource::WindowsUninstallRegistry);
+        assert_eq!(
+            inventory[0].source,
+            InventorySource::WindowsUninstallRegistry
+        );
         assert_eq!(inventory[0].publisher_hint.as_deref(), Some("Example Corp"));
         assert_eq!(inventory[0].version_hint.as_deref(), Some("2.4.1"));
         assert_eq!(

--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -1,10 +1,11 @@
 //! Minimal local software inventory foundations for advisory relevance.
 //!
 //! Phase 16 starts with conservative, low-risk inventory sources:
-//! currently-running processes, Windows uninstall-registry entries, and the
-//! Debian dpkg status database on Linux. This keeps inventory collection
-//! offline and low-risk while still giving the advisory pipeline stable product
-//! candidates plus lightweight publisher/version hints for later matching.
+//! currently-running processes, Windows uninstall-registry entries, the
+//! Debian dpkg status database on Linux, and Homebrew Cellar formula inventory
+//! on macOS. This keeps inventory collection offline and low-risk while still
+//! giving the advisory pipeline stable product candidates plus lightweight
+//! publisher/version hints for later matching.
 
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
@@ -26,6 +27,7 @@ pub struct InstalledSoftware {
 pub enum InventorySource {
     RunningProcess,
     LinuxDpkgStatus,
+    MacosHomebrew,
     WindowsUninstallRegistry,
     RunningService,
 }
@@ -78,6 +80,7 @@ pub fn collect_installed_software() -> Vec<InstalledSoftware> {
     }
     entries.extend(collect_windows_uninstall_entries());
     entries.extend(collect_linux_dpkg_entries());
+    entries.extend(collect_macos_homebrew_entries());
     collect_from_entries(entries)
 }
 
@@ -176,6 +179,110 @@ fn collect_linux_dpkg_entries() -> Vec<InventorySeed> {
 #[cfg(not(target_os = "linux"))]
 fn collect_linux_dpkg_entries() -> Vec<InventorySeed> {
     Vec::new()
+}
+
+#[cfg(target_os = "macos")]
+fn collect_macos_homebrew_entries() -> Vec<InventorySeed> {
+    [
+        (
+            std::path::Path::new("/opt/homebrew/Cellar"),
+            std::path::Path::new("/opt/homebrew/opt"),
+        ),
+        (
+            std::path::Path::new("/usr/local/Cellar"),
+            std::path::Path::new("/usr/local/opt"),
+        ),
+    ]
+    .into_iter()
+    .flat_map(|(cellar_root, opt_root)| collect_homebrew_entries_from_roots(cellar_root, opt_root))
+    .collect()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn collect_macos_homebrew_entries() -> Vec<InventorySeed> {
+    Vec::new()
+}
+
+fn collect_homebrew_entries_from_roots(
+    cellar_root: &std::path::Path,
+    opt_root: &std::path::Path,
+) -> Vec<InventorySeed> {
+    let Ok(packages) = std::fs::read_dir(cellar_root) else {
+        return Vec::new();
+    };
+
+    let mut entries = Vec::new();
+    for package in packages.flatten() {
+        let Ok(file_type) = package.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+
+        let Some(display_name) = inventory_hint(package.file_name().to_string_lossy().to_string())
+        else {
+            continue;
+        };
+        let version_hint = homebrew_version_hint_for_package(&display_name, &package.path(), opt_root);
+        entries.push(InventorySeed {
+            display_name,
+            executable_path: String::new(),
+            publisher_hint: None,
+            version_hint,
+            source: InventorySource::MacosHomebrew,
+        });
+    }
+    entries
+}
+
+fn homebrew_version_hint_for_package(
+    package_name: &str,
+    package_root: &std::path::Path,
+    opt_root: &std::path::Path,
+) -> Option<String> {
+    let canonical_package_root = std::fs::canonicalize(package_root).ok()?;
+    if let Some(active_version) = active_homebrew_version_from_opt(
+        package_name,
+        &canonical_package_root,
+        opt_root,
+    ) {
+        return Some(active_version);
+    }
+    sole_child_directory_name(&canonical_package_root)
+}
+
+fn active_homebrew_version_from_opt(
+    package_name: &str,
+    canonical_package_root: &std::path::Path,
+    opt_root: &std::path::Path,
+) -> Option<String> {
+    let resolved = std::fs::canonicalize(opt_root.join(package_name)).ok()?;
+    if !resolved.starts_with(canonical_package_root) {
+        return None;
+    }
+    resolved
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .and_then(inventory_hint)
+}
+
+fn sole_child_directory_name(dir: &std::path::Path) -> Option<String> {
+    let mut only = None;
+    for child in std::fs::read_dir(dir).ok()? {
+        let child = child.ok()?;
+        if !child.file_type().ok()?.is_dir() {
+            continue;
+        }
+        let Some(name) = inventory_hint(child.file_name().to_string_lossy().to_string()) else {
+            continue;
+        };
+        if only.is_some() {
+            return None;
+        }
+        only = Some(name);
+    }
+    only
 }
 
 fn parse_dpkg_status(status: &str) -> Vec<InventorySeed> {
@@ -384,8 +491,9 @@ fn source_sort_key(source: InventorySource) -> u8 {
     match source {
         InventorySource::RunningProcess => 0,
         InventorySource::LinuxDpkgStatus => 1,
-        InventorySource::WindowsUninstallRegistry => 2,
-        InventorySource::RunningService => 3,
+        InventorySource::MacosHomebrew => 2,
+        InventorySource::WindowsUninstallRegistry => 3,
+        InventorySource::RunningService => 4,
     }
 }
 
@@ -443,6 +551,7 @@ fn inventory_hint(value: String) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     fn seed(
         display_name: &str,
@@ -458,6 +567,28 @@ mod tests {
             version_hint: version_hint.map(str::to_string),
             source,
         }
+    }
+
+    fn temp_test_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "vigil-homebrew-test-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn make_homebrew_roots(label: &str) -> (PathBuf, PathBuf, PathBuf) {
+        let base = temp_test_dir(label);
+        let cellar = base.join("Cellar");
+        let opt = base.join("opt");
+        std::fs::create_dir_all(&cellar).unwrap();
+        std::fs::create_dir_all(&opt).unwrap();
+        (base, cellar, opt)
     }
 
     #[test]
@@ -529,6 +660,55 @@ mod tests {
                 "Dhcp".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn collect_homebrew_entries_from_roots_uses_sole_version_without_opt_link() {
+        let (base, cellar, opt) = make_homebrew_roots("sole-version");
+        std::fs::create_dir_all(cellar.join("ripgrep/14.1.0")).unwrap();
+
+        let parsed = collect_homebrew_entries_from_roots(&cellar, &opt);
+
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].display_name, "ripgrep");
+        assert_eq!(parsed[0].version_hint.as_deref(), Some("14.1.0"));
+        assert_eq!(parsed[0].source, InventorySource::MacosHomebrew);
+
+        std::fs::remove_dir_all(base).unwrap();
+    }
+
+    #[test]
+    fn collect_homebrew_entries_from_roots_leaves_ambiguous_versions_unset() {
+        let (base, cellar, opt) = make_homebrew_roots("ambiguous-version");
+        std::fs::create_dir_all(cellar.join("wget/1.0.0")).unwrap();
+        std::fs::create_dir_all(cellar.join("wget/1.2.0")).unwrap();
+
+        let parsed = collect_homebrew_entries_from_roots(&cellar, &opt);
+
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].display_name, "wget");
+        assert_eq!(parsed[0].version_hint, None);
+
+        std::fs::remove_dir_all(base).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_homebrew_entries_from_roots_prefers_opt_link_version() {
+        let (base, cellar, opt) = make_homebrew_roots("opt-version");
+        let old_version = cellar.join("wget/1.0.0");
+        let active_version = cellar.join("wget/1.2.0");
+        std::fs::create_dir_all(&old_version).unwrap();
+        std::fs::create_dir_all(&active_version).unwrap();
+        std::os::unix::fs::symlink(&active_version, opt.join("wget")).unwrap();
+
+        let parsed = collect_homebrew_entries_from_roots(&cellar, &opt);
+
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].display_name, "wget");
+        assert_eq!(parsed[0].version_hint.as_deref(), Some("1.2.0"));
+
+        std::fs::remove_dir_all(base).unwrap();
     }
 
     #[test]
@@ -713,6 +893,31 @@ mod tests {
         );
         assert_eq!(inventory[0].version_hint.as_deref(), Some("8.8.0-1"));
         assert_eq!(inventory[0].executable_path, "/usr/bin/curl");
+    }
+
+    #[test]
+    fn collect_from_entries_keeps_process_path_when_homebrew_metadata_wins() {
+        let entries = vec![
+            seed(
+                "wget",
+                "/opt/homebrew/bin/wget",
+                None,
+                None,
+                InventorySource::RunningProcess,
+            ),
+            seed(
+                "wget",
+                "",
+                None,
+                Some("1.25.0"),
+                InventorySource::MacosHomebrew,
+            ),
+        ];
+        let inventory = collect_from_entries(entries);
+        assert_eq!(inventory.len(), 1);
+        assert_eq!(inventory[0].source, InventorySource::MacosHomebrew);
+        assert_eq!(inventory[0].version_hint.as_deref(), Some("1.25.0"));
+        assert_eq!(inventory[0].executable_path, "/opt/homebrew/bin/wget");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- extend the Phase 16 software inventory snapshot with offline macOS Homebrew Cellar discovery
- capture Homebrew formula names plus conservative version hints from the active `opt` symlink or a single installed version directory
- preserve running-process executable paths when Homebrew metadata becomes the canonical inventory row for later advisory matching

## Why This Task
PR #174 was already merged, and there were no remaining open agent PRs, review threads, requested changes, or fresh CI blockers to follow up on. That means the roadmap becomes the primary prioritization signal again.

The first unfinished Phase 16 item is still `Local software inventory and version discovery`. The existing tree now covers running processes, running services, Windows uninstall-registry entries, and Debian `dpkg` packages. The next small, safe slice is macOS Homebrew formula inventory because it stays offline, uses local filesystem state only, and broadens a supported platform without jumping ahead into product normalization or advisory matching.

## Validation
- added focused unit coverage for sole-version Homebrew packages, ambiguous multi-version installs, and active `opt` symlink selection
- added duplicate-merge coverage to verify Homebrew metadata can enrich a running-process row without discarding its executable path
- I could not run `cargo fmt`, `cargo test`, or CI locally in this scheduled environment because the repository checkout and Rust toolchain are not available here, so this PR should remain draft until normal validation runs

## Scope Notes
- this change only adds a new inventory source under the existing Phase 16 collection foundations
- it does not yet add macOS app-bundle parsing, Homebrew cask parsing, product normalization, or version-range comparison