### PR TITLE
fix: enforce tag/source_ref commit equality in release workflow dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,11 +85,13 @@ jobs:
             echo "Input version $VERSION did not match tag $REF_NAME" >&2
             exit 1
           fi
+
+          RELEASE_TAG_REF="refs/tags/$REF_NAME"
           CHECKOUT_REF="$INPUT_SOURCE_REF"
           if [ -z "$CHECKOUT_REF" ]; then
-            CHECKOUT_REF="refs/tags/$REF_NAME"
+            CHECKOUT_REF="$RELEASE_TAG_REF"
           elif [ "$CHECKOUT_REF" = "$REF_NAME" ]; then
-            CHECKOUT_REF="refs/tags/$REF_NAME"
+            CHECKOUT_REF="$RELEASE_TAG_REF"
           elif [[ "$CHECKOUT_REF" =~ ^refs/(heads|tags)/[^[:space:]]+$ ]]; then
             :
           elif [[ "$CHECKOUT_REF" =~ ^[0-9a-fA-F]{40}$ ]]; then
@@ -99,6 +101,43 @@ jobs:
             echo "Expected a full refs/heads/... or refs/tags/... value, the exact release tag, or a 40-character commit SHA." >&2
             exit 1
           fi
+
+          resolve_remote_commit() {
+            local ref="$1"
+            local remote_url="https://github.com/${GITHUB_REPOSITORY}.git"
+            if [[ "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              printf '%s\n' "$ref" | tr 'A-F' 'a-f'
+              return 0
+            fi
+            if [[ "$ref" =~ ^refs/tags/ ]]; then
+              local peeled
+              peeled="$(git ls-remote "$remote_url" "${ref}^{}" | awk '{print $1}' | head -n1)"
+              if [ -n "$peeled" ]; then
+                printf '%s\n' "$peeled"
+                return 0
+              fi
+            fi
+            git ls-remote --refs "$remote_url" "$ref" | awk '{print $1}' | head -n1
+          }
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$CHECKOUT_REF" != "$RELEASE_TAG_REF" ]; then
+            TAG_SHA="$(resolve_remote_commit "$RELEASE_TAG_REF")"
+            if [ -z "$TAG_SHA" ]; then
+              echo "Release tag $REF_NAME was not found on remote." >&2
+              exit 1
+            fi
+            SOURCE_SHA="$(resolve_remote_commit "$CHECKOUT_REF")"
+            if [ -z "$SOURCE_SHA" ]; then
+              echo "source_ref $CHECKOUT_REF was not found on remote." >&2
+              exit 1
+            fi
+            if [ "$SOURCE_SHA" != "$TAG_SHA" ]; then
+              echo "source_ref $CHECKOUT_REF resolves to $SOURCE_SHA but $RELEASE_TAG_REF resolves to $TAG_SHA." >&2
+              echo "Release builds must be sourced from the same commit as the release tag." >&2
+              exit 1
+            fi
+          fi
+
           PR_NUMBER="$INPUT_PR_NUMBER"
           if [ -n "$PR_NUMBER" ] && [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
             echo "Invalid pr_number: $PR_NUMBER" >&2


### PR DESCRIPTION
### Motivation
- The `release` workflow allowed a manually-dispatched `source_ref` that could differ from the claimed `tag`/`version`, enabling builds to be published or signed with mismatched provenance. 
- This breaks release integrity by permitting artifacts to be labeled with a tag while being built from a different commit. 
- The change tightly binds the declared release tag/version to the actual checked-out commit to restore provenance guarantees.

### Description
- Introduces a `RELEASE_TAG_REF` helper and normalizes empty or same-tag `source_ref` values to `refs/tags/<tag>` in `/.github/workflows/release.yml`. 
- For `workflow_dispatch` runs where `source_ref` is provided and not equal to the tag, resolves the tag and source ref to SHAs using `git ls-remote` (and normalizes 40-char SHAs) and fails the workflow if the SHAs do not match. 
- Preserves existing input formats and behavior for empty or exact-tag `source_ref` while failing early if the tag or source_ref cannot be resolved or point to different commits.

### Testing
- Parsed the updated workflow YAML with Ruby via `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'ok'"` which succeeded and confirms the file is valid YAML. 
- Attempted to parse with Python `yaml.safe_load` but the run failed due to a missing `PyYAML` module in the environment and not due to the change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f06eae588c832887b36807fe439158)