### PR TITLE
Replace real-looking inventory fixtures with neutral data

### DIFF
--- a/src/bin/vigil_inventory.rs
+++ b/src/bin/vigil_inventory.rs
@@ -499,20 +499,17 @@ mod tests {
     #[test]
     fn parse_apk_installed_collects_maintainer_or_origin() {
         let parsed = parse_apk_installed(
-            "P:busybox\nV:1.36.1-r7\nm:Natanael Copa <ncopa@alpinelinux.org>\n\nP:musl\nV:1.2.5-r1\no:alpine-baselayout\n\n",
+            "P:busybox\nV:1.36.1-r7\nm:Example Maintainer\n\nP:musl\nV:1.2.5-r1\no:example-origin\n\n",
         );
         assert_eq!(parsed.len(), 2);
         assert_eq!(parsed[0].display_name, "busybox");
         assert_eq!(parsed[0].version_hint.as_deref(), Some("1.36.1-r7"));
         assert_eq!(
             parsed[0].publisher_hint.as_deref(),
-            Some("Natanael Copa <ncopa@alpinelinux.org>")
+            Some("Example Maintainer")
         );
         assert_eq!(parsed[1].display_name, "musl");
-        assert_eq!(
-            parsed[1].publisher_hint.as_deref(),
-            Some("alpine-baselayout")
-        );
+        assert_eq!(parsed[1].publisher_hint.as_deref(), Some("example-origin"));
     }
 
     #[test]

--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -1,11 +1,11 @@
 //! Minimal local software inventory foundations for advisory relevance.
 //!
 //! Phase 16 starts with conservative, low-risk inventory sources:
-//! currently-running processes, Windows uninstall-registry entries, Linux
-//! package-manager metadata (dpkg, RPM, and apk), and Homebrew formula/cask
-//! inventory on macOS. This keeps inventory collection offline and low-risk
-//! while still giving the advisory pipeline stable product candidates plus
-//! lightweight publisher/version hints for later matching.
+//! currently-running processes, Windows uninstall-registry entries, and Linux
+//! package-manager metadata (dpkg, RPM, and apk). This keeps inventory
+//! collection offline and low-risk while still giving the advisory pipeline
+//! stable product candidates plus lightweight publisher/version hints for
+//! later matching.
 
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
@@ -33,7 +33,6 @@ pub enum InventorySource {
     LinuxDpkgStatus,
     LinuxRpmDatabase,
     LinuxApkInstalled,
-    MacosHomebrew,
     WindowsUninstallRegistry,
     RunningService,
 }
@@ -119,10 +118,6 @@ fn collect_installed_software_limited(max_entries: usize) -> Vec<InstalledSoftwa
     if entries.len() < max_entries {
         let remaining = max_entries - entries.len();
         append_limited_entries(&mut entries, collect_linux_apk_entries(), remaining);
-    }
-    if entries.len() < max_entries {
-        let remaining = max_entries - entries.len();
-        append_limited_entries(&mut entries, collect_macos_homebrew_entries(), remaining);
     }
 
     collect_from_entries(entries)
@@ -269,208 +264,6 @@ fn collect_linux_apk_entries() -> Vec<InventorySeed> {
 #[cfg(not(target_os = "linux"))]
 fn collect_linux_apk_entries() -> Vec<InventorySeed> {
     Vec::new()
-}
-
-#[cfg(target_os = "macos")]
-fn collect_macos_homebrew_entries() -> Vec<InventorySeed> {
-    [
-        (
-            std::path::Path::new("/opt/homebrew/Cellar"),
-            std::path::Path::new("/opt/homebrew/opt"),
-        ),
-        (
-            std::path::Path::new("/usr/local/Cellar"),
-            std::path::Path::new("/usr/local/opt"),
-        ),
-    ]
-    .into_iter()
-    .flat_map(|(cellar_root, opt_root)| {
-        collect_homebrew_formula_entries_from_roots(cellar_root, opt_root)
-    })
-    .chain(
-        [
-            std::path::Path::new("/opt/homebrew/Caskroom"),
-            std::path::Path::new("/usr/local/Caskroom"),
-        ]
-        .into_iter()
-        .flat_map(collect_homebrew_cask_entries_from_root),
-    )
-    .collect()
-}
-
-#[cfg(not(target_os = "macos"))]
-fn collect_macos_homebrew_entries() -> Vec<InventorySeed> {
-    Vec::new()
-}
-
-fn collect_homebrew_formula_entries_from_roots(
-    cellar_root: &std::path::Path,
-    opt_root: &std::path::Path,
-) -> Vec<InventorySeed> {
-    let Ok(packages) = std::fs::read_dir(cellar_root) else {
-        return Vec::new();
-    };
-
-    let mut entries = Vec::new();
-    for package in packages.flatten() {
-        let Ok(file_type) = package.file_type() else {
-            continue;
-        };
-        if !file_type.is_dir() {
-            continue;
-        }
-
-        let Some(display_name) = inventory_hint(package.file_name().to_string_lossy().to_string())
-        else {
-            continue;
-        };
-        let version_hint =
-            homebrew_version_hint_for_package(&display_name, &package.path(), opt_root);
-        entries.push(InventorySeed {
-            display_name,
-            executable_path: String::new(),
-            publisher_hint: None,
-            version_hint,
-            source: InventorySource::MacosHomebrew,
-        });
-    }
-    entries
-}
-
-fn collect_homebrew_cask_entries_from_root(caskroom_root: &std::path::Path) -> Vec<InventorySeed> {
-    let Ok(casks) = std::fs::read_dir(caskroom_root) else {
-        return Vec::new();
-    };
-
-    let mut entries = Vec::new();
-    for cask in casks.flatten() {
-        let Ok(file_type) = cask.file_type() else {
-            continue;
-        };
-        if !file_type.is_dir() {
-            continue;
-        }
-
-        if let Some(entry) = inventory_seed_from_homebrew_cask_dir(&cask.path()) {
-            entries.push(entry);
-        }
-    }
-    entries
-}
-
-fn inventory_seed_from_homebrew_cask_dir(cask_dir: &std::path::Path) -> Option<InventorySeed> {
-    let version_dir = sole_child_directory_path(cask_dir)?;
-    let version_hint = version_dir
-        .file_name()
-        .map(|name| name.to_string_lossy().to_string())
-        .and_then(inventory_hint);
-    let app_bundle = sole_app_bundle_path(&version_dir);
-    let executable_path = app_bundle
-        .as_ref()
-        .map(|path| path.to_string_lossy().to_string())
-        .unwrap_or_default();
-    let display_name = app_bundle
-        .as_ref()
-        .and_then(|path| display_name_from_app_bundle(path))
-        .or_else(|| {
-            cask_dir
-                .file_name()
-                .map(|name| name.to_string_lossy().to_string())
-                .and_then(inventory_hint)
-        })?;
-
-    Some(InventorySeed {
-        display_name,
-        executable_path,
-        publisher_hint: None,
-        version_hint,
-        source: InventorySource::MacosHomebrew,
-    })
-}
-
-fn homebrew_version_hint_for_package(
-    package_name: &str,
-    package_root: &std::path::Path,
-    opt_root: &std::path::Path,
-) -> Option<String> {
-    let canonical_package_root = std::fs::canonicalize(package_root).ok()?;
-    if let Some(active_version) =
-        active_homebrew_version_from_opt(package_name, &canonical_package_root, opt_root)
-    {
-        return Some(active_version);
-    }
-    sole_child_directory_name(&canonical_package_root)
-}
-
-fn active_homebrew_version_from_opt(
-    package_name: &str,
-    canonical_package_root: &std::path::Path,
-    opt_root: &std::path::Path,
-) -> Option<String> {
-    let resolved = std::fs::canonicalize(opt_root.join(package_name)).ok()?;
-    if !resolved.starts_with(canonical_package_root) {
-        return None;
-    }
-    resolved
-        .file_name()
-        .map(|name| name.to_string_lossy().to_string())
-        .and_then(inventory_hint)
-}
-
-fn sole_child_directory_name(dir: &std::path::Path) -> Option<String> {
-    sole_child_directory_path(dir).and_then(|path| {
-        path.file_name()
-            .map(|name| name.to_string_lossy().to_string())
-            .and_then(inventory_hint)
-    })
-}
-
-fn sole_child_directory_path(dir: &std::path::Path) -> Option<std::path::PathBuf> {
-    let mut only = None;
-    for child in std::fs::read_dir(dir).ok()? {
-        let child = child.ok()?;
-        if !child.file_type().ok()?.is_dir() {
-            continue;
-        }
-        if inventory_hint(child.file_name().to_string_lossy().to_string()).is_none() {
-            continue;
-        }
-        if only.is_some() {
-            return None;
-        }
-        only = Some(child.path());
-    }
-    only
-}
-
-fn sole_app_bundle_path(dir: &std::path::Path) -> Option<std::path::PathBuf> {
-    let mut only = None;
-    for child in std::fs::read_dir(dir).ok()? {
-        let child = child.ok()?;
-        if !child.file_type().ok()?.is_dir() {
-            continue;
-        }
-        if !child
-            .path()
-            .extension()
-            .and_then(|ext| ext.to_str())
-            .map(|ext| ext.eq_ignore_ascii_case("app"))
-            .unwrap_or(false)
-        {
-            continue;
-        }
-        if only.is_some() {
-            return None;
-        }
-        only = Some(child.path());
-    }
-    only
-}
-
-fn display_name_from_app_bundle(path: &std::path::Path) -> Option<String> {
-    path.file_stem()
-        .map(|name| name.to_string_lossy().to_string())
-        .and_then(inventory_hint)
 }
 
 fn parse_dpkg_status(status: &str) -> Vec<InventorySeed> {
@@ -747,9 +540,8 @@ fn source_sort_key(source: InventorySource) -> u8 {
         InventorySource::LinuxDpkgStatus => 1,
         InventorySource::LinuxRpmDatabase => 2,
         InventorySource::LinuxApkInstalled => 3,
-        InventorySource::MacosHomebrew => 4,
-        InventorySource::WindowsUninstallRegistry => 5,
-        InventorySource::RunningService => 6,
+        InventorySource::WindowsUninstallRegistry => 4,
+        InventorySource::RunningService => 5,
     }
 }
 
@@ -807,7 +599,6 @@ fn inventory_hint(value: String) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
 
     fn seed(
         display_name: &str,
@@ -823,35 +614,6 @@ mod tests {
             version_hint: version_hint.map(str::to_string),
             source,
         }
-    }
-
-    fn temp_test_dir(label: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!(
-            "vigil-homebrew-test-{label}-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        dir
-    }
-
-    fn make_homebrew_formula_roots(label: &str) -> (PathBuf, PathBuf, PathBuf) {
-        let base = temp_test_dir(label);
-        let cellar = base.join("Cellar");
-        let opt = base.join("opt");
-        std::fs::create_dir_all(&cellar).unwrap();
-        std::fs::create_dir_all(&opt).unwrap();
-        (base, cellar, opt)
-    }
-
-    fn make_homebrew_cask_root(label: &str) -> (PathBuf, PathBuf) {
-        let base = temp_test_dir(label);
-        let caskroom = base.join("Caskroom");
-        std::fs::create_dir_all(&caskroom).unwrap();
-        (base, caskroom)
     }
 
     #[test]
@@ -926,104 +688,6 @@ mod tests {
     }
 
     #[test]
-    fn collect_homebrew_entries_from_roots_uses_sole_version_without_opt_link() {
-        let (base, cellar, opt) = make_homebrew_formula_roots("sole-version");
-        std::fs::create_dir_all(cellar.join("ripgrep/14.1.0")).unwrap();
-
-        let parsed = collect_homebrew_formula_entries_from_roots(&cellar, &opt);
-
-        assert_eq!(parsed.len(), 1);
-        assert_eq!(parsed[0].display_name, "ripgrep");
-        assert_eq!(parsed[0].version_hint.as_deref(), Some("14.1.0"));
-        assert_eq!(parsed[0].source, InventorySource::MacosHomebrew);
-
-        std::fs::remove_dir_all(base).unwrap();
-    }
-
-    #[test]
-    fn collect_homebrew_entries_from_roots_leaves_ambiguous_versions_unset() {
-        let (base, cellar, opt) = make_homebrew_formula_roots("ambiguous-version");
-        std::fs::create_dir_all(cellar.join("wget/1.0.0")).unwrap();
-        std::fs::create_dir_all(cellar.join("wget/1.2.0")).unwrap();
-
-        let parsed = collect_homebrew_formula_entries_from_roots(&cellar, &opt);
-
-        assert_eq!(parsed.len(), 1);
-        assert_eq!(parsed[0].display_name, "wget");
-        assert_eq!(parsed[0].version_hint, None);
-
-        std::fs::remove_dir_all(base).unwrap();
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn collect_homebrew_entries_from_roots_prefers_opt_link_version() {
-        let (base, cellar, opt) = make_homebrew_formula_roots("opt-version");
-        let old_version = cellar.join("wget/1.0.0");
-        let active_version = cellar.join("wget/1.2.0");
-        std::fs::create_dir_all(&old_version).unwrap();
-        std::fs::create_dir_all(&active_version).unwrap();
-        std::os::unix::fs::symlink(&active_version, opt.join("wget")).unwrap();
-
-        let parsed = collect_homebrew_formula_entries_from_roots(&cellar, &opt);
-
-        assert_eq!(parsed.len(), 1);
-        assert_eq!(parsed[0].display_name, "wget");
-        assert_eq!(parsed[0].version_hint.as_deref(), Some("1.2.0"));
-
-        std::fs::remove_dir_all(base).unwrap();
-    }
-
-    #[test]
-    fn collect_homebrew_cask_entries_from_root_uses_app_bundle_name_and_version() {
-        let (base, caskroom) = make_homebrew_cask_root("cask-app");
-        std::fs::create_dir_all(caskroom.join("google-chrome/136.0.7103.93/Google Chrome.app"))
-            .unwrap();
-
-        let parsed = collect_homebrew_cask_entries_from_root(&caskroom);
-
-        assert_eq!(parsed.len(), 1);
-        assert_eq!(parsed[0].display_name, "Google Chrome");
-        assert_eq!(parsed[0].version_hint.as_deref(), Some("136.0.7103.93"));
-        assert_eq!(
-            parsed[0].executable_path,
-            caskroom
-                .join("google-chrome/136.0.7103.93/Google Chrome.app")
-                .to_string_lossy()
-        );
-
-        std::fs::remove_dir_all(base).unwrap();
-    }
-
-    #[test]
-    fn collect_homebrew_cask_entries_from_root_falls_back_to_token_without_app_bundle() {
-        let (base, caskroom) = make_homebrew_cask_root("cask-token");
-        std::fs::create_dir_all(caskroom.join("cursor/latest")).unwrap();
-
-        let parsed = collect_homebrew_cask_entries_from_root(&caskroom);
-
-        assert_eq!(parsed.len(), 1);
-        assert_eq!(parsed[0].display_name, "cursor");
-        assert_eq!(parsed[0].version_hint.as_deref(), Some("latest"));
-        assert!(parsed[0].executable_path.is_empty());
-
-        std::fs::remove_dir_all(base).unwrap();
-    }
-
-    #[test]
-    fn collect_homebrew_cask_entries_from_root_skips_ambiguous_versions() {
-        let (base, caskroom) = make_homebrew_cask_root("cask-ambiguous");
-        std::fs::create_dir_all(caskroom.join("firefox/136.0/Firefox.app")).unwrap();
-        std::fs::create_dir_all(caskroom.join("firefox/137.0/Firefox.app")).unwrap();
-
-        let parsed = collect_homebrew_cask_entries_from_root(&caskroom);
-
-        assert!(parsed.is_empty());
-
-        std::fs::remove_dir_all(base).unwrap();
-    }
-
-    #[test]
     fn dpkg_status_requires_ok_installed_state() {
         assert!(dpkg_status_is_installed("install ok installed"));
         assert!(dpkg_status_is_installed("hold ok installed"));
@@ -1066,7 +730,7 @@ mod tests {
     #[test]
     fn parse_apk_installed_collects_maintainer_or_origin() {
         let parsed = parse_apk_installed(
-            "P:busybox\nV:1.36.1-r7\nm:Natanael Copa <ncopa@alpinelinux.org>\n\nP:musl\nV:1.2.5-r1\no:alpine-baselayout\n\n",
+            "P:busybox\nV:1.36.1-r7\nm:Example Maintainer\n\nP:musl\nV:1.2.5-r1\no:example-origin\n\n",
         );
 
         assert_eq!(parsed.len(), 2);
@@ -1074,10 +738,10 @@ mod tests {
         assert_eq!(parsed[0].version_hint.as_deref(), Some("1.36.1-r7"));
         assert_eq!(
             parsed[0].publisher_hint.as_deref(),
-            Some("Natanael Copa <ncopa@alpinelinux.org>")
+            Some("Example Maintainer")
         );
         assert_eq!(parsed[1].display_name, "musl");
-        assert_eq!(parsed[1].publisher_hint.as_deref(), Some("alpine-baselayout"));
+        assert_eq!(parsed[1].publisher_hint.as_deref(), Some("example-origin"));
         assert_eq!(parsed[1].source, InventorySource::LinuxApkInstalled);
     }
 
@@ -1268,7 +932,10 @@ mod tests {
         let inventory = collect_from_entries(entries);
         assert_eq!(inventory.len(), 1);
         assert_eq!(inventory[0].source, InventorySource::LinuxRpmDatabase);
-        assert_eq!(inventory[0].publisher_hint.as_deref(), Some("Fedora Project"));
+        assert_eq!(
+            inventory[0].publisher_hint.as_deref(),
+            Some("Fedora Project")
+        );
         assert_eq!(inventory[0].version_hint.as_deref(), Some("8.8.0-1.fc40"));
         assert_eq!(inventory[0].executable_path, "/usr/bin/curl");
     }
@@ -1300,59 +967,6 @@ mod tests {
         );
         assert_eq!(inventory[0].version_hint.as_deref(), Some("1.36.1-r7"));
         assert_eq!(inventory[0].executable_path, "/bin/busybox");
-    }
-
-    #[test]
-    fn collect_from_entries_keeps_process_path_when_homebrew_metadata_wins() {
-        let entries = vec![
-            seed(
-                "wget",
-                "/opt/homebrew/bin/wget",
-                None,
-                None,
-                InventorySource::RunningProcess,
-            ),
-            seed(
-                "wget",
-                "",
-                None,
-                Some("1.25.0"),
-                InventorySource::MacosHomebrew,
-            ),
-        ];
-        let inventory = collect_from_entries(entries);
-        assert_eq!(inventory.len(), 1);
-        assert_eq!(inventory[0].source, InventorySource::MacosHomebrew);
-        assert_eq!(inventory[0].version_hint.as_deref(), Some("1.25.0"));
-        assert_eq!(inventory[0].executable_path, "/opt/homebrew/bin/wget");
-    }
-
-    #[test]
-    fn collect_from_entries_keeps_process_path_when_homebrew_cask_metadata_wins() {
-        let entries = vec![
-            seed(
-                "Google Chrome",
-                "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-                None,
-                None,
-                InventorySource::RunningProcess,
-            ),
-            seed(
-                "Google Chrome",
-                "",
-                None,
-                Some("136.0.7103.93"),
-                InventorySource::MacosHomebrew,
-            ),
-        ];
-        let inventory = collect_from_entries(entries);
-        assert_eq!(inventory.len(), 1);
-        assert_eq!(inventory[0].source, InventorySource::MacosHomebrew);
-        assert_eq!(inventory[0].version_hint.as_deref(), Some("136.0.7103.93"));
-        assert_eq!(
-            inventory[0].executable_path,
-            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-        );
     }
 
     #[test]

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -316,7 +316,7 @@ fn inner(ui: &mut egui::Ui, draft: &mut SettingsDraft, changed: &mut bool) {
             );
         });
     });
-    ui.label(RichText::new("Watchdog implementation uses the local OS scheduler (Windows Task Scheduler, Linux cron, macOS launchd) and runs the same Vigil binary with --break-glass-recover.").color(theme::TEXT3).size(10.8));
+    ui.label(RichText::new("Watchdog implementation uses the local OS scheduler (Windows Task Scheduler, Linux cron) and runs the same Vigil binary with --break-glass-recover.").color(theme::TEXT3).size(10.8));
 
     ui.add_space(16.0);
     section_header(ui, "Forensics on alert");


### PR DESCRIPTION
## Summary
- Replaces real-looking package-maintainer fixture data in APK parser tests with neutral fictional values (`Example Maintainer` / `example-origin`).
- Removes the remaining unsupported-platform inventory leftovers (Homebrew formula/cask collector, `MacosHomebrew` source variant, related helpers and tests, doc comments).
- Updates the Break-glass recovery wording in Settings to name only Windows Task Scheduler + Linux cron.

## Validation
Commands run:
- `rustfmt --check src/bin/vigil_inventory.rs src/software_inventory.rs src/ui/settings.rs` — clean
- `cargo check` — passes (warnings only, no errors)
- `cargo test --bin vigil_inventory` — 9/9 pass
- `cargo test` — 176 pass, 1 pre-existing failure (`collect_from_entries_prefers_stable_named_entry_for_duplicate_key`) confirmed failing on master before this branch

## Test plan
- [ ] CI passes on the changed files
- [ ] Settings tab still renders the Break-glass label correctly on Windows/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)