### PR TITLE
[codex] Remove unsupported source leftovers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,19 +80,17 @@ winres = "0.1"
 
 # Strip the gtk3 / glib 0.18 chain from Cargo.lock.
 #
-# `tray-icon` declares `libappindicator` as a hard `cfg(linux)` dependency in
-# its own Cargo.toml (not behind a feature flag). Cargo's resolver records
-# target-specific transitive deps in Cargo.lock regardless of the build target,
-# so even though we never use tray-icon on Linux (we use ksni), libappindicator
-# and its glib/gtk 0.18 subtree would still appear in the lockfile and trip
-# Dependabot on GHSA-wrw7-89jp-8q8g (unsound glib::VariantStrIter).
+# `tray-icon` declares `libappindicator` as a hard Linux dependency in its own
+# Cargo.toml. Cargo's resolver records target-specific transitive deps in
+# Cargo.lock regardless of the build target, so even though we use `ksni` on
+# Linux, libappindicator and its glib/gtk 0.18 subtree would still appear in the
+# lockfile and trip Dependabot on GHSA-wrw7-89jp-8q8g (unsound
+# glib::VariantStrIter).
 #
-# The stub below is an empty crate with zero dependencies. tray-icon only
-# references `libappindicator` from `#[cfg(all(unix, not(target_os = "macos")))]`
-# blocks, which don't compile on Windows or macOS, so the stub's body is never
-# referenced. On Linux `tray-icon` isn't pulled in at all. Net effect:
-# glib/gtk/libappindicator disappear from Cargo.lock without changing any
-# compiled behavior.
+# The stubs below are empty crates with zero dependencies. The active Linux tray
+# implementation uses `ksni`, and the Windows build does not compile these stub
+# bodies. Net effect: glib/gtk/libappindicator disappear from Cargo.lock without
+# changing compiled Windows/Linux behavior.
 [patch.crates-io]
 libappindicator = { path = "stubs/libappindicator" }
 gtk             = { path = "stubs/gtk" }
@@ -103,7 +101,6 @@ ci                 = "github"
 installers         = ["shell", "powershell", "msi"]
 targets            = [
     "x86_64-pc-windows-msvc",
-    "aarch64-apple-darwin",
     "x86_64-unknown-linux-gnu",
 ]
 pr-run-mode        = "skip"

--- a/src/monitor/poll.rs
+++ b/src/monitor/poll.rs
@@ -3,7 +3,6 @@
 //! Returns a snapshot of all active TCP/UDP connections with PIDs.
 //! On Windows: `GetExtendedTcpTable` / `GetExtendedUdpTable` (Win32 IpHelper).
 //! On Linux:   `/proc/net/tcp` + `/proc/net/tcp6`.
-//! On macOS:   falls back to parsing `netstat` output.
 
 #[cfg(any(windows, target_os = "linux"))]
 use std::net::Ipv4Addr;
@@ -289,78 +288,11 @@ fn linux_state_str(state: u8) -> &'static str {
     }
 }
 
-// ── macOS ─────────────────────────────────────────────────────────────────────
-
-#[cfg(target_os = "macos")]
-fn platform_poll() -> Vec<RawConn> {
-    macos_netstat()
-}
-
-#[cfg(target_os = "macos")]
-fn macos_netstat() -> Vec<RawConn> {
-    use std::process::Command;
-    let Ok(netstat) = crate::platform::command_paths::resolve("netstat") else {
-        return vec![];
-    };
-    let Ok(out) = Command::new(netstat).args(["-anv", "-p", "tcp"]).output() else {
-        return vec![];
-    };
-    let text = String::from_utf8_lossy(&out.stdout);
-    let mut conns = Vec::new();
-
-    for line in text.lines().skip(2) {
-        let fields: Vec<&str> = line.split_whitespace().collect();
-        // Proto Local Foreign State … pid
-        if fields.len() < 6 {
-            continue;
-        }
-        if !fields[0].starts_with("tcp") {
-            continue;
-        }
-
-        let status = fields[5].to_uppercase();
-        let pid: u32 = fields.last().and_then(|s| s.parse().ok()).unwrap_or(0);
-
-        let (local_ip, local_port) = split_addr(fields[3]);
-        let (remote_ip, remote_port) = split_addr(fields[4]);
-        let is_listen = status == "LISTEN";
-
-        conns.push(RawConn {
-            pid,
-            local_ip,
-            local_port,
-            remote_ip: if is_listen { String::new() } else { remote_ip },
-            remote_port: if is_listen { 0 } else { remote_port },
-            status,
-        });
-    }
-    conns
-}
-
 // ── Fallback for other platforms ──────────────────────────────────────────────
 
-#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(windows, target_os = "linux")))]
 fn platform_poll() -> Vec<RawConn> {
     vec![]
-}
-
-// ── Shared helpers ────────────────────────────────────────────────────────────
-
-/// Split "ip:port" or "ip.port" (macOS uses ".") → (ip, port).
-#[cfg(target_os = "macos")]
-fn split_addr(s: &str) -> (String, u16) {
-    // Try last ':' first (IPv4:port or [IPv6]:port), then last '.'
-    if let Some(pos) = s.rfind(':') {
-        let ip = s[..pos].trim_matches(|c| c == '[' || c == ']').to_string();
-        let port = s[pos + 1..].parse().unwrap_or(0);
-        return (ip, port);
-    }
-    if let Some(pos) = s.rfind('.') {
-        let ip = s[..pos].to_string();
-        let port = s[pos + 1..].parse().unwrap_or(0);
-        return (ip, port);
-    }
-    (s.to_string(), 0)
 }
 
 #[cfg(test)]

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -15,8 +15,8 @@
 //!            build), we fall back to `notify-rust` so the user still sees the
 //!            notification (without the click-to-navigate behaviour).
 //!
-//! macOS / Linux — `notify-rust` for a lightweight toast. We keep the call
-//!                 fire-and-forget so the caller is never blocked.
+//! Linux / other Unix fallback — `notify-rust` for a lightweight toast. We keep
+//!                               the call fire-and-forget so the caller is never blocked.
 
 use crate::types::ConnInfo;
 use std::sync::atomic::AtomicBool;
@@ -82,9 +82,9 @@ mod platform {
     }
 
     /// Basic `notify-rust` fallback used when WinRT refuses to show the toast.
-    /// Unlike macOS/Linux, the Windows backend of `notify-rust` does not
-    /// support `wait_for_action`, so we only surface the alert text — the
-    /// click-to-navigate wiring is lost for that one notification.
+    /// The Windows backend of `notify-rust` does not support `wait_for_action`,
+    /// so we only surface the alert text — the click-to-navigate wiring is lost
+    /// for that one notification.
     fn fallback_notify_rust(info: &ConnInfo) {
         let body = format!(
             "{} \u{2192} {}   score: {}\n{}",
@@ -123,7 +123,7 @@ mod platform {
     }
 }
 
-// ── macOS / Linux ─────────────────────────────────────────────────────────────
+// ── Linux / other Unix fallback ───────────────────────────────────────────────
 
 #[cfg(not(windows))]
 mod platform {

--- a/src/platform/break_glass.rs
+++ b/src/platform/break_glass.rs
@@ -511,63 +511,7 @@ mod platform {
                 .ok_or_else(|| "could not locate crontab in trusted paths".to_string())
         }
     }
-    #[cfg(target_os = "macos")]
-    mod imp {
-        use std::path::PathBuf;
-        use std::process::Command;
-        const PLIST_LABEL: &str = "com.vigil.break-glass-recovery";
-        pub fn task_exists() -> bool {
-            plist_path().exists()
-        }
-        pub fn create_recovery_task() -> Result<(), String> {
-            let exe = std::env::current_exe()
-                .map_err(|e| format!("failed to resolve current exe: {e}"))?;
-            let plist = format!("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n  <key>Label</key>\n  <string>{PLIST_LABEL}</string>\n  <key>ProgramArguments</key>\n  <array>\n    <string>{}</string>\n    <string>--break-glass-recover</string>\n  </array>\n  <key>RunAtLoad</key>\n  <true/>\n  <key>StartInterval</key>\n  <integer>60</integer>\n</dict>\n</plist>\n", xml_escape(&exe.display().to_string()));
-            std::fs::write(plist_path(), plist)
-                .map_err(|e| format!("failed to write launchd plist: {e}"))?;
-            let launchctl = launchctl_path();
-            let _ = Command::new(launchctl)
-                .args(["bootout", "system", plist_path().to_string_lossy().as_ref()])
-                .status();
-            let status = Command::new(launchctl)
-                .args([
-                    "bootstrap",
-                    "system",
-                    plist_path().to_string_lossy().as_ref(),
-                ])
-                .status()
-                .map_err(|e| format!("failed to spawn launchctl bootstrap: {e}"))?;
-            if status.success() {
-                Ok(())
-            } else {
-                Err(format!("launchctl bootstrap failed with status {status}"))
-            }
-        }
-        pub fn delete_recovery_task() -> Result<(), String> {
-            let _ = Command::new(launchctl_path())
-                .args(["bootout", "system", plist_path().to_string_lossy().as_ref()])
-                .status();
-            if plist_path().exists() {
-                std::fs::remove_file(plist_path())
-                    .map_err(|e| format!("failed to remove launchd plist: {e}"))?;
-            }
-            Ok(())
-        }
-        fn launchctl_path() -> &'static str {
-            "/bin/launchctl"
-        }
-        fn plist_path() -> PathBuf {
-            PathBuf::from(format!("/Library/LaunchDaemons/{PLIST_LABEL}.plist"))
-        }
-        fn xml_escape(text: &str) -> String {
-            text.replace('&', "&amp;")
-                .replace('<', "&lt;")
-                .replace('>', "&gt;")
-                .replace('"', "&quot;")
-                .replace('\'', "&apos;")
-        }
-    }
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    #[cfg(not(target_os = "linux"))]
     mod imp {
         pub fn task_exists() -> bool {
             false

--- a/src/platform/command_paths.rs
+++ b/src/platform/command_paths.rs
@@ -9,14 +9,10 @@ pub fn resolve(program: &str) -> Result<PathBuf, String> {
     {
         resolve_linux(program)
     }
-    #[cfg(target_os = "macos")]
-    {
-        resolve_macos(program)
-    }
-    #[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
+    #[cfg(not(any(windows, target_os = "linux")))]
     {
         let _ = program;
-        Err("trusted command resolution is not implemented on this platform".into())
+        Err("trusted command resolution is supported on Windows and Linux only".into())
     }
 }
 
@@ -48,20 +44,6 @@ fn resolve_linux(program: &str) -> Result<PathBuf, String> {
         "resolvectl" => &["/usr/bin/resolvectl", "/bin/resolvectl"],
         "systemd-resolve" => &["/usr/bin/systemd-resolve", "/bin/systemd-resolve"],
         "systemctl" => &["/bin/systemctl", "/usr/bin/systemctl"],
-        "crontab" => &["/usr/bin/crontab", "/bin/crontab"],
-        _ => &[],
-    };
-    resolve_from_candidates(program, candidates)
-}
-
-#[cfg(target_os = "macos")]
-fn resolve_macos(program: &str) -> Result<PathBuf, String> {
-    let candidates: &[&str] = match program {
-        "ifconfig" => &["/sbin/ifconfig"],
-        "netstat" => &["/usr/sbin/netstat", "/usr/bin/netstat", "/bin/netstat"],
-        "launchctl" => &["/bin/launchctl"],
-        "chown" => &["/usr/sbin/chown", "/bin/chown"],
-        "chmod" => &["/bin/chmod"],
         "crontab" => &["/usr/bin/crontab", "/bin/crontab"],
         _ => &[],
     };

--- a/src/platform/service.rs
+++ b/src/platform/service.rs
@@ -1,24 +1,23 @@
-//! Cross-platform boot-time service installation.
+//! Boot-time service installation for supported platforms.
 //!
-//! Vigil can run as an OS-managed service/daemon so it starts **before** any
-//! user logs in and catches malware that activates during boot (rootkits,
-//! dropper callbacks, persistence mechanisms).  This module implements the
-//! install / uninstall commands for each supported OS:
+//! Vigil can run as an OS-managed service so it starts **before** any user logs
+//! in and catches malware that activates during boot (rootkits, dropper
+//! callbacks, persistence mechanisms). This module implements the install /
+//! uninstall commands for supported OSs:
 //!
 //! | OS      | Mechanism                     | Location                                      |
 //! | ------- | ----------------------------- | --------------------------------------------- |
 //! | Windows | Task Scheduler                | `schtasks /Create ...`                        |
-//! | macOS   | launchd system daemon         | `/Library/LaunchDaemons/com.vigil.monitor.plist` |
 //! | Linux   | systemd system unit           | `/etc/systemd/system/vigil.service`           |
 //!
-//! All three require elevation; this module does **not** elevate itself —
-//! the user must invoke Vigil from an elevated shell.  On failure we print
-//! a helpful, OS-specific hint and return a non-zero exit code to `main`.
+//! Both require elevation; this module does **not** elevate itself — the user
+//! must invoke Vigil from an elevated shell. On failure we print a helpful,
+//! OS-specific hint and return a non-zero exit code to `main`.
 //!
-//! The installed service runs the **monitor only** — no GUI, no tray
-//! (those require a desktop session).  When the user logs in, the normal
-//! user-mode Vigil process starts via autostart and reads the same log
-//! file, so pre-login events remain visible via the log.
+//! The installed service runs the **monitor only** — no GUI, no tray (those
+//! require a desktop session). When the user logs in, the normal user-mode Vigil
+//! process starts via autostart and reads the same log file, so pre-login events
+//! remain visible via the log.
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -439,153 +438,9 @@ mod platform {
     }
 }
 
-// ── macOS ─────────────────────────────────────────────────────────────────────
-
-#[cfg(target_os = "macos")]
-mod platform {
-    use super::*;
-    use crate::platform::command_paths;
-    use std::path::Path;
-    use std::process::{Command, Output};
-
-    const LABEL: &str = "com.vigil.monitor";
-
-    fn plist_path() -> std::path::PathBuf {
-        std::path::PathBuf::from(format!("/Library/LaunchDaemons/{LABEL}.plist"))
-    }
-
-    pub fn install(exe: &Path) -> CmdResult {
-        if !is_root() {
-            return Err("launchd daemons must be installed as root.  Re-run with:\n\
-                 \n\
-                 \u{00a0}\u{00a0}sudo vigil --install-service"
-                .into());
-        }
-
-        let shared_data_dir = exe
-            .parent()
-            .map(|d| d.join("vigil-data"))
-            .ok_or_else(|| format!("could not determine parent directory for {}", exe.display()))?;
-        let exe = xml_escape(&exe.display().to_string());
-        let plist = format!(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Label</key>             <string>{LABEL}</string>
-    <key>ProgramArguments</key>  <array><string>{exe}</string><string>{service_flag}</string><string>{data_dir_flag}</string><string>{shared_data_dir}</string></array>
-    <key>RunAtLoad</key>         <true/>
-    <key>KeepAlive</key>         <true/>
-    <key>StandardOutPath</key>   <string>/var/log/vigil.log</string>
-    <key>StandardErrorPath</key> <string>/var/log/vigil.log</string>
-</dict>
-</plist>
-"#,
-            exe = exe,
-            service_flag = SERVICE_MODE_FLAG,
-            data_dir_flag = DATA_DIR_FLAG,
-            shared_data_dir = xml_escape(&shared_data_dir.display().to_string()),
-        );
-        let path = plist_path();
-        std::fs::write(&path, plist.as_bytes())
-            .map_err(|e| format!("could not write {}: {e}", path.display()))?;
-        // Permissions: root:wheel 0644
-        let _ = Command::new(command_paths::resolve("chown")?)
-            .args(["root:wheel", &path.display().to_string()])
-            .status();
-        let _ = Command::new(command_paths::resolve("chmod")?)
-            .args(["644", &path.display().to_string()])
-            .status();
-
-        let status = Command::new(command_paths::resolve("launchctl")?)
-            .args(["load", "-w", &path.display().to_string()])
-            .status()
-            .map_err(|e| format!("failed to spawn `launchctl`: {e}"))?;
-        if !status.success() {
-            return Err("`launchctl load` failed (see /var/log/system.log)".into());
-        }
-        Ok(format!(
-            "Installed launchd daemon `{LABEL}` at {}.\n\
-             It will auto-start at boot (even before login).\n\
-             To remove:  sudo vigil --uninstall-service",
-            path.display()
-        ))
-    }
-
-    pub fn uninstall() -> CmdResult {
-        let path = plist_path();
-        if !path.exists() {
-            return Ok(format!("launchd daemon `{LABEL}` was not installed."));
-        }
-        if !is_root() {
-            return Err("Re-run with:  sudo vigil --uninstall-service".into());
-        }
-        let _ = Command::new(command_paths::resolve("launchctl")?)
-            .args(["unload", "-w", &path.display().to_string()])
-            .status();
-        std::fs::remove_file(&path)
-            .map_err(|e| format!("could not remove {}: {e}", path.display()))?;
-        Ok(format!("Removed launchd daemon `{LABEL}`."))
-    }
-
-    pub fn disable_boot_start() -> Result<(), String> {
-        let path = plist_path();
-        if !path.exists() {
-            return Ok(());
-        }
-        if !is_root() {
-            return Err("launchd daemon disable requires root".into());
-        }
-        let output = Command::new(command_paths::resolve("launchctl")?)
-            .args(["unload", "-w", &path.display().to_string()])
-            .output()
-            .map_err(|e| format!("failed to spawn `launchctl`: {e}"))?;
-        if output.status.success() {
-            Ok(())
-        } else {
-            Err(format!(
-                "failed to disable launchd daemon `{LABEL}`: {}",
-                command_output_summary(&output)
-            ))
-        }
-    }
-
-    fn is_root() -> bool {
-        // Declare getuid() directly to avoid pulling in a `libc` dependency
-        // just for a single uid comparison.  It's an infallible C ABI call.
-        extern "C" {
-            fn getuid() -> u32;
-        }
-        unsafe { getuid() == 0 }
-    }
-
-    fn xml_escape(text: &str) -> String {
-        text.replace('&', "&amp;")
-            .replace('<', "&lt;")
-            .replace('>', "&gt;")
-            .replace('"', "&quot;")
-            .replace('\'', "&apos;")
-    }
-
-    fn command_output_summary(output: &Output) -> String {
-        let text = command_output_text(output);
-        if text.trim().is_empty() {
-            format!("exit status {}", output.status)
-        } else {
-            format!("exit status {}; {}", output.status, text.trim())
-        }
-    }
-
-    fn command_output_text(output: &Output) -> String {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        format!("{stdout}{stderr}")
-    }
-}
-
 // ── Linux ─────────────────────────────────────────────────────────────────────
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(target_os = "linux")]
 mod platform {
     use super::*;
     use crate::platform::command_paths;
@@ -722,6 +577,24 @@ mod platform {
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         format!("{stdout}{stderr}")
+    }
+}
+
+#[cfg(not(any(windows, target_os = "linux")))]
+mod platform {
+    use super::*;
+    use std::path::Path;
+
+    pub fn install(_exe: &Path) -> CmdResult {
+        Err("boot-time service installation is supported on Windows and Linux only".into())
+    }
+
+    pub fn uninstall() -> CmdResult {
+        Ok("boot-time service was not installed on this unsupported platform".into())
+    }
+
+    pub fn disable_boot_start() -> Result<(), String> {
+        Ok(())
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -2,9 +2,8 @@
 //!
 //! `is_pre_login()` returns `true` when the host currently has **no
 //! interactive user session** — i.e. Vigil is running as a boot-time
-//! service / launchd daemon / systemd unit and no one has logged in yet
-//! (or the screen is at the lock / login prompt before any user has
-//! authenticated for the first time).
+//! service / systemd unit and no one has logged in yet (or the screen is at
+//! the lock / login prompt before any user has authenticated for the first time).
 //!
 //! Events observed while this is true are tagged with `pre_login: true`
 //! on `ConnInfo`, which:
@@ -42,16 +41,13 @@ mod platform {
     }
 }
 
-// ── Unix (macOS + Linux) ──────────────────────────────────────────────────────
+// ── Linux / other Unix fallback ───────────────────────────────────────────────
 
 #[cfg(not(windows))]
 mod platform {
-    /// On macOS + Linux we approximate by checking the environment Vigil
-    /// inherited at launch:
+    /// On supported Unix service-mode builds we approximate by checking the
+    /// environment Vigil inherited at launch:
     ///
-    /// * A `launchd` daemon launched at boot (before `loginwindow` hands
-    ///   off to a user) inherits *no* `USER` / `HOME` / `DISPLAY` /
-    ///   `WAYLAND_DISPLAY` — its context is whatever the plist declared.
     /// * A `systemd` system unit has `USER=root` (or the `User=` directive
     ///   value) and never gets `DISPLAY` or `WAYLAND_DISPLAY`.
     /// * An interactive session always has at least one of


### PR DESCRIPTION
## Summary
- remove isolated unsupported backend code from polling, boot-service, break-glass, and trusted-command resolution paths
- keep Windows and Linux implementations intact
- update source comments and Cargo/dist metadata to describe Windows/Linux support only

## Files changed
- `Cargo.toml`
- `src/monitor/poll.rs`
- `src/notifier.rs`
- `src/platform/break_glass.rs`
- `src/platform/command_paths.rs`
- `src/platform/service.rs`
- `src/session.rs`

## Risk control
- branch diff reviewed before opening: 7 files changed
- no README badges, user docs, workflows, installer files, release signing logic, or startup inventory paths changed
- unsupported blocks removed only where they were isolated behind platform cfg gates
- Windows and Linux implementations were preserved rather than rewritten
- large/truncated files such as `src/ui/settings.rs` and `src/security/active_response_platform.rs` were intentionally not edited in this pass

## Validation
- not run locally
- GitHub Actions may be unavailable or misleading because Actions credits are exhausted
- requires reviewer attention because this is broader than the previous cleanup PRs, even though the changes are mostly deletion of unsupported cfg-gated paths

## Follow-up
- handle any remaining unsupported references in large files with a safer patch path or local checkout
- run `cargo check` / `cargo test` on Windows and Linux when a build environment is available