### PR TITLE
[codex] Update docs for Windows and Linux support scope

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,51 +31,57 @@ machines — treat every contributor and user accordingly.
 Use the [Bug Report](.github/ISSUE_TEMPLATE/bug_report.md) issue template.
 Please include:
 
-- Vigil version (`Help` tab → footer, or `vigil --version`)
+- Vigil version (`Help` tab footer, or release version)
 - Operating system and version
 - Whether you are running as Administrator / root
 - Steps to reproduce
 - What you expected vs what actually happened
-- Relevant lines from the log file (`<exe-dir>/logs/`)
+- Relevant lines from the log file
 
-For security vulnerabilities, please **do not** open a public issue.
-Email the maintainer directly instead.
+For security vulnerabilities, please **do not** open a public issue. Email the
+maintainer directly instead.
 
 ---
 
 ## Requesting features
 
 Use the [Feature Request](.github/ISSUE_TEMPLATE/feature_request.md) issue
-template.  Before opening one, check the [ROADMAP](ROADMAP.md) — the feature
-may already be planned.
+template. Before opening one, check the [ROADMAP](ROADMAP.md) — the feature may
+already be planned.
 
 ---
 
 ## Development setup
 
+Vigil's active support targets are Windows and Linux. See
+[`docs/SUPPORTED-PLATFORMS.md`](docs/SUPPORTED-PLATFORMS.md) before adding
+platform-specific work.
+
 **Prerequisites**
 
 | Tool | Minimum version | Notes |
 |------|----------------|-------|
-| Rust (stable) | 1.75 | Install via [rustup](https://rustup.rs) |
+| Rust stable | 1.75 | Install via [rustup](https://rustup.rs) |
 | just | any | Optional but recommended — `cargo install just` |
 | Git | any | |
 
-**Windows extras** (needed to embed the `.ico` resource):
+**Windows extras** needed to embed the `.ico` resource:
 
-- Windows SDK (`rc.exe`) — installed with Visual Studio, or
-- `llvm-rc` — included with LLVM
+- Windows SDK (`rc.exe`) installed with Visual Studio, or
+- `llvm-rc` included with LLVM
 
-**Linux extras** (needed for the egui/eframe backend and eBPF support):
+**Linux extras** needed for the egui/eframe backend and eBPF support:
 
 ```sh
 sudo apt-get install libgtk-3-dev libxdo-dev libayatana-appindicator3-dev
 ```
 
 For eBPF real-time monitoring, the binary needs Linux capabilities:
+
 ```sh
 sudo setcap cap_bpf,cap_net_admin,cap_perfmon,cap_dac_read_search,cap_dac_override+ep target/release/vigil
 ```
+
 Without these capabilities, Vigil falls back to `/proc/net/tcp` polling.
 
 **Clone and build**
@@ -83,56 +89,48 @@ Without these capabilities, Vigil falls back to `/proc/net/tcp` polling.
 ```sh
 git clone https://github.com/YMRYMR/vigil.git
 cd vigil
-cargo build                # debug
-cargo build --release      # optimised
-cargo test                 # run all tests
+cargo build
+cargo build --release
+cargo test
 ```
 
 Or with `just`:
 
 ```sh
-just ci    # fmt-check + lint + test (same checks as CI)
+just ci
 ```
 
 ---
 
 ## Pull request process
 
-1. **Open an issue first** for non-trivial changes so the approach can be
-   agreed before you invest significant time writing code.
+1. **Open an issue first** for non-trivial changes so the approach can be agreed before you invest significant time writing code.
 2. Fork the repository and create a branch:
    ```sh
    git checkout -b feature/my-new-detection-rule
    ```
-3. Make your changes.  Every PR must:
+3. Make your changes. Every PR must:
    - Pass `cargo fmt --check`
    - Pass `cargo clippy -- -D warnings`
    - Pass `cargo test`
-   - Build cleanly on all three platforms (Windows, macOS, Linux) — the CI
-     matrix will verify this automatically.
-4. Write or update tests for any changed logic.  Scoring rules in
-   `src/score.rs` **must** have unit tests.
+   - Build cleanly on Windows and Linux.
+4. Write or update tests for any changed logic. Scoring rules in `src/score.rs` **must** have unit tests.
 5. Update `ROADMAP.md` if you complete a backlog item.
-6. Open the PR against `main` and fill in the PR template.
+6. Open the PR against `master` and fill in the PR template.
 7. A maintainer will review and either merge or request changes.
 
 ---
 
 ## Coding style
 
-- **Format:** `cargo fmt` (default Rust style — no custom config).
-- **Lints:** `cargo clippy -- -D warnings`.  All warnings are errors in CI.
-- **Unsafe:** avoid unless absolutely necessary.  All `unsafe` blocks must
-  have a safety comment explaining the invariant.
-- **Platform-specific code:** gate with `#[cfg(windows)]` / `#[cfg(not(windows))]`.
-  Every feature must have a meaningful fallback on non-Windows platforms.
-- **No `println!` / `eprintln!`** in non-test code — use `tracing::info!`,
-  `tracing::warn!`, or `tracing::error!` instead.
-- **Error handling:** prefer `?` propagation and `tracing::warn!` for
-  non-fatal errors over `unwrap()` / `expect()` in hot paths.
-- **UI code:** follow the existing egui 0.34 patterns (`ui.interact()` before
-  child widgets for reliable click detection; `Frame::NONE`, `Panel::top/right`,
-  `exact_size`).
+- **Format:** `cargo fmt`.
+- **Lints:** `cargo clippy -- -D warnings`.
+- **Unsafe:** avoid unless absolutely necessary. All `unsafe` blocks must have a safety comment explaining the invariant.
+- **Platform-specific code:** define Windows and Linux behavior explicitly. Use `#[cfg(windows)]`, `#[cfg(target_os = "linux")]`, or clear unsupported fallbacks where needed.
+- **Startup safety:** supported-platform startup paths must fail open. A Vigil bug, hang, network failure, advisory-cache failure, package-inventory failure, or service-mode error must not repeatedly prevent the machine from reaching a usable login/session state.
+- **No `println!` / `eprintln!`** in non-test library code — use `tracing::info!`, `tracing::warn!`, or `tracing::error!` instead.
+- **Error handling:** prefer `?` propagation and `tracing::warn!` for non-fatal errors over `unwrap()` / `expect()` in hot paths.
+- **UI code:** follow the existing egui 0.34 patterns.
 
 ---
 
@@ -153,9 +151,9 @@ cargo test
 
 ## Fuzzing
 
-Vigil keeps a small continuous fuzzing setup for parser-style code paths.
-The current fuzz target exercises the TLS ClientHello parser used by the
-monitoring stack.
+Vigil keeps a small continuous fuzzing setup for parser-style code paths. The
+current fuzz target exercises the TLS ClientHello parser used by the monitoring
+stack.
 
 To run it locally:
 
@@ -164,41 +162,24 @@ cd fuzz
 cargo fuzz run parse_client_hello
 ```
 
-Pull requests are fuzzed in CI through ClusterFuzzLite.
-
 ---
 
 ## Platform notes
 
 ### Windows
 
-- Real-time monitoring uses ETW (Event Tracing for Windows) and requires
-  Administrator rights.  The fallback polling path always works.
-- The `windows` crate features used are listed in `Cargo.toml` —
-  add new features there if you need additional Win32 APIs.
-
-### macOS
-
-- Monitoring uses the polling path (no ETW equivalent on macOS).
-- Tray icon and notifications use platform-native APIs via `tray-icon` and
-  `notify-rust`.
+- Real-time monitoring uses ETW and requires Administrator rights. The fallback polling path always works.
+- The `windows` crate features used are listed in `Cargo.toml`; add new features there if you need additional Win32 APIs.
+- Boot-time monitoring uses a scheduled task and must fail open if startup is unsafe.
 
 ### Linux
 
-- eBPF real-time monitoring via aya 0.13 (`sock:inet_sock_set_state`
-  tracepoint) — requires `CAP_BPF`, `CAP_NET_ADMIN`, `CAP_PERFMON`,
-  `CAP_DAC_READ_SEARCH`, and `CAP_DAC_OVERRIDE`; falls back to
-  `/proc/net/tcp` polling if unavailable.
-- Active response: network isolation via iptables, TCP kill via `ss -K`,
-  process suspend/resume via SIGSTOP/SIGCONT, IP blocking via iptables
-  comment rules, domain blocking via `/etc/hosts`. All gated on
-  `CAP_NET_ADMIN` (checked from `/proc/self/status`) or root.
-- System tray via libappindicator (GNOME AppIndicator); uses themed icon
-  names — install PNG icons at
-  `~/.local/share/icons/hicolor/32x32/apps/`.
-- GTK3 and libayatana-appindicator are required at link time (see setup
-  above).
+- eBPF real-time monitoring via aya (`sock:inet_sock_set_state` tracepoint) requires `CAP_BPF`, `CAP_NET_ADMIN`, `CAP_PERFMON`, `CAP_DAC_READ_SEARCH`, and `CAP_DAC_OVERRIDE`; it falls back to `/proc/net/tcp` polling if unavailable.
+- Active response: network isolation via iptables, TCP kill via `ss -K`, process suspend/resume via SIGSTOP/SIGCONT, IP blocking via iptables comment rules, and domain blocking via `/etc/hosts`. Actions are gated on `CAP_NET_ADMIN` or root where needed.
+- Boot-time monitoring uses a systemd unit and must fail open if startup is unsafe.
+- System tray uses libappindicator on supported desktop environments.
+- GTK3 and libayatana-appindicator are required at link time.
 
 ---
 
-*Vigil is built with care.  Thank you for helping make it better.*
+*Vigil is built with care. Thank you for helping make it better.*

--- a/README.md
+++ b/README.md
@@ -3,38 +3,25 @@
 [![CI](https://github.com/YMRYMR/vigil/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/YMRYMR/vigil/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/YMRYMR/vigil/actions/workflows/codeql.yml/badge.svg?branch=master&event=push)](https://github.com/YMRYMR/vigil/actions/workflows/codeql.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/YMRYMR/vigil/badge)](https://securityscorecards.dev/viewer/?uri=github.com/YMRYMR/vigil)
-[![Snyk](https://github.com/YMRYMR/vigil/actions/workflows/snyk-open-source.yml/badge.svg?branch=master&event=push)](https://github.com/YMRYMR/vigil/actions/workflows/snyk-open-source.yml)
-[![Dependency Review](https://github.com/YMRYMR/vigil/actions/workflows/dependency-review.yml/badge.svg?event=pull_request)](https://github.com/YMRYMR/vigil/actions/workflows/dependency-review.yml)
-[![Artifact hygiene](https://github.com/YMRYMR/vigil/actions/workflows/artifact-hygiene.yml/badge.svg?branch=master)](https://github.com/YMRYMR/vigil/actions/workflows/artifact-hygiene.yml)
-[![Secret scan](https://github.com/YMRYMR/vigil/actions/workflows/secret-scan.yml/badge.svg?branch=master)](https://github.com/YMRYMR/vigil/actions/workflows/secret-scan.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/YMRYMR/vigil?label=release)](https://github.com/YMRYMR/vigil/releases/latest)
 
-Cross-platform endpoint defense for Windows, macOS, and Linux.
+Endpoint defense for **Windows and Linux**.
 
-Vigil watches live network and process activity on your machine, scores suspicious
-behaviour, shows you the process and connection context behind each alert, and
-can take reversible containment actions when something needs to be stopped.
+Vigil watches live network and process activity, scores suspicious behaviour,
+shows the process and connection context behind each alert, and can take
+reversible containment actions when something needs to be stopped.
 
-It is designed for local machine protection first: detect suspicious outbound
-activity quickly, help the operator understand what is happening, preserve
-evidence when needed, and contain the machine or process without turning every
-high-noise event into a destructive action.
-
-Vigil also treats public vulnerability and advisory matches conservatively. A
-match means Vigil found a plausible link between software on the machine and a
-public CVE or advisory record from its local source cache; it does not mean
-exploitation happened or that the machine is confirmed compromised. Treat a
-match as operator decision support alongside process context, exposure, and
-vendor remediation guidance.
-
-![Vigil current UI](docs/images/vigil-current.png)
+The active support scope is Windows and Linux only. See
+[`docs/SUPPORTED-PLATFORMS.md`](docs/SUPPORTED-PLATFORMS.md) for the support
+contract and startup-safety rule.
 
 ---
 
 ## Documentation
 
-- [User guide](docs/USER-GUIDE.md) — released functionality, operator workflows, and day-to-day use
+- [User guide](docs/USER-GUIDE.md) — released functionality and operator workflows
+- [Supported platforms](docs/SUPPORTED-PLATFORMS.md) — Windows/Linux support contract
 - [Security policy](SECURITY.md) — vulnerability reporting and security contacts
 - [OpenSSF Best Practices controls](docs/OPENSSF-BEST-PRACTICES.md) — repository controls and maintainer settings
 - [Codebase inventory](docs/CODEBASES.md) — repositories that are part of Vigil
@@ -45,19 +32,15 @@ vendor remediation guidance.
 ## Download the latest build
 
 - [Windows installer](https://github.com/YMRYMR/vigil/releases/latest/download/Vigil-latest-windows-x86_64.exe)
-- [macOS DMG](https://github.com/YMRYMR/vigil/releases/latest/download/Vigil-latest-macos-aarch64.dmg)
 - [Linux AppImage](https://github.com/YMRYMR/vigil/releases/latest/download/Vigil-latest-linux-x86_64.AppImage)
-- [All supported OSs bundle](https://github.com/YMRYMR/vigil/releases/latest/download/Vigil-latest-all-supported-os.zip)
 - [Signed update manifest](https://github.com/YMRYMR/vigil/releases/latest/download/Vigil-latest-update-manifest.json)
 - [Manifest signature](https://github.com/YMRYMR/vigil/releases/latest/download/Vigil-latest-update-manifest.json.sig)
 - GHCR Linux package image: `ghcr.io/YMRYMR/vigil`
 
-The latest-release links above are refreshed by the release pipeline after a
-merged `master` change finishes CI and the tag-driven publishing workflow
-completes.
+The latest-release links are refreshed by the release pipeline after a merged
+`master` change finishes CI and the tag-driven publishing workflow completes.
 
-The GHCR image tracks the latest released Linux AppImage as a container package
-so it is easy to mirror, automate, or consume in CI environments:
+The GHCR image tracks the latest released Linux AppImage as a container package:
 
 ```bash
 docker pull ghcr.io/YMRYMR/vigil:latest
@@ -70,446 +53,189 @@ downloaded file with:
 gh attestation verify PATH/TO/FILE -R YMRYMR/vigil
 ```
 
-The release workflow also emits SLSA3 provenance for the published assets via
-the GitHub Actions SLSA generator. That provenance is attached to the release
-for users who prefer `slsa-verifier`-style supply-chain checks.
-
-Merged pull requests to `master` now cut the next patch release automatically
-after the `CI` workflow succeeds. That automated version bump creates the tag
-that feeds the existing signed release pipeline, so `releases/latest` and the
-signed update manifest stay in sync with merged code.
-
 The signed update manifest is the trust anchor for Vigil's update channel. It
-lists the release assets and their SHA-256 digests, then gets signed with an
-embedded Ed25519 public key in the app. You can verify it offline with:
+lists release assets and SHA-256 digests, then gets signed with the embedded
+Ed25519 public key. Verify it offline with:
 
 ```bash
 vigil --verify-update-manifest Vigil-latest-update-manifest.json Vigil-latest-update-manifest.json.sig
 ```
 
-Vigil's offline advisory importer also accepts one or more local NVD CVE JSON
-files in a single run, which is useful when the export is split into pages or
-incremental batches:
+---
+
+## What Vigil does
+
+### Detect and surface suspicious activity
+
+- **Sub-100 ms detection** on Windows via ETW and on Linux via eBPF when available.
+- **Polling fallback** when the realtime backend is unavailable.
+- **Multi-signal threat scoring** across behaviour, reputation, persistence, and execution context.
+- **Passive persistence and timing signals** such as registry autoruns, beaconing, pre-login activity, long-lived connections, and DGA-like hostnames.
+- **Offline enrichment** with local blocklists, geolocation, ASN data, reverse DNS, and file-drop correlation.
+
+### Help investigate what is happening
+
+- **Full ancestor process tree** up to 8 levels deep.
+- **Process-first GUI** with Activity, Alerts, Settings, Help, and a detailed Inspector.
+- **Clickable notifications and tray workflow** for fast triage.
+- **Boot-time service mode** for monitoring before login on supported platforms.
+
+### Protect and contain the machine
+
+- **Active response** on Windows and Linux: kill a live TCP connection, suspend/resume a process, block a remote IP, block a process by executable path, or isolate the machine.
+- **Containment safety rails**: confirmation prompts, countdowns for temporary blocks, inline unblock controls, and break-glass recovery.
+- **Policy-driven automation**: user-defined response rules, scheduled lockdown, allowlist-only mode, and threshold escalation.
+
+### Preserve trust, evidence, and operator control
+
+- **Forensic capture on high-confidence alerts** where supported, including PCAP, process dump, TLS sidecar metadata, and provenance manifests.
+- **Tamper-evident local state** for policy, generated state, audit logs, and update manifests.
+- **Daily rolling logs and audit trail** for alerts, actions, integrity events, and other security-relevant changes.
+- **Privilege-aware UX** that shows when deeper visibility or containment requires elevation.
+
+---
+
+## Public advisory and vulnerability intelligence
+
+Vigil treats public vulnerability and advisory matches conservatively. A match
+means Vigil found a plausible link between local software and a public CVE or
+advisory record from its local source cache; it does not prove exploitation or
+compromise.
+
+Offline import examples:
 
 ```bash
 vigil --import-nvd-snapshot nvdcve-page-1.json nvdcve-page-2.json
-```
-
-Vigil can also pull the live NVD CVE API directly into the same protected
-cache. The sync path uses incremental `lastModStartDate` / `lastModEndDate`
-windows after the first fetch, respects the NVD's 2-hour automated polling
-guidance, and keeps the last trusted cache if refresh fails:
-
-```bash
-vigil --sync-nvd
-```
-
-Vigil can also maintain a separate protected cache of the public NVD CVE
-change-history feed so operators can audit re-analysis and upstream metadata
-changes over time:
-
-```bash
-vigil --sync-nvd-change-history
-vigil --advisory-change-history-status
-```
-
-For offline or batched imports, pass one or more local NVD CVE change-history
-JSON snapshots:
-
-```bash
-vigil --import-nvd-change-history nvdcvehistory-page-1.json nvdcvehistory-page-2.json
-```
-
-When Vigil is using the live NVD API, `vigil --advisory-cache-status` now shows
-the required notice: "This product uses the NVD API but is not endorsed or
-certified by the NVD."
-
-Use `--sync-nvd --force` only when you need to override the normal 2-hour
-minimum interval. Provide an API key via `VIGIL_NVD_API_KEY` if your deployment
-needs higher NVD API headroom.
-
-Phase 16 also includes offline foundations for additional public advisory
-sources. Operators can import one or more local EUVD JSON snapshots into the
-same protected advisory cache with:
-
-```bash
+vigil --import-nvd-change-history nvdcvehistory-page-1.json
 vigil --import-euvd euvd-export.json
-```
-
-JVN / JVN iPedia snapshots support either JSON exports or JVNDBRSS XML items,
-including batched imports when a feed is mirrored into multiple files:
-
-```bash
 vigil --import-jvn jvn-export.json jvndbrss.xml
-```
-
-Those EUVD and JVN import paths preserve source-specific identifiers,
-references, mitigation guidance, and provenance in the protected advisory cache.
-They are intentionally operator-supplied/offline foundations for now; live
-scheduled fetching remains future work until the upstream feed contracts are
-pinned down conservatively.
-
-Vigil also supports public NCSC and BSI/CERT-Bund imports from RSS snapshots or
-mirrored JSON exports:
-
-```bash
 vigil --import-ncsc ncsc-feed.xml ncsc-mirror.json
 vigil --import-bsi certbund-feed.xml bsi-advisories.json
 ```
 
-Those NCSC and BSI/CERT-Bund imports preserve source-specific identifiers, CVE
-aliases, source links, timestamps, severity hints, and provenance in the same
-protected advisory cache. Like EUVD and JVN, they are intentionally
-operator-supplied/offline foundations for now while Vigil keeps live refresh
-work conservative and source-contract aware.
+Live NVD sync:
 
----
+```bash
+vigil --sync-nvd
+vigil --sync-nvd-change-history
+vigil --advisory-cache-status
+vigil --advisory-change-history-status
+```
 
-## What Vigil Does
+Use `--sync-nvd --force` only when you need to override the normal 2-hour
+minimum interval. Provide an API key via `VIGIL_NVD_API_KEY` if the deployment
+needs higher NVD API headroom.
 
-### Detect and surface suspicious activity
+The standalone inventory helper can inspect local Windows/Linux software
+metadata without touching Vigil's startup path:
 
-- **Sub-100 ms detection** on Windows via ETW (Event Tracing for Windows);
-  on Linux via eBPF (`sock:inet_sock_set_state` tracepoint); DTrace-assisted
-  fallback on macOS when available; polling fallback on older kernels and other
-  degraded paths
-- **Visible backend status** — the header now makes it clear whether Vigil is
-  running on ETW, eBPF, DTrace-assisted fallback, or a polling fallback, and
-  current macOS builds show an explicit native-backend fallback notice instead
-  of implying full Endpoint Security coverage
-- **Multi-signal threat scoring** across behavioural, reputation, persistence,
-  and execution-context signals so alerts stay explainable instead of opaque
-- **Passive persistence and timing signals** including registry autoruns,
-  beaconing behaviour, pre-login activity, long-lived connections, and DGA-like
-  hostnames
-- **Offline enrichment** with local blocklists, geolocation, ASN data, reverse
-  DNS, and file-drop correlation
-
-### Help investigate what is happening
-- **Full ancestor process tree** — see exactly which process spawned which,
-  up to 8 levels deep
-- **Process-first GUI** — Activity and Alerts views are grouped around the local
-  process, with a detailed Inspector for path, parent, publisher, user, remote
-  endpoint, score reasons, badges, and enrichment context
-- **Clickable notifications and tray workflow** — alerts can take you straight
-  into the relevant connection from the desktop or tray icon
-- **Boot-time service mode** — monitor before login so early persistence and
-  pre-user activity are still visible when the operator signs in
-
-### Protect and contain the machine
-
-- **Active response** — reversible actions (Windows + Linux) for killing a live
-  TCP connection, suspending or resuming a process during investigation,
-  blocking a remote IP for 1 hour, 24 hours, or permanently, blocking a
-  process by executable path, or isolating the machine
-- **Containment safety rails** — confirmation prompts for destructive actions,
-  live countdowns for temporary blocks, inline unblock controls, and break-glass
-  recovery for isolation
-- **Policy-driven automation** — user-defined response rules, scheduled
-  lockdown, allowlist-only mode, and threshold-based escalation planning
-
-### Preserve trust, evidence, and operator control
-
-- **Forensic capture on high-confidence alerts (Windows today)** — short PCAP
-  capture, process memory dump, TLS sidecar metadata, and provenance manifests
-- **Tamper-evident local state** — protected policy store, integrity-backed
-  generated state, audit-log chaining, and signed update manifests
-- **Daily rolling logs and audit trail** — operator-visible records for alerts,
-  actions, integrity events, and other security-relevant state changes
-- **Privilege-aware UX** — Vigil makes clear when elevated permissions are
-  required for deeper visibility or containment
-
----
-
-## How the score works
-
-Each new connection is scored independently across seventeen signals. Points
-stack — a PowerShell process spawned by Word, connecting to port 4444, can
-score 3 + 3 + 4 + 5 = 15. The alert threshold is configurable (default: 3).
-
-| Points | Signal |
-|--------|--------|
-| +5 | Connection to a known malware / C2 port (4444, 1337, 31337, …) |
-| +4 | Living-off-the-land binary making a network connection (`powershell`, `cmd`, `mshta`, …) |
-| +3 | No executable path found — possible process injection or hollowing |
-| +3 | Running from a suspicious directory (`\Temp\`, `\AppData\Roaming\`, …) |
-| +3 | Suspicious parent process (e.g. `winword.exe` spawning `powershell.exe`) |
-| +3 | Beaconing pattern detected — regular C2 callback timing signature |
-| +3 | IP reputation hit — remote matched a user-supplied blocklist (**Phase 10**, REP badge) |
-| +3 | Executable was just dropped into Temp/AppData/Downloads before connecting (**Phase 10**, DRP badge) |
-| +2 | Unrecognised process (not on your trusted list) |
-| +2 | Unsigned binary — no code-signing certificate |
-| +2 | DNS query (port 53) from a non-DNS process — possible DNS tunneling |
-| +2 | Connection observed **before user login** — rootkit / dropper signal (PL badge) |
-| +2 | Connection to an unexpected country (**Phase 10**, requires `allowed_countries`) |
-| +2 | Long-lived connection from untrusted process past threshold (**Phase 10**, LL badge) |
-| +2 | Hostname looks DGA-generated — high Shannon entropy (**Phase 10**, DGA badge) |
-| +1 | Unusual destination port for an untrusted process |
-
-Trusted processes skip the **+2 unrecognised** and **+2 unsigned** penalties,
-so routine connections from browsers and system services score 0. High-severity
-signals (malware ports, LoLBins, pre-login activity) still apply — if a trusted
-app suddenly dials a C2 port, you want to know.
-
-Vigil also runs two passive persistence watchers that raise synthetic alerts
-(independent of active connections):
-
-- **Registry autorun watcher** (Windows) — polls `HKCU\…\Run`, `HKLM\…\Run`,
-  and both `RunOnce` keys every 30 s; alerts on any new entry.
-- **Beaconing detector** — tracks inter-arrival time per `(pid, remote_ip)`
-  across a rolling 30-sample window; flags stddev < 5 s / mean 1 – 600 s.
+```bash
+vigil_inventory
+```
 
 ---
 
 ## Installation
 
-### Windows — one-click installer
+### Windows
 
-1. Download `Vigil-Setup-<version>-x86_64.exe` from the [latest release].
-2. Run the installer — by default it installs for the current user, creates a
-   Start Menu shortcut, and enables Vigil to start when you log in.
-3. If you want monitoring to begin before login, choose an all-users install
-   during setup. On Windows, the elevated installer now registers the boot-time
-   monitor service automatically for that install mode.
+1. Download the Windows installer from the latest release.
+2. Run the installer. By default it installs for the current user, creates a Start Menu shortcut, and enables Vigil at login.
+3. For before-login monitoring, choose an all-users install or run the service install command from an elevated shell.
 
-> **Note:** ETW-based real-time monitoring requires Administrator rights.
-> Without elevation, Vigil falls back to polling every few seconds — all
-> other features work normally.
+> ETW-backed realtime monitoring requires Administrator rights. Without elevation, Vigil falls back to polling.
 
-### macOS — DMG
+### Linux
 
-1. Download `Vigil-<version>-aarch64.dmg` from the [latest release].
-2. Open the DMG and drag **Vigil.app** to your Applications folder.
-3. Launch Vigil — it will ask for network monitoring permission on first run.
+1. Download the Linux AppImage from the latest release.
+2. Make it executable:
 
-### Linux — AppImage
+```bash
+chmod +x Vigil-*.AppImage
+```
 
-1. Download `Vigil-<version>-x86_64.AppImage` from the [latest release].
-2. Make it executable: `chmod +x Vigil-*.AppImage`
-3. Double-click to run, or launch from the terminal.
+3. Launch it from the desktop or terminal.
+
+Linux active response requires root or the required Linux capabilities, depending on the action.
 
 ---
 
 ## Building from source
 
-**Prerequisites:** [Rust stable](https://rustup.rs) 1.75+
+Prerequisite: Rust stable 1.75+.
 
-```sh
+```bash
 git clone https://github.com/YMRYMR/vigil.git
 cd vigil
 cargo build --release
 ```
 
-The binary is written to `target/release/vigil` (or `vigil.exe` on Windows).
+The binary is written to `target/release/vigil` or `target/release/vigil.exe`.
 
-### Using `just`
+Using `just`:
 
-Install [just](https://just.systems) then:
-
-```sh
-just build      # debug build
-just release    # optimised release build
-just test       # run the test suite
-just lint       # clippy -D warnings
-just install    # copy release binary to the system (platform-specific)
-just ci         # fmt-check + lint + test (mirrors CI)
+```bash
+just build
+just release
+just test
+just lint
+just install
+just ci
 ```
 
 ### Windows icon embedding
 
-`build.rs` generates a multi-size `.ico` file and embeds it via
-[`winres`](https://crates.io/crates/winres). This requires the Windows SDK
-(`rc.exe`) or [`llvm-rc`](https://llvm.org/docs/CommandGuide/llvm-rc.html).
-If neither is present the build still succeeds — it just won't have the
-custom icon in the taskbar.
+`build.rs` generates a multi-size `.ico` file and embeds it via `winres`. This
+requires the Windows SDK `rc.exe` or `llvm-rc`. If neither is present, the build
+still succeeds without the custom taskbar icon.
 
 ---
 
 ## Configuration
 
-Settings are stored in `vigil.json` in the per-user Vigil data directory and are fully
-editable in-app via the **Settings** tab:
+Settings are stored in `vigil.json` in the per-user Vigil data directory and are
+editable in-app through Settings.
+
+Common settings include:
 
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `alert_threshold` | 3 | Minimum score to trigger an alert |
 | `poll_interval_secs` | 5 | Seconds between full connection polls |
 | `log_all_connections` | false | Log every connection, not just suspicious ones |
-| `autostart` | true | Launch Vigil at login; elevated Windows runs use a highest-privilege scheduled task |
-| `trusted_processes` | *(see below)* | Process names exempt from low-level scoring |
+| `autostart` | true | Launch Vigil at login |
+| `trusted_processes` | shipped defaults | Process names exempt from low-level scoring |
 
-### Default trusted processes
+---
 
-Vigil ships with a curated list of common trusted processes (browsers,
-Windows system services, antivirus, communication apps, etc.) so you get
-useful alerts out of the box without tuning. On first run that list is
-written into `vigil.json` in the per-user Vigil data directory as the
-starting config, and any later edits you make in-app persist immediately.
-You can add or remove entries in the
-**Settings → Trusted Processes** grid, or click **Trust** in the Inspector
-panel while a real process with a known executable location is selected.
-The Settings tab also includes a `Reset shipped defaults` button if you want
-to restore the bundled list.
+## Running before login
 
-The Inspector disables `Trust` and `Open Loc` when the executable location is
-unknown, and disables `Kill` for unresolved PID placeholder rows like
-`<11540>`.
+Vigil can install a boot-time monitor so monitoring starts before any user logs
+in. This is useful for detecting early persistence and pre-user activity.
 
-### Active response
+| OS | Install | Remove |
+|---|---|---|
+| Windows | `vigil.exe --install-service` | `vigil.exe --uninstall-service` |
+| Linux | `sudo vigil --install-service` | `sudo vigil --uninstall-service` |
 
-The top bar also reflects privilege state: it shows an `Admin` badge when
-Vigil is elevated. On Windows and Linux, the app can also offer an in-app
-elevation action when that relaunch path is supported. Current macOS builds
-require starting Vigil from an elevated shell for privileged features.
+Under the hood:
 
-When Vigil is running with elevated privileges (admin on Windows,
-`CAP_NET_ADMIN` or root on Linux), the Inspector can take reversible action:
+- Windows uses Task Scheduler with an `ONSTART` task that runs Vigil as `SYSTEM`.
+- Linux writes a systemd unit at `/etc/systemd/system/vigil.service` and enables it with `systemctl enable --now vigil.service`.
 
-- **Kill connection** immediately tears down the selected live TCP socket.
-- **Suspend process** freezes the selected PID without killing it; **Resume process** continues it later.
-- **Block remote** lets you choose a 1 hour, 24 hour, or permanent outbound
-  firewall rule for the selected connection's remote IP. Temporary blocks show
-  a live countdown and an inline unblock button.
-- **Block process** lets you choose a 1 hour, 24 hour, or permanent firewall
-  rule for all traffic from the selected executable path. Temporary blocks
-  show a live countdown and an inline unblock button.
-- **Isolate network** (Windows, Linux, macOS) now uses strict containment:
-  it first applies firewall-level isolation (iptables on Linux) and verifies outbound reachability.
-  If outbound traffic is still possible, Vigil falls back to emergency adapter
-  cutoff and keeps snapshot state for restore.
-- **Restore network** restores the saved firewall and adapter state.
-- **Isolation failsafe**: isolation always carries an auto-restore deadline,
-  and Vigil always arms break-glass recovery while isolation is active so a
-  crash can restore networking from saved state.
-- Isolation/restore run immediately from the panic button; confirmation remains
-  for destructive process/connection actions.
+Startup safety rule: Vigil must fail open. A Vigil bug, hang, network failure,
+advisory-cache failure, package-inventory failure, or service-mode error must
+not repeatedly prevent the machine from reaching a usable login/session state.
 
 ---
 
 ## Logs
 
-Log files land in `<exe-dir>/logs/` and rotate daily:
+Log files land in the Vigil data directory and rotate daily. Open the log folder
+from the tray icon context menu with **Open Logs Folder**.
 
-```
-vigil.2025-07-04
-vigil.2025-07-05
-```
-
-Each line follows the format:
-
-```
-2025-07-04 14:23:01.412  INFO chrome.exe (1234) | 192.168.1.5:54321 → 142.250.80.46:443 | score=0
-2025-07-04 14:23:05.119  WARN powershell.exe (9012) | 10.0.0.2:61000 → 10.10.10.10:4444 | score=9
-```
-
-Open the log folder via the tray icon context menu → **Open Logs Folder**.
-The folder is inside the per-user Vigil data directory.
-
----
-
-## Running before login (all platforms)
-
-Vigil can install itself as a boot-time service so monitoring starts
-**before any user logs in** — useful for detecting rogue processes that
-activate early in the boot sequence (rootkits, dropper callbacks,
-persistence mechanisms).
-
-Connections captured before login get a **+2 score bump** and a red
-**`PL`** badge in the Time column, so when the first user logs in they
-immediately see everything the monitor caught during boot.
-
-On Windows, the all-users installer path now registers this boot-time monitor
-service automatically. You can still install or repair it manually from an
-elevated shell:
-
-| OS      | Command                                          |
-| ------- | ------------------------------------------------ |
-| Windows | `vigil.exe --install-service`   *(Admin CMD)*    |
-| macOS   | `sudo vigil --install-service`                   |
-| Linux   | `sudo vigil --install-service`                   |
-
-To remove the boot-time service, replace with `--uninstall-service`.
-
-Under the hood:
-
-- Windows uses Task Scheduler with an `ONSTART` task that runs Vigil as `SYSTEM`.
-- macOS writes a launchd system daemon at
-  `/Library/LaunchDaemons/com.vigil.monitor.plist` and `launchctl load`s it.
-- Linux writes a systemd unit at `/etc/systemd/system/vigil.service` and
-  enables it with `systemctl enable --now vigil.service`.
-
-Note: service mode runs the **monitor only** — the tray icon and GUI
-require a logged-in desktop session and launch normally via autostart.
-
----
-
-## Reputation, geolocation & file-drop correlation (Phase 10)
-
-Vigil layers offline reputation data on top of its behavioural scoring.
-All of it is off by default; point the config at your data to enable it.
-
-### Add geolocation and ASN lookup
-
-Download the free MaxMind GeoLite2-City and GeoLite2-ASN `.mmdb` files
-from https://www.maxmind.com/en/geolite2/signup and drop them anywhere
-on disk. Then edit the `vigil.json` file in the per-user Vigil data directory:
-
-```json
-{
-  "geoip_city_db": "C:\\vigil\\GeoLite2-City.mmdb",
-  "geoip_asn_db":  "C:\\vigil\\GeoLite2-ASN.mmdb",
-  "allowed_countries": ["US", "GB", "ES"]
-}
-```
-
-With the City DB, every row in Activity and Alerts gets a country code
-in the Remote column. With the ASN DB, the Inspector shows the remote's
-ASN number and AS organisation (e.g. `AS15169  Google LLC`). With
-`allowed_countries` set, connections to anywhere else score **+2**.
-
-### Add IP blocklists
-
-Drop plain-text blocklists anywhere and list them:
-
-```json
-{
-  "blocklist_paths": [
-    "C:\\vigil\\abuseipdb.txt",
-    "C:\\vigil\\firehol-level1.txt"
-  ]
-}
-```
-
-Format: one IP or CIDR per line, `#` starts a comment. Each blocklist file
-must have a matching `<filename>.sha256` sidecar in standard `sha256sum`
-format or Vigil will refuse to load it. Hits add **+3** and the Alerts row
-gets a red `REP` badge naming the source list.
-
-### File-drop correlation
-
-Enabled by default. Vigil watches `%TEMP%`, `%LOCALAPPDATA%\\Temp`,
-`%APPDATA%`, `Downloads`, and (on Unix) `/tmp` and `/var/tmp` for new
-`.exe` / `.dll` / `.ps1` / `.scr` / `.msi` / `.sh` / `.py` drops. When a
-connection originates from a file that was dropped within the last
-`fswatch_window_secs` seconds (default 600), Vigil adds **+3** and shows
-a `DRP` badge. This catches staged-payload chains
-(phish → macro → dropper → callback) in flagrante.
-
-### Long-lived connection bonus
-
-Untrusted processes that hold a connection open past `long_lived_secs`
-(default 3600 s = 1 h) earn **+2** and an `LL` badge. Browsers and other
-trusted processes are exempt.
-
-### DGA hostname detection
-
-Off by default because reverse-DNS queries leak the fact Vigil is
-watching to the OS resolver. Turn it on with `"reverse_dns_enabled":
-true` in the config. Hostnames whose leftmost label has Shannon entropy
-≥ `dga_entropy_threshold` (default 3.2 bits/char) earn **+2** and a
-`DGA` badge. Brand names like `google.com` or `paypal.com` score well
-below the threshold; machine-generated strings like `xj4k8s9qzr.com`
-trip it.
+Audit events include active response actions, integrity scan summaries,
+uninstall attempts, and other security-relevant state changes.
 
 ---
 

--- a/docs/SUPPORTED-PLATFORMS.md
+++ b/docs/SUPPORTED-PLATFORMS.md
@@ -2,7 +2,7 @@
 
 Vigil's active product scope is **Windows and Linux only**.
 
-This document is the project-level support contract for new development. When roadmap text, older docs, or legacy code mention macOS, treat that macOS material as historical or deprecated unless a later support-policy change explicitly re-adds it.
+This document is the project-level support contract for new development. When roadmap text, older docs, generated artifacts, installer leftovers, or legacy code mention other platforms, treat that material as historical until it is removed.
 
 ## Tier 1: Windows
 
@@ -28,17 +28,17 @@ Current Linux-specific priorities:
 - Reversible active-response actions through Linux-native controls.
 - Clear privilege UX around root and Linux capabilities.
 
-## Deprecated: macOS
+## Out of active scope
 
-macOS is not an active support target right now.
+Only Windows and Linux are active support targets.
 
 Practical consequences:
 
-- Do not add new macOS-only features.
-- Do not spend roadmap effort on macOS parity.
-- Do not expand macOS packaging, launchd, DTrace, Endpoint Security, or Network Extension work.
-- When touching shared code, avoid making macOS behavior worse accidentally, but do not block Windows/Linux work on macOS parity.
-- Existing macOS code can be removed gradually when doing so reduces maintenance burden and does not destabilize Windows/Linux builds.
+- Do not add new features for unsupported platforms.
+- Do not spend roadmap effort on unsupported-platform parity.
+- Do not expand unsupported packaging, service, monitor, or installer work.
+- When touching shared code, avoid making unsupported legacy paths worse accidentally, but do not block Windows/Linux work on parity outside the active scope.
+- Existing unsupported-platform code can be removed gradually when doing so reduces maintenance burden and does not destabilize Windows/Linux builds.
 
 ## Development rule
 

--- a/docs/SUPPORTED-PLATFORMS.md
+++ b/docs/SUPPORTED-PLATFORMS.md
@@ -1,0 +1,54 @@
+# Supported Platforms
+
+Vigil's active product scope is **Windows and Linux only**.
+
+This document is the project-level support contract for new development. When roadmap text, older docs, or legacy code mention macOS, treat that macOS material as historical or deprecated unless a later support-policy change explicitly re-adds it.
+
+## Tier 1: Windows
+
+Windows remains a first-class target for detection, response, service mode, packaging, and operator UX.
+
+Current Windows-specific priorities:
+
+- ETW-backed real-time network visibility.
+- Windows service / scheduled-task boot monitoring with fail-open guardrails.
+- Windows uninstall-registry software inventory.
+- Reversible active-response actions through Windows-native controls.
+- Safe startup behavior: Vigil must never be able to repeatedly block the user from logging in.
+
+## Tier 1: Linux
+
+Linux remains a first-class target for detection, response, service mode, packaging, and operator UX.
+
+Current Linux-specific priorities:
+
+- eBPF-backed real-time network visibility where available, with polling fallback.
+- systemd service mode with fail-open guardrails.
+- Package inventory through dpkg, RPM, and Alpine apk sources.
+- Reversible active-response actions through Linux-native controls.
+- Clear privilege UX around root and Linux capabilities.
+
+## Deprecated: macOS
+
+macOS is not an active support target right now.
+
+Practical consequences:
+
+- Do not add new macOS-only features.
+- Do not spend roadmap effort on macOS parity.
+- Do not expand macOS packaging, launchd, DTrace, Endpoint Security, or Network Extension work.
+- When touching shared code, avoid making macOS behavior worse accidentally, but do not block Windows/Linux work on macOS parity.
+- Existing macOS code can be removed gradually when doing so reduces maintenance burden and does not destabilize Windows/Linux builds.
+
+## Development rule
+
+New functionality should answer two questions before implementation:
+
+1. What is the Windows behavior?
+2. What is the Linux behavior?
+
+If one platform cannot support the feature yet, the code and UI should say so explicitly rather than pretending parity exists.
+
+## Startup safety rule
+
+Across supported platforms, Vigil must fail open at OS startup. A Vigil bug, hang, network failure, advisory-cache failure, package-inventory failure, or service-mode error must not repeatedly prevent the machine from reaching a usable login/session state.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1,6 +1,6 @@
 # Vigil User Guide
 
-This guide covers the basic functionality available in released Vigil builds.
+This guide covers the basic functionality available in released Vigil builds for Windows and Linux.
 
 ## What Vigil is for
 
@@ -11,9 +11,15 @@ It is built to help you:
 - see suspicious network and process activity quickly
 - understand which local process is responsible and why it looks risky
 - contain a process, connection, or machine when you decide the risk is real
-- preserve an audit trail for follow-up investigation and, on Windows today, capture forensic artifacts
+- preserve an audit trail for follow-up investigation and, where supported, capture forensic artifacts
 
 Vigil is intentionally conservative about action. Scores and advisory context are there to help an operator make better decisions, not to pretend every suspicious connection is a confirmed compromise.
+
+## Supported platforms
+
+Vigil's active support targets are Windows and Linux. New feature work should define behavior for both platforms, or clearly state when a feature is platform-limited.
+
+See [Supported platforms](SUPPORTED-PLATFORMS.md) for the support contract and startup safety rule.
 
 ## Install and launch
 
@@ -21,23 +27,16 @@ Vigil is intentionally conservative about action. Scores and advisory context ar
 
 1. Download the Windows installer from the latest GitHub Release.
 2. Run the installer. By default it installs for the current user and enables Vigil to start when you log in.
-3. If you want Vigil to start before login, choose an all-users install during setup. On Windows, that elevated installer path now registers the boot-time monitor service automatically.
-4. Launch Vigil from the Start Menu or the installed shortcut.
+3. If you want Vigil to start before login, choose an all-users install during setup. On Windows, that elevated installer path registers the boot-time monitor service automatically.
+4. Launch Vigil from the Start Menu or installed shortcut.
 5. Use **Run as Admin** in the header when you need ETW visibility or active response actions.
-
-### macOS
-
-1. Download the macOS DMG from the latest GitHub Release.
-2. Drag `Vigil.app` to Applications.
-3. Launch Vigil and approve any operating system prompts that are required for network visibility.
-
-Current macOS builds use a degraded fallback path because the native Endpoint Security backend is not integrated yet. When `dtrace` is available and permitted, Vigil uses DTrace-assisted polling to surface new connections faster; otherwise it falls back to polling-only. Detection remains functional, but coverage is still behind the Windows ETW and Linux eBPF paths, and privileged features currently require launching from an elevated shell.
 
 ### Linux
 
 1. Download the Linux AppImage from the latest GitHub Release.
 2. Run `chmod +x Vigil-*.AppImage`.
 3. Launch it from the desktop or terminal.
+4. Use root or the required Linux capabilities when you need deeper monitoring or active response actions.
 
 ## Main screens
 
@@ -75,15 +74,12 @@ The Settings tab stores changes automatically. Common settings include:
 - user-defined response rules
 - scheduled lockdown
 - break-glass recovery timeout
-- forensic capture options (Windows today)
+- forensic capture options
 - honeypot decoy settings
 - uninstall confirmation flow
 
 Policy-sensitive settings require Admin Mode when protected policy editing is enabled.
-Configured blocklists and response-rule YAML stay operator-managed: Vigil can
-verify optional `.sha256` sidecars when you provide them, and it also records
-first-seen and changed hashes in its protected local provenance registry so
-later edits are visible without treating every intentional update as corruption.
+Configured blocklists and response-rule YAML stay operator-managed: Vigil can verify optional `.sha256` sidecars when you provide them, and it also records first-seen and changed hashes in its protected local provenance registry so later edits are visible without treating every intentional update as corruption.
 
 ### Help
 
@@ -113,7 +109,7 @@ Temporary actions show countdowns and unblock controls. Isolation always arms br
 
 ### Capture evidence on high-confidence alerts
 
-On Windows today, when forensic capture is enabled, Vigil can preserve:
+When forensic capture is enabled and supported, Vigil can preserve:
 
 - process memory dumps
 - short PCAP captures
@@ -128,31 +124,15 @@ Vigil does more with elevated privileges, but it is still usable without them.
 
 - On Windows, elevation enables ETW-backed near-real-time visibility and active response actions.
 - On Linux, elevated privileges or the needed capabilities are required for actions such as firewall-based containment and some deeper monitoring paths.
-- On macOS, the app may rely on OS-granted visibility and falls back where deeper system hooks are unavailable.
 
 The header and controls are meant to make that state visible so you can tell when Vigil is observing only, and when it is able to act.
-
-## Forensics
-
-On Windows today, when enabled, Vigil can capture forensic evidence for high-confidence alerts:
-
-- process memory dumps
-- short PCAP captures
-- TLS sidecar metadata
-- provenance manifests with SHA-256 and alert context
-
-Generated artifacts are stored under the Vigil data directory unless a custom path is configured.
 
 ## Logs and audit trail
 
 Vigil writes rolling logs and an audit stream under the per-user Vigil data directory. The tray menu includes an **Open Logs Folder** shortcut.
 
 Audit events include active response actions, integrity scan summaries, uninstall attempts, and other security-relevant state changes.
-At startup, Vigil also checks configured operator-managed inputs and Vigil-owned
-forensic artifact manifests. Changed blocklists or response-rule files are
-recorded as provenance events, while unreadable or tampered Vigil-owned
-artifacts are logged as integrity failures and may be moved into the integrity
-quarantine under the data directory.
+At startup, Vigil also checks configured operator-managed inputs and Vigil-owned forensic artifact manifests. Changed blocklists or response-rule files are recorded as provenance events, while unreadable or tampered Vigil-owned artifacts are logged as integrity failures and may be moved into the integrity quarantine under the data directory.
 
 At launch, Vigil also verifies protected policy state, operator-managed blocklists and rule files, and forensic artifact manifests. Blocklists and response-rule YAML files must have matching SHA-256 sidecars; Vigil combines that verification with a protected local provenance registry, so an expected local edit shows up as a warning while a missing sidecar, mismatch, or unreadable file is treated as a failure. Corrupted forensic artifact sets are moved under `quarantine/integrity/` in the Vigil data directory so they are no longer mixed with trusted evidence.
 
@@ -163,14 +143,15 @@ To monitor before login, install the OS service from an elevated shell:
 | OS | Install | Remove |
 |---|---|---|
 | Windows | `vigil.exe --install-service` | `vigil.exe --uninstall-service` |
-| macOS | `sudo vigil --install-service` | `sudo vigil --uninstall-service` |
 | Linux | `sudo vigil --install-service` | `sudo vigil --uninstall-service` |
 
-On Windows, the all-users installer path now performs that service registration automatically. Service mode runs the monitor without the desktop UI. The GUI/tray launches normally after login.
+On Windows, the all-users installer path performs service registration automatically. Service mode runs the monitor without the desktop UI. The GUI/tray launches normally after login.
+
+Startup safety rule: Vigil must fail open. A Vigil bug, hang, network failure, advisory-cache failure, package-inventory failure, or service-mode error must not repeatedly prevent the machine from reaching a usable login/session state.
 
 ## Uninstall from Settings
 
-Settings includes **Uninstall Vigil**. It asks for confirmation, disables login/startup registration, removes the OS service or daemon when present, records an audit event, and closes Vigil after successful cleanup.
+Settings includes **Uninstall Vigil**. It asks for confirmation, disables login/startup registration, removes the OS service when present, records an audit event, and closes Vigil after successful cleanup.
 
 If privileged service removal is required and Vigil is not elevated, the app stays open and shows an error so you can relaunch with the required privileges.
 
@@ -186,9 +167,7 @@ vigil --verify-update-manifest Vigil-latest-update-manifest.json Vigil-latest-up
 
 ## Advisory snapshot imports
 
-Vigil can also extend its protected local advisory cache with operator-supplied
-public-source snapshots. This is useful when you want advisory context to stay
-available offline from the last trusted local cache.
+Vigil can also extend its protected local advisory cache with operator-supplied public-source snapshots. This is useful when you want advisory context to stay available offline from the last trusted local cache.
 
 Use the CLI importer that matches the source material you have:
 
@@ -201,7 +180,19 @@ vigil --import-ncsc ncsc-feed.xml ncsc-mirror.json
 vigil --import-bsi certbund-feed.xml bsi-advisories.json
 ```
 
-The NCSC and BSI/CERT-Bund importers accept either RSS snapshots or mirrored
-JSON, then preserve source links, identifiers, timestamps, and other
-provenance fields in the same protected advisory cache as the other Phase 16
-sources.
+The NCSC and BSI/CERT-Bund importers accept either RSS snapshots or mirrored JSON, then preserve source links, identifiers, timestamps, and other provenance fields in the same protected advisory cache as the other Phase 16 sources.
+
+## Local software inventory
+
+The standalone `vigil_inventory` helper prints local Windows/Linux software inventory metadata as JSON without touching Vigil's startup path.
+
+```bash
+vigil_inventory
+```
+
+Current inventory sources:
+
+- Windows uninstall registry
+- Linux dpkg status database
+- Linux RPM database
+- Linux Alpine apk installed database


### PR DESCRIPTION
## Summary
- add `docs/SUPPORTED-PLATFORMS.md` declaring Windows and Linux as the active support targets
- update README to advertise Windows/Linux only and remove unsupported-platform download, install, service, and backend guidance
- update the User Guide to cover Windows/Linux only, including boot-time service mode and local software inventory
- update CONTRIBUTING to require Windows/Linux behavior and remove unsupported-platform development expectations
- document the startup safety rule: Vigil must fail open at OS startup on supported platforms

## Why this task
We decided to stop pursuing support outside Windows and Linux. This PR updates the main user-facing and contributor-facing documentation so the project direction is clear before doing larger code, installer, release-workflow, or roadmap cleanup.

## Validation
- docs-only change
- not run: tests/build, because no code changes were made and GitHub Actions credits are unavailable

## Follow-up
- remove stale unsupported-platform references from legacy roadmap/history sections and source-code comments
- remove or quarantine unsupported installer/release artifacts and CI/release jobs incrementally
- remove unsupported code paths only when doing so does not destabilize Windows/Linux builds