### PR TITLE
[codex] Fix vigil_inventory review findings

### DIFF
--- a/src/bin/vigil_inventory.rs
+++ b/src/bin/vigil_inventory.rs
@@ -165,22 +165,22 @@ fn collect_windows_uninstall_entries() -> Vec<InventoryEntry> {
     let uninstall_roots = [
         (
             HKEY_LOCAL_MACHINE,
-            r"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
+            r"Software\Microsoft\Windows\CurrentVersion\Uninstall",
             KEY_READ | KEY_WOW64_64KEY,
         ),
         (
             HKEY_LOCAL_MACHINE,
-            r"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
+            r"Software\Microsoft\Windows\CurrentVersion\Uninstall",
             KEY_READ | KEY_WOW64_32KEY,
         ),
         (
             HKEY_CURRENT_USER,
-            r"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
+            r"Software\Microsoft\Windows\CurrentVersion\Uninstall",
             KEY_READ | KEY_WOW64_64KEY,
         ),
         (
             HKEY_CURRENT_USER,
-            r"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
+            r"Software\Microsoft\Windows\CurrentVersion\Uninstall",
             KEY_READ | KEY_WOW64_32KEY,
         ),
     ];
@@ -522,7 +522,7 @@ mod tests {
             r#"C:\\Program Files\\App\\app.exe"#
         );
         assert_eq!(
-            clean_display_icon_path(r#""C:\\Program Files\\App\\app.exe,1""#),
+            clean_display_icon_path(r#"C:\\Program Files\\App\\app.exe,1"#),
             r#"C:\\Program Files\\App\\app.exe"#
         );
     }


### PR DESCRIPTION
## Summary
- fix Windows uninstall registry root strings to use single separators in Rust raw strings
- correct the quoted/unquoted `DisplayIcon` test fixture so it matches the parser behavior and should not fail `cargo test --bin vigil_inventory`

## Why this matters
Codex review on PR #194 flagged a P1 issue where doubled separators in raw registry strings could make Windows uninstall enumeration silently return no entries. It also flagged a P2 test fixture issue that could break targeted validation.

## Risk control
- one file changed: `src/bin/vigil_inventory.rs`
- 5 additions, 5 deletions
- follow-up only for merged PR #194 review comments
- no startup-path, service-mode, networking, advisory-cache, main inventory model, docs, or workflow changes

## Validation
- not run locally in this environment
- change is limited to literal registry paths and one unit-test fixture