### PR TITLE
Attempt fail-open recovery when protected break-glass state is missing or fails to load

### DIFF
--- a/src/platform/break_glass.rs
+++ b/src/platform/break_glass.rs
@@ -52,18 +52,20 @@ pub fn recover_if_stale() -> i32 {
         Ok(Some(state)) => state,
         Ok(None) => {
             if active_response::status().isolated {
-                audit::record(
-                    "break_glass_recovery",
-                    "error",
-                    json!({
-                        "reason": "missing protected break-glass state while machine is isolated"
-                    }),
+                return attempt_fail_open_recovery(
+                    "missing protected break-glass state while machine is isolated",
+                    None,
                 );
-                return 1;
             }
             return 0;
         }
         Err(err) => {
+            if active_response::status().isolated {
+                return attempt_fail_open_recovery(
+                    "failed to load protected break-glass state",
+                    Some(err),
+                );
+            }
             audit::record(
                 "break_glass_recovery",
                 "error",
@@ -106,6 +108,38 @@ pub fn recover_if_stale() -> i32 {
                     "error": err,
                     "heartbeat_age_secs": heartbeat_age,
                     "deadline_unix": state.deadline_unix,
+                }),
+            );
+            1
+        }
+    }
+}
+
+fn attempt_fail_open_recovery(reason: &str, error: Option<String>) -> i32 {
+    match active_response::restore_machine() {
+        Ok(message) => {
+            audit::record(
+                "break_glass_recovery",
+                "success",
+                json!({
+                    "message": message,
+                    "reason": reason,
+                    "error": error,
+                    "fail_open_path": true,
+                }),
+            );
+            let _ = disarm();
+            0
+        }
+        Err(restore_err) => {
+            audit::record(
+                "break_glass_recovery",
+                "error",
+                json!({
+                    "reason": reason,
+                    "error": error,
+                    "restore_error": restore_err,
+                    "fail_open_path": true,
                 }),
             );
             1


### PR DESCRIPTION
### Motivation
- Ensure an isolated machine can recover when the protected break-glass state is missing or cannot be loaded to avoid permanently locking the machine.
- Consolidate the fail-open recovery path and produce richer audit records that include the failure reason and path taken.

### Description
- Add a new helper `attempt_fail_open_recovery(reason: &str, error: Option<String>) -> i32` that attempts `active_response::restore_machine()` and records success or error with `fail_open_path: true` in the audit payload and disarms on success.
- Update `recover_if_stale()` to call `attempt_fail_open_recovery()` and return its result when the machine is isolated and the protected state is missing or failed to load, instead of only logging an audit error and returning `1`.
- Enhance audit payloads in the new fail-open path to include the `reason`, original `error`, and `fail_open_path` flag for clearer diagnostics.

### Testing
- Ran `cargo build` to ensure the code compiles successfully and the build passed.
- Ran `cargo test` against the test suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc502cbb508328b94f2c45e84b6b84)