### PR TITLE
[codex] Remove final unsupported platform docs references

### DIFF
--- a/docs/OPENSSF-BEST-PRACTICES.md
+++ b/docs/OPENSSF-BEST-PRACTICES.md
@@ -38,7 +38,6 @@ Suggested required status checks:
 
 - CI / Format & lint
 - CI / Build & test (x86_64-pc-windows-msvc)
-- CI / Build & test (aarch64-apple-darwin)
 - CI / Build & test (x86_64-unknown-linux-gnu)
 - Artifact hygiene / Check for generated executables and large binaries
 - Secret scan / Scan for common plaintext secret patterns
@@ -113,7 +112,7 @@ If additional repositories are added, list them here and in the README.
 
 Repository policy:
 
-- do not commit generated installers, release archives, compiled executables, DMGs, AppImages, object files, or build output
+- do not commit generated installers, release archives, compiled executables, AppImages, object files, or build output
 - avoid unreviewable binary blobs unless they are small source assets required for the UI and documented
 - generated release artifacts must be produced by CI and attached to GitHub Releases, not committed to the repository
 


### PR DESCRIPTION
## Summary
- remove the unsupported target from the OpenSSF suggested required status checks
- remove the stale generated-artifact reference for unsupported release bundles

## Risk control
- docs-only change
- one file changed: `docs/OPENSSF-BEST-PRACTICES.md`
- branch diff reviewed before opening: 1 addition, 2 deletions
- no runtime code, workflows, installer files, README badges, release signing logic, or user-guide content changed

## Validation
- docs-only change; tests not run