### PR TITLE
[codex] Make startup inventory collection safer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -131,7 +131,11 @@ fn apply_data_dir_override_early(args: &[String]) {
     }
 }
 
-fn spawn_bootstrap(cfg_bootstrap: Arc<RwLock<Config>>, manage_login_autostart: bool) {
+fn spawn_bootstrap(
+    cfg_bootstrap: Arc<RwLock<Config>>,
+    manage_login_autostart: bool,
+    pre_login_service_mode: bool,
+) {
     std::thread::Builder::new()
         .name("vigil-bootstrap".into())
         .spawn(move || {
@@ -141,7 +145,7 @@ fn spawn_bootstrap(cfg_bootstrap: Arc<RwLock<Config>>, manage_login_autostart: b
             if c.fswatch_enabled {
                 fswatch::start();
             }
-            if c.reverse_dns_enabled {
+            if c.reverse_dns_enabled && !pre_login_service_mode {
                 revdns::start();
             }
             let (n_lists, n_entries) = blocklist::stats();
@@ -151,24 +155,42 @@ fn spawn_bootstrap(cfg_bootstrap: Arc<RwLock<Config>>, manage_login_autostart: b
                 n_lists,
                 n_entries,
                 c.fswatch_enabled,
-                c.reverse_dns_enabled
+                c.reverse_dns_enabled && !pre_login_service_mode
             );
             advisory::log_cache_status();
             advisory_history::log_cache_status();
 
             active_response::reconcile();
             break_glass::start_heartbeat_loop(cfg_bootstrap.clone());
-            advisory::refresh_nvd_in_background_if_due();
-            advisory_history::refresh_nvd_in_background_if_due();
+            if !pre_login_service_mode {
+                let _ = std::thread::Builder::new()
+                    .name("vigil-bootstrap-nvd-refresh".into())
+                    .spawn(advisory::refresh_nvd_in_background_if_due);
+                let _ = std::thread::Builder::new()
+                    .name("vigil-bootstrap-nvd-history-refresh".into())
+                    .spawn(advisory_history::refresh_nvd_in_background_if_due);
+            }
 
-            let inventory = software_inventory::collect_installed_software();
-            let software_count = inventory.len();
-            tracing::info!(software_count, "software inventory snapshot collected");
-            let inventory_store = storage::ProtectedJsonInventoryStore::new_default();
-            if let Err(err) =
-                storage::InventoryStore::replace_inventory(&inventory_store, &inventory)
-            {
-                tracing::warn!(%err, "failed to persist software inventory snapshot");
+            std::thread::sleep(software_inventory::startup_inventory_delay());
+            match std::panic::catch_unwind(software_inventory::collect_startup_inventory) {
+                Ok(inventory) => {
+                    let software_count = inventory.len();
+                    tracing::info!(
+                        software_count,
+                        "startup-safe software inventory snapshot collected"
+                    );
+                    let inventory_store = storage::ProtectedJsonInventoryStore::new_default();
+                    if let Err(err) =
+                        storage::InventoryStore::replace_inventory(&inventory_store, &inventory)
+                    {
+                        tracing::warn!(%err, "failed to persist software inventory snapshot");
+                    }
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        "software inventory refresh panicked; continuing without startup inventory snapshot"
+                    );
+                }
             }
 
             if manage_login_autostart {
@@ -495,6 +517,20 @@ fn main() {
         }
     }
 
+    let pre_login = session::is_pre_login();
+    let pre_login_service_mode = service_mode && pre_login;
+    let mut pre_login_boot_guard = if pre_login_service_mode {
+        match service::enter_prelogin_boot_guard() {
+            Ok(guard) => Some(guard),
+            Err(err) => {
+                eprintln!("{err}");
+                std::process::exit(0);
+            }
+        }
+    } else {
+        None
+    };
+
     let instance_id = if service_mode {
         SINGLE_INSTANCE_SERVICE_ID
     } else {
@@ -522,7 +558,7 @@ fn main() {
     let log_dir = _log_dir.clone();
 
     tracing::info!("Vigil v{} starting", env!("CARGO_PKG_VERSION"));
-    tracing::info!("pre-login session: {}", session::is_pre_login());
+    tracing::info!("pre-login session: {}", pre_login);
 
     #[cfg(windows)]
     {
@@ -548,7 +584,7 @@ fn main() {
     startup_integrity::run();
     startup_integrity::scan_operator_inputs(&loaded_cfg);
     let cfg = Arc::new(RwLock::new(loaded_cfg));
-    spawn_bootstrap(cfg.clone(), !service_mode);
+    spawn_bootstrap(cfg.clone(), !service_mode, pre_login_service_mode);
 
     let mon = Monitor::new(cfg.clone());
     let service_event_rx = if service_mode {
@@ -562,6 +598,10 @@ fn main() {
         Some(mon.subscribe())
     };
     let _mon_handle = mon.start();
+
+    if let Some(guard) = pre_login_boot_guard.as_mut() {
+        guard.disarm();
+    }
 
     if service_mode {
         if let Some(service_event_rx) = service_event_rx {

--- a/src/platform/service.rs
+++ b/src/platform/service.rs
@@ -100,9 +100,7 @@ fn spawn_deferred_disarm_worker() -> Result<(), String> {
                 PRELOGIN_GUARD_POLL_INTERVAL,
                 crate::session::is_pre_login,
                 || {
-                    tracing::info!(
-                        "interactive login detected; disarming pre-login boot guard"
-                    );
+                    tracing::info!("interactive login detected; disarming pre-login boot guard");
                     if let Err(err) = disarm_prelogin_guard() {
                         tracing::warn!(
                             %err,
@@ -678,8 +676,8 @@ pub fn run_cmd(cmd: &str) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::{
-        drive_prelogin_guard_until_login, format_fail_open_disable_message,
-        next_failure_streak, should_disable_boot_start, PreLoginGuardState,
+        drive_prelogin_guard_until_login, format_fail_open_disable_message, next_failure_streak,
+        should_disable_boot_start, PreLoginGuardState,
     };
     use std::cell::Cell;
     use std::time::Duration;

--- a/src/platform/service.rs
+++ b/src/platform/service.rs
@@ -155,7 +155,7 @@ pub fn enter_prelogin_boot_guard() -> Result<PreLoginBootGuard, String> {
                 )
             })?;
             return Err(
-                "Vigil disabled its boot-time startup after an unclean pre-login run so Windows can finish booting safely. Re-enable only after reviewing the failure."
+                "Vigil disabled its boot-time startup after an unclean pre-login run so the operating system can finish booting safely. Re-enable only after reviewing the failure."
                     .into(),
             );
         }
@@ -441,7 +441,7 @@ mod platform {
     use super::*;
     use crate::platform::command_paths;
     use std::path::Path;
-    use std::process::Command;
+    use std::process::{Command, Output};
 
     const LABEL: &str = "com.vigil.monitor";
 
@@ -524,7 +524,25 @@ mod platform {
     }
 
     pub fn disable_boot_start() -> Result<(), String> {
-        Ok(())
+        let path = plist_path();
+        if !path.exists() {
+            return Ok(());
+        }
+        if !is_root() {
+            return Err("launchd daemon disable requires root".into());
+        }
+        let output = Command::new(command_paths::resolve("launchctl")?)
+            .args(["unload", "-w", &path.display().to_string()])
+            .output()
+            .map_err(|e| format!("failed to spawn `launchctl`: {e}"))?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(format!(
+                "failed to disable launchd daemon `{LABEL}`: {}",
+                command_output_summary(&output)
+            ))
+        }
     }
 
     fn is_root() -> bool {
@@ -543,6 +561,21 @@ mod platform {
             .replace('"', "&quot;")
             .replace('\'', "&apos;")
     }
+
+    fn command_output_summary(output: &Output) -> String {
+        let text = command_output_text(output);
+        if text.trim().is_empty() {
+            format!("exit status {}", output.status)
+        } else {
+            format!("exit status {}; {}", output.status, text.trim())
+        }
+    }
+
+    fn command_output_text(output: &Output) -> String {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        format!("{stdout}{stderr}")
+    }
 }
 
 // ── Linux ─────────────────────────────────────────────────────────────────────
@@ -552,7 +585,7 @@ mod platform {
     use super::*;
     use crate::platform::command_paths;
     use std::path::Path;
-    use std::process::Command;
+    use std::process::{Command, Output};
 
     const UNIT_NAME: &str = "vigil.service";
 
@@ -638,6 +671,25 @@ mod platform {
     }
 
     pub fn disable_boot_start() -> Result<(), String> {
+        if !unit_path().exists() {
+            return Ok(());
+        }
+        if !is_root() {
+            return Err("systemd unit disable requires root".into());
+        }
+        let output = Command::new(command_paths::resolve("systemctl")?)
+            .args(["disable", "--now", UNIT_NAME])
+            .output()
+            .map_err(|e| format!("failed to spawn `systemctl`: {e}"))?;
+        if !output.status.success() {
+            return Err(format!(
+                "failed to disable systemd unit `{UNIT_NAME}`: {}",
+                command_output_summary(&output)
+            ));
+        }
+        let _ = Command::new(command_paths::resolve("systemctl")?)
+            .args(["daemon-reload"])
+            .status();
         Ok(())
     }
 
@@ -650,6 +702,21 @@ mod platform {
 
     fn systemd_quote(text: &str) -> String {
         format!("\"{}\"", text.replace('"', "\\\""))
+    }
+
+    fn command_output_summary(output: &Output) -> String {
+        let text = command_output_text(output);
+        if text.trim().is_empty() {
+            format!("exit status {}", output.status)
+        } else {
+            format!("exit status {}; {}", output.status, text.trim())
+        }
+    }
+
+    fn command_output_text(output: &Output) -> String {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        format!("{stdout}{stderr}")
     }
 }
 

--- a/src/platform/service.rs
+++ b/src/platform/service.rs
@@ -20,6 +20,10 @@
 //! user-mode Vigil process starts via autostart and reads the same log
 //! file, so pre-login events remain visible via the log.
 
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::time::Duration;
+
 /// Result of an install / uninstall command.  `Ok(msg)` is printed verbatim
 /// to stdout; `Err(msg)` is printed to stderr and the process exits 1.
 pub type CmdResult = Result<String, String>;
@@ -27,6 +31,222 @@ pub type CmdResult = Result<String, String>;
 /// Internal headless entrypoint used by OS services / daemons.
 pub const SERVICE_MODE_FLAG: &str = "--service-mode";
 pub const DATA_DIR_FLAG: &str = "--data-dir";
+const PRELOGIN_GUARD_FILE: &str = "vigil-prelogin-guard.json";
+const PRELOGIN_GUARD_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct PreLoginGuardState {
+    armed: bool,
+    last_start_unix: u64,
+    last_success_unix: u64,
+    failure_streak: u32,
+    disabled_boot_start: bool,
+}
+
+pub struct PreLoginBootGuard {
+    active: bool,
+    disarmed: bool,
+    handoff_started: bool,
+}
+
+impl PreLoginBootGuard {
+    pub fn disarm(&mut self) {
+        if !self.active || self.disarmed {
+            return;
+        }
+        if crate::session::is_pre_login() {
+            if self.handoff_started {
+                return;
+            }
+            if let Err(err) = spawn_deferred_disarm_worker() {
+                tracing::warn!(%err, "failed to defer pre-login boot guard disarm until login");
+                return;
+            }
+            self.handoff_started = true;
+            return;
+        }
+        if let Err(err) = disarm_prelogin_guard() {
+            tracing::warn!(%err, "failed to disarm pre-login boot guard");
+            return;
+        }
+        self.disarmed = true;
+    }
+}
+
+impl Drop for PreLoginBootGuard {
+    fn drop(&mut self) {
+        if !self.active || self.disarmed {
+            return;
+        }
+        if crate::session::is_pre_login() {
+            tracing::warn!(
+                "pre-login Vigil service exited before boot guard disarm; the next boot will trip the circuit breaker"
+            );
+            return;
+        }
+        if let Err(err) = disarm_prelogin_guard() {
+            tracing::warn!(%err, "failed to disarm pre-login boot guard during shutdown handoff");
+            return;
+        }
+        self.disarmed = true;
+    }
+}
+
+fn spawn_deferred_disarm_worker() -> Result<(), String> {
+    std::thread::Builder::new()
+        .name("vigil-prelogin-guard".into())
+        .spawn(|| {
+            drive_prelogin_guard_until_login(
+                PRELOGIN_GUARD_POLL_INTERVAL,
+                crate::session::is_pre_login,
+                || {
+                    tracing::info!(
+                        "interactive login detected; disarming pre-login boot guard"
+                    );
+                    if let Err(err) = disarm_prelogin_guard() {
+                        tracing::warn!(
+                            %err,
+                            "failed to disarm pre-login boot guard after login transition"
+                        );
+                    }
+                },
+            );
+        })
+        .map(|_| ())
+        .map_err(|err| format!("failed to spawn pre-login guard handoff thread: {err}"))
+}
+
+fn drive_prelogin_guard_until_login<FCheck, FDisarm>(
+    poll_interval: Duration,
+    mut still_pre_login: FCheck,
+    mut disarm: FDisarm,
+) where
+    FCheck: FnMut() -> bool,
+    FDisarm: FnMut(),
+{
+    while still_pre_login() {
+        std::thread::sleep(poll_interval);
+    }
+    disarm();
+}
+
+pub fn enter_prelogin_boot_guard() -> Result<PreLoginBootGuard, String> {
+    let path = prelogin_guard_path();
+    let mut state = load_prelogin_guard_state(&path).map_err(|err| {
+        fail_open_disable_boot_start(
+            &format!(
+                "Vigil could not read its pre-login boot guard state at {}",
+                path.display()
+            ),
+            err,
+        )
+    })?;
+    if state.armed {
+        state.failure_streak = next_failure_streak(&state);
+        if should_disable_boot_start(&state) {
+            disable_boot_start()?;
+            state.armed = false;
+            state.disabled_boot_start = true;
+            save_prelogin_guard_state(&path, &state).map_err(|err| {
+                fail_open_disable_boot_start(
+                    &format!(
+                        "Vigil disabled its boot-time startup after an unclean pre-login run, but could not persist that guard state at {}",
+                        path.display()
+                    ),
+                    err,
+                )
+            })?;
+            return Err(
+                "Vigil disabled its boot-time startup after an unclean pre-login run so Windows can finish booting safely. Re-enable only after reviewing the failure."
+                    .into(),
+            );
+        }
+    }
+
+    state.armed = true;
+    state.disabled_boot_start = false;
+    state.last_start_unix = unix_now();
+    save_prelogin_guard_state(&path, &state).map_err(|err| {
+        fail_open_disable_boot_start(
+            &format!(
+                "Vigil could not arm its pre-login boot guard at {}",
+                path.display()
+            ),
+            err,
+        )
+    })?;
+    Ok(PreLoginBootGuard {
+        active: true,
+        disarmed: false,
+        handoff_started: false,
+    })
+}
+
+fn fail_open_disable_boot_start(context: &str, cause: String) -> String {
+    let disable_result = disable_boot_start().err();
+    format_fail_open_disable_message(context, &cause, disable_result.as_deref())
+}
+
+fn format_fail_open_disable_message(
+    context: &str,
+    cause: &str,
+    disable_err: Option<&str>,
+) -> String {
+    match disable_err {
+        None => format!(
+            "{context}: {cause}. Vigil disabled its own boot-time startup so one bad boot cannot repeat on the next restart."
+        ),
+        Some(disable_err) => format!(
+            "{context}: {cause}. Vigil then tried to disable its own boot-time startup but failed: {disable_err}"
+        ),
+    }
+}
+
+fn next_failure_streak(state: &PreLoginGuardState) -> u32 {
+    state.failure_streak.saturating_add(1)
+}
+
+fn should_disable_boot_start(state: &PreLoginGuardState) -> bool {
+    state.failure_streak >= 1
+}
+
+fn disarm_prelogin_guard() -> Result<(), String> {
+    let path = prelogin_guard_path();
+    let mut state = load_prelogin_guard_state(&path)?;
+    state.armed = false;
+    state.failure_streak = 0;
+    state.disabled_boot_start = false;
+    state.last_success_unix = unix_now();
+    save_prelogin_guard_state(&path, &state)
+}
+
+fn prelogin_guard_path() -> PathBuf {
+    crate::config::data_dir().join(PRELOGIN_GUARD_FILE)
+}
+
+fn load_prelogin_guard_state(path: &std::path::Path) -> Result<PreLoginGuardState, String> {
+    if !path.exists() {
+        return Ok(PreLoginGuardState::default());
+    }
+    let loaded = crate::security::policy::load_struct_with_integrity(path)
+        .map_err(|e| format!("failed to load pre-login guard {}: {e}", path.display()))?;
+    Ok(loaded.unwrap_or_default())
+}
+
+fn save_prelogin_guard_state(
+    path: &std::path::Path,
+    state: &PreLoginGuardState,
+) -> Result<(), String> {
+    crate::security::policy::save_struct_with_integrity(path, state)
+        .map_err(|e| format!("failed to save pre-login guard {}: {e}", path.display()))
+}
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
 
 pub fn install() -> CmdResult {
     let exe =
@@ -36,6 +256,10 @@ pub fn install() -> CmdResult {
 
 pub fn uninstall() -> CmdResult {
     platform::uninstall()
+}
+
+fn disable_boot_start() -> Result<(), String> {
+    platform::disable_boot_start()
 }
 
 // ── Windows ─────────────────────────────────────────────────────────────────
@@ -164,6 +388,21 @@ mod platform {
         }
     }
 
+    pub fn disable_boot_start() -> Result<(), String> {
+        let output = Command::new(command_paths::resolve("schtasks")?)
+            .args(["/Change", "/TN", TASK_NAME, "/DISABLE"])
+            .output()
+            .map_err(|e| format!("failed to spawn `schtasks`: {e}"))?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(format!(
+                "failed to disable Windows boot-time monitor task `{TASK_NAME}`: {}",
+                command_output_summary(&output)
+            ))
+        }
+    }
+
     fn task_path() -> PathBuf {
         let mut path = std::env::var_os("SystemRoot")
             .map(PathBuf::from)
@@ -286,6 +525,10 @@ mod platform {
         Ok(format!("Removed launchd daemon `{LABEL}`."))
     }
 
+    pub fn disable_boot_start() -> Result<(), String> {
+        Ok(())
+    }
+
     fn is_root() -> bool {
         // Declare getuid() directly to avoid pulling in a `libc` dependency
         // just for a single uid comparison.  It's an infallible C ABI call.
@@ -396,6 +639,10 @@ mod platform {
         Ok(format!("Removed systemd unit `{UNIT_NAME}`."))
     }
 
+    pub fn disable_boot_start() -> Result<(), String> {
+        Ok(())
+    }
+
     fn is_root() -> bool {
         extern "C" {
             fn getuid() -> u32;
@@ -425,5 +672,79 @@ pub fn run_cmd(cmd: &str) -> i32 {
             eprintln!("vigil: {msg}");
             1
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        drive_prelogin_guard_until_login, format_fail_open_disable_message,
+        next_failure_streak, should_disable_boot_start, PreLoginGuardState,
+    };
+    use std::cell::Cell;
+    use std::time::Duration;
+
+    #[test]
+    fn next_unclean_prelogin_run_increments_failure_streak() {
+        let state = PreLoginGuardState {
+            armed: true,
+            failure_streak: 0,
+            ..Default::default()
+        };
+        assert_eq!(next_failure_streak(&state), 1);
+    }
+
+    #[test]
+    fn first_unclean_prelogin_run_disables_boot_start() {
+        let state = PreLoginGuardState {
+            failure_streak: 1,
+            ..Default::default()
+        };
+        assert!(should_disable_boot_start(&state));
+    }
+
+    #[test]
+    fn deferred_guard_handoff_waits_for_login_transition() {
+        let mut states = vec![true, true, false].into_iter();
+        let polls = Cell::new(0);
+        let disarmed = Cell::new(false);
+
+        drive_prelogin_guard_until_login(
+            Duration::ZERO,
+            || {
+                polls.set(polls.get() + 1);
+                states.next().unwrap_or(false)
+            },
+            || disarmed.set(true),
+        );
+
+        assert!(disarmed.get());
+        assert_eq!(polls.get(), 3);
+    }
+
+    #[test]
+    fn deferred_guard_handoff_disarms_immediately_after_login() {
+        let polls = Cell::new(0);
+        let disarmed = Cell::new(false);
+
+        drive_prelogin_guard_until_login(
+            Duration::ZERO,
+            || {
+                polls.set(polls.get() + 1);
+                false
+            },
+            || disarmed.set(true),
+        );
+
+        assert!(disarmed.get());
+        assert_eq!(polls.get(), 1);
+    }
+
+    #[test]
+    fn fail_open_message_mentions_boot_disable_attempt() {
+        let message = format_fail_open_disable_message("guard write failed", "disk full", None);
+        assert!(message.contains("guard write failed"));
+        assert!(message.contains("disk full"));
+        assert!(message.contains("boot-time startup"));
     }
 }

--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -9,7 +9,11 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
+use std::time::Duration;
 use sysinfo::System;
+
+const STARTUP_INVENTORY_DELAY: Duration = Duration::from_secs(15);
+const STARTUP_INVENTORY_MAX_ENTRIES: usize = 512;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InstalledSoftware {
@@ -41,13 +45,29 @@ struct InventorySeed {
     source: InventorySource,
 }
 
+pub fn startup_inventory_delay() -> Duration {
+    STARTUP_INVENTORY_DELAY
+}
+
+pub fn collect_startup_inventory() -> Vec<InstalledSoftware> {
+    collect_installed_software_limited(STARTUP_INVENTORY_MAX_ENTRIES)
+}
+
 pub fn collect_installed_software() -> Vec<InstalledSoftware> {
+    collect_installed_software_limited(usize::MAX)
+}
+
+fn collect_installed_software_limited(max_entries: usize) -> Vec<InstalledSoftware> {
     let mut sys = System::new_all();
     sys.refresh_all();
 
     let service_map = crate::process::build_services_by_pid();
     let mut entries = Vec::new();
     for process in sys.processes().values() {
+        if entries.len() >= max_entries {
+            break;
+        }
+
         let display_name = process.name().to_string_lossy().trim().to_string();
         let executable_path = process
             .exe()
@@ -65,9 +85,13 @@ pub fn collect_installed_software() -> Vec<InstalledSoftware> {
             version_hint: version_hint.clone(),
             source: InventorySource::RunningProcess,
         });
+
         for service_name in
             service_names_for_process(process.pid().as_u32(), &service_map, &display_name)
         {
+            if entries.len() >= max_entries {
+                break;
+            }
             entries.push(InventorySeed {
                 display_name: service_name,
                 executable_path: executable_path.clone(),
@@ -77,10 +101,32 @@ pub fn collect_installed_software() -> Vec<InstalledSoftware> {
             });
         }
     }
-    entries.extend(collect_windows_uninstall_entries());
-    entries.extend(collect_linux_dpkg_entries());
-    entries.extend(collect_macos_homebrew_entries());
+
+    if entries.len() < max_entries {
+        let remaining = max_entries - entries.len();
+        append_limited_entries(&mut entries, collect_windows_uninstall_entries(), remaining);
+    }
+    if entries.len() < max_entries {
+        let remaining = max_entries - entries.len();
+        append_limited_entries(&mut entries, collect_linux_dpkg_entries(), remaining);
+    }
+    if entries.len() < max_entries {
+        let remaining = max_entries - entries.len();
+        append_limited_entries(&mut entries, collect_macos_homebrew_entries(), remaining);
+    }
+
     collect_from_entries(entries)
+}
+
+fn append_limited_entries(
+    entries: &mut Vec<InventorySeed>,
+    additional: Vec<InventorySeed>,
+    remaining: usize,
+) {
+    if remaining == 0 {
+        return;
+    }
+    entries.extend(additional.into_iter().take(remaining));
 }
 
 fn service_names_for_process(
@@ -1155,5 +1201,22 @@ mod tests {
         assert!(inventory.iter().any(|row| {
             row.product_key == "dnscache" && row.source == InventorySource::RunningService
         }));
+    }
+
+    #[test]
+    fn startup_inventory_limit_caps_seed_count_before_deduplication() {
+        let mut entries = Vec::new();
+        for i in 0..(STARTUP_INVENTORY_MAX_ENTRIES + 25) {
+            entries.push(seed(
+                &format!("proc-{i}"),
+                &format!("/opt/proc-{i}"),
+                None,
+                None,
+                InventorySource::RunningProcess,
+            ));
+        }
+        let mut limited = Vec::new();
+        append_limited_entries(&mut limited, entries, STARTUP_INVENTORY_MAX_ENTRIES);
+        assert_eq!(limited.len(), STARTUP_INVENTORY_MAX_ENTRIES);
     }
 }


### PR DESCRIPTION
## Summary
- delay the startup inventory sweep so Vigil can finish its critical launch path before collecting advisory-relevance hints
- cap the launch-time inventory snapshot to a bounded number of entries instead of scanning an unbounded set during startup
- wrap startup inventory refresh in panic isolation so a bad inventory edge case cannot take down the rest of Vigil startup
- add a pre-login boot circuit breaker for service mode so an unclean before-login Vigil run disables the Windows boot-time task on the next boot instead of repeating and risking another blocked machine
- trim nonessential pre-login bootstrap work by skipping advisory refresh and reverse-DNS startup while Vigil is running before login as a service
- make the normal NVD and NVD change-history refresh calls bootstrap-safe by moving them off the main bootstrap path

## Why this task
The roadmap’s next explicit unfinished item is Phase 16 local software inventory and version discovery. The repo already started that work by collecting software inventory at launch, so the safest concrete next slice was to make that startup behavior bounded and failure-tolerant before broadening it further.

The reported before-login startup failure raised the priority of the service-mode boot path. A security tool has to fail open at boot rather than risk locking the machine into repeated bad startups.

## Validation
- added focused unit coverage around the startup inventory limit helper path in `src/software_inventory.rs`
- added focused unit coverage for the pre-login boot guard trip logic in `src/platform/service.rs`
- reviewed the startup bootstrap flow in `src/main.rs` to confirm inventory refresh now runs after a delay and cannot unwind the rest of the bootstrap path
- reviewed the service-mode startup flow to confirm pre-login runs now arm a guard and disable future boot-time startup after an unclean pre-login exit

## Notes
- this replaces the earlier diverged draft branch with a clean master-based branch so mergeability can be evaluated on current `master`
- I could not run `cargo test`, `cargo check`, or a Windows boot reproduction in this environment