### PR TITLE
Fix version comparison edge cases for SemVer prereleases and RPM caret snapshots

### DIFF
--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -1207,14 +1207,8 @@ mod tests {
             inventory[0].publisher_hint.as_deref(),
             Some("Debian curl maintainers")
         );
-        assert_eq!(
-            inventory[0].vendor_key.as_deref(),
-            Some("debian-curl")
-        );
-        assert_eq!(
-            inventory[0].product_aliases,
-            vec!["curl".to_string()]
-        );
+        assert_eq!(inventory[0].vendor_key.as_deref(), Some("debian-curl"));
+        assert_eq!(inventory[0].product_aliases, vec!["curl".to_string()]);
         assert_eq!(inventory[0].version_hint.as_deref(), Some("8.8.0-1"));
         assert_eq!(inventory[0].executable_path, "/usr/bin/curl");
     }

--- a/src/version_compare.rs
+++ b/src/version_compare.rs
@@ -69,12 +69,18 @@ pub fn version_in_range(
         return None;
     }
 
-    if let Some(start_including) = range.start_including.filter(|value| !value.trim().is_empty()) {
+    if let Some(start_including) = range
+        .start_including
+        .filter(|value| !value.trim().is_empty())
+    {
         if compare_versions(installed_version, start_including, scheme)? == Ordering::Less {
             return Some(false);
         }
     }
-    if let Some(start_excluding) = range.start_excluding.filter(|value| !value.trim().is_empty()) {
+    if let Some(start_excluding) = range
+        .start_excluding
+        .filter(|value| !value.trim().is_empty())
+    {
         let ordering = compare_versions(installed_version, start_excluding, scheme)?;
         if matches!(ordering, Ordering::Less | Ordering::Equal) {
             return Some(false);
@@ -156,7 +162,10 @@ fn detect_default_scheme(installed_version: &str) -> VersionScheme {
 
 fn looks_like_semver(value: &str) -> bool {
     let trimmed = value.trim_start_matches(['v', 'V']);
-    let core = trimmed.split_once('+').map(|(core, _)| core).unwrap_or(trimmed);
+    let core = trimmed
+        .split_once('+')
+        .map(|(core, _)| core)
+        .unwrap_or(trimmed);
     let core = core.split_once('-').map(|(core, _)| core).unwrap_or(core);
     let mut saw_digit = false;
     let mut saw_dot = false;

--- a/src/version_compare.rs
+++ b/src/version_compare.rs
@@ -267,7 +267,8 @@ fn compare_debian_part(left: &str, right: &str) -> Ordering {
     let right_bytes = right.as_bytes();
 
     while left_idx < left_bytes.len() || right_idx < right_bytes.len() {
-        let left_non_digits_end = advance_while(left_bytes, left_idx, |byte| !byte.is_ascii_digit());
+        let left_non_digits_end =
+            advance_while(left_bytes, left_idx, |byte| !byte.is_ascii_digit());
         let right_non_digits_end =
             advance_while(right_bytes, right_idx, |byte| !byte.is_ascii_digit());
         let ordering = compare_debian_non_digit_part(
@@ -300,7 +301,8 @@ fn compare_debian_non_digit_part(left: &str, right: &str) -> Ordering {
     let mut left_chars = left.chars();
     let mut right_chars = right.chars();
     loop {
-        let ordering = debian_char_order(left_chars.next()).cmp(&debian_char_order(right_chars.next()));
+        let ordering =
+            debian_char_order(left_chars.next()).cmp(&debian_char_order(right_chars.next()));
         if ordering != Ordering::Equal {
             return ordering;
         }
@@ -617,11 +619,19 @@ mod tests {
     #[test]
     fn semver_prerelease_hyphen_stays_inside_identifier() {
         assert_eq!(
-            compare_versions("1.0.0-a-b", "1.0.0-a.b", VersionScheme::SemverLike),
+            compare_versions(
+                "1.0.0-a-b",
+                "1.0.0-a.b",
+                VersionScheme::SemverLike,
+            ),
             Some(Ordering::Greater)
         );
         assert_eq!(
-            compare_versions("1.0.0-alpha-beta", "1.0.0-alpha-beta", VersionScheme::SemverLike),
+            compare_versions(
+                "1.0.0-alpha-beta",
+                "1.0.0-alpha-beta",
+                VersionScheme::SemverLike,
+            ),
             Some(Ordering::Equal)
         );
     }

--- a/src/version_compare.rs
+++ b/src/version_compare.rs
@@ -628,11 +628,7 @@ mod tests {
     #[test]
     fn semver_prerelease_hyphen_stays_inside_identifier() {
         assert_eq!(
-            compare_versions(
-                "1.0.0-a-b",
-                "1.0.0-a.b",
-                VersionScheme::SemverLike,
-            ),
+            compare_versions("1.0.0-a-b", "1.0.0-a.b", VersionScheme::SemverLike,),
             Some(Ordering::Greater)
         );
         assert_eq!(

--- a/src/version_compare.rs
+++ b/src/version_compare.rs
@@ -200,14 +200,8 @@ fn split_semver_parts(value: &str) -> (&str, Option<&str>) {
 }
 
 fn compare_semver_prerelease(left: &str, right: &str) -> Ordering {
-    let left_parts: Vec<&str> = left
-        .split(['.', '-', '_'])
-        .filter(|part| !part.is_empty())
-        .collect();
-    let right_parts: Vec<&str> = right
-        .split(['.', '-', '_'])
-        .filter(|part| !part.is_empty())
-        .collect();
+    let left_parts: Vec<&str> = left.split('.').filter(|part| !part.is_empty()).collect();
+    let right_parts: Vec<&str> = right.split('.').filter(|part| !part.is_empty()).collect();
     let len = left_parts.len().max(right_parts.len());
     for idx in 0..len {
         match (left_parts.get(idx), right_parts.get(idx)) {
@@ -373,6 +367,29 @@ fn compare_rpm_part(left: &str, right: &str) -> Ordering {
             (None, None) => {}
         }
 
+        match (left.strip_prefix('^'), right.strip_prefix('^')) {
+            (Some(rest), Some(other_rest)) => {
+                left = rest;
+                right = other_rest;
+                continue;
+            }
+            (Some(_), None) => {
+                return if right.is_empty() {
+                    Ordering::Greater
+                } else {
+                    Ordering::Less
+                }
+            }
+            (None, Some(_)) => {
+                return if left.is_empty() {
+                    Ordering::Less
+                } else {
+                    Ordering::Greater
+                }
+            }
+            (None, None) => {}
+        }
+
         if left.is_empty() || right.is_empty() {
             return left.is_empty().cmp(&right.is_empty()).reverse();
         }
@@ -402,7 +419,7 @@ fn compare_rpm_part(left: &str, right: &str) -> Ordering {
 }
 
 fn skip_rpm_separators(value: &str) -> &str {
-    value.trim_start_matches(|ch: char| !ch.is_ascii_alphanumeric() && ch != '~')
+    value.trim_start_matches(|ch: char| !ch.is_ascii_alphanumeric() && ch != '~' && ch != '^')
 }
 
 fn next_rpm_segment(value: &str) -> Option<(bool, &str, &str)> {
@@ -598,6 +615,18 @@ mod tests {
     }
 
     #[test]
+    fn semver_prerelease_hyphen_stays_inside_identifier() {
+        assert_eq!(
+            compare_versions("1.0.0-a-b", "1.0.0-a.b", VersionScheme::SemverLike),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            compare_versions("1.0.0-alpha-beta", "1.0.0-alpha-beta", VersionScheme::SemverLike),
+            Some(Ordering::Equal)
+        );
+    }
+
+    #[test]
     fn debian_versions_handle_epoch_and_tilde() {
         assert_eq!(
             compare_versions("1.0~beta1", "1.0", VersionScheme::Debian),
@@ -617,6 +646,18 @@ mod tests {
         );
         assert_eq!(
             compare_versions("0:1.0a-1", "0:1.0b-1", VersionScheme::Rpm),
+            Some(Ordering::Less)
+        );
+    }
+
+    #[test]
+    fn rpm_versions_place_caret_snapshots_between_base_and_next_release() {
+        assert_eq!(
+            compare_versions("2.0^20250611", "2.0", VersionScheme::Rpm),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            compare_versions("2.0^20250611", "2.0.1", VersionScheme::Rpm),
             Some(Ordering::Less)
         );
     }


### PR DESCRIPTION
## Summary
- treat SemVer prerelease identifiers as dot-separated so hyphens stay inside a single identifier
- handle RPM `^` snapshot ordering so snapshot builds sort after the base release but before the next release
- add focused unit tests for both cases to keep the version-matching foundation conservative and auditable

## Why this follow-up
PR #220 merged the Phase 16 version comparison foundation, then later received two concrete review findings that point to incorrect ordering results. This PR addresses only those correctness issues and stays within the existing version comparison scope.

## Validation
- added unit tests covering `1.0.0-a-b` vs `1.0.0-a.b`
- added unit tests covering `2.0^20250611` vs `2.0` and `2.0.1`
- could not run Rust tests in this scheduled-run container because `cargo` and `rustc` are not installed here, so repository CI still needs to exercise the new tests
