### PR TITLE
ci: pin format-and-lint toolchain to Rust 1.94.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           git fetch --no-tags origin "${{ github.base_ref }}"
           changed_files=$(git diff --name-only FETCH_HEAD...HEAD)
 
-          if printf '%s\n' "$changed_files" | grep -Eq '(^|/).*\.rs$|(^|/)Cargo\.(toml|lock)$|(^|/)build\.rs$'; then
+          if printf '%s\n' "$changed_files" | grep -Eq '(^|/).*\.rs$|(^|/)Cargo\.(toml|lock)$|(^|/)build\.rs$|^\.github/workflows/ci\.yml$'; then
             echo "rust=true" >> "$GITHUB_OUTPUT"
           else
             echo "rust=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - name: Install Rust stable
+      - name: Install Rust 1.94.1 for format and lint
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
+          toolchain: 1.94.1
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32


### PR DESCRIPTION
## Summary
- restore an explicit Rust 1.94.1 toolchain pin in the `Format & lint` CI job
- make the Rust-change detector treat `.github/workflows/ci.yml` edits as Rust-relevant so workflow fixes actually exercise the fast gate
- keep the build/test matrix on `stable` so broader compiler coverage remains unchanged

## Why This Task
There were no open agent-owned pull requests needing follow-up, so I checked for concrete blockers before starting a new roadmap slice. Issue #175 is currently the clearest actionable blocker: `cargo fmt --check` is failing because the workflow installs plain `stable`, which is now Rust 1.95.0, while the repository formatting baseline was produced under Rust 1.94.1.

The smallest safe in-scope fix is to restore an explicit formatter/lint toolchain pin in CI. I also tightened the existing Rust-change filter so workflow edits to `ci.yml` no longer produce misleading green runs with the Rust gate skipped.

## Validation
- inspected the failing `Format & lint` GitHub Actions log for PR #174 and confirmed the job installed Rust 1.95.0 from `stable`
- inspected the current `.github/workflows/ci.yml` and verified the workflow had regressed to an unpinned `stable` install in the `check` job
- observed that the first draft revision of this PR skipped the Rust gate because the repo's change filter did not treat `ci.yml` edits as Rust-relevant, then patched that filter on the same branch
- I could not run the workflow locally in this scheduled environment, so CI on this PR is the validation path for the change

## Scope Notes
- this change intentionally does not modify Rust source files
- if the repository prefers to move the whole tree to Rust 1.95 formatting instead, that can happen later as a separate formatting-only refresh PR