### PR TITLE
Add advisory match status CLI for protected cache inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ vigil --advisory-cache-status
 vigil --advisory-change-history-status
 ```
 
+After the protected software inventory snapshot and protected advisory cache both
+exist locally, print explainable product-to-advisory matches with:
+
+```bash
+vigil --advisory-match-status
+```
+
 Use `--sync-nvd --force` only when you need to override the normal 2-hour
 minimum interval. Provide an API key via `VIGIL_NVD_API_KEY` if the deployment
 needs higher NVD API headroom.

--- a/src/advisory_match_status.rs
+++ b/src/advisory_match_status.rs
@@ -65,7 +65,11 @@ pub fn run_cli() -> Result<(), String> {
     );
 
     for product in &product_matches {
-        let applicable = product.matches.iter().filter(|record| record.applies).count();
+        let applicable = product
+            .matches
+            .iter()
+            .filter(|record| record.applies)
+            .count();
         let version = product
             .installed
             .version_hint
@@ -136,7 +140,11 @@ fn collect_product_matches(
             .count()
             .cmp(&left.matches.iter().filter(|record| record.applies).count())
             .then_with(|| right.matches.len().cmp(&left.matches.len()))
-            .then_with(|| left.installed.display_name.cmp(&right.installed.display_name))
+            .then_with(|| {
+                left.installed
+                    .display_name
+                    .cmp(&right.installed.display_name)
+            })
             .then_with(|| left.installed.product_key.cmp(&right.installed.product_key))
     });
     product_matches
@@ -403,7 +411,10 @@ mod tests {
         assert_eq!(matches[0].matches.len(), 1);
         assert_eq!(matches[0].matches[0].matched_alias, "google-chrome");
         assert_eq!(matches[0].matches[0].confidence, MatchConfidence::High);
-        assert_eq!(matches[0].matches[0].version_status, VersionMatchStatus::Exact);
+        assert_eq!(
+            matches[0].matches[0].version_status,
+            VersionMatchStatus::Exact
+        );
         assert!(matches[0].matches[0].applies);
     }
 

--- a/src/advisory_match_status.rs
+++ b/src/advisory_match_status.rs
@@ -1,7 +1,7 @@
 use crate::advisory::{AdvisoryCache, AffectedProduct, VulnerabilityRecord};
 use crate::advisory_match::{
-    evaluate_cpe23_product_match, AffectedProductRef, CpeProductMatch, InstalledProductRef,
-    MatchConfidence, VersionMatchStatus,
+    evaluate_cpe23_product_match, AffectedProductRef, InstalledProductRef, MatchConfidence,
+    VersionMatchStatus,
 };
 use crate::software_inventory::{InstalledSoftware, InventorySource};
 use crate::storage::{InventoryStore, ProtectedJsonInventoryStore};
@@ -148,7 +148,10 @@ fn sort_record_matches(mut matches: Vec<RecordAdvisoryMatch>) -> Vec<RecordAdvis
             .known_exploited
             .cmp(&left.known_exploited)
             .then_with(|| right.applies.cmp(&left.applies))
-            .then_with(|| match_rank(&right.confidence, right.version_status).cmp(&match_rank(&left.confidence, left.version_status)))
+            .then_with(|| {
+                match_rank(right.confidence, right.version_status)
+                    .cmp(&match_rank(left.confidence, left.version_status))
+            })
             .then_with(|| left.primary_id.cmp(&right.primary_id))
     });
     matches
@@ -172,7 +175,7 @@ fn best_record_match(
         .filter_map(|affected| {
             evaluate_cpe23_product_match(&installed_ref, &affected_product_ref(affected))
         })
-        .max_by_key(|matched| match_rank(&matched.confidence, matched.version_status))?;
+        .max_by_key(|matched| match_rank(matched.confidence, matched.version_status))?;
 
     Some(RecordAdvisoryMatch {
         primary_id: record.primary_id.clone(),
@@ -199,13 +202,15 @@ fn affected_product_ref<'a>(affected: &'a AffectedProduct) -> AffectedProductRef
     }
 }
 
-fn match_rank(confidence: &MatchConfidence, version_status: VersionMatchStatus) -> (u8, u8, u8) {
+fn match_rank(confidence: MatchConfidence, version_status: VersionMatchStatus) -> (u8, u8, u8) {
     (
         u8::from(matches!(
             version_status,
-            VersionMatchStatus::Exact | VersionMatchStatus::InRange | VersionMatchStatus::NoConstraint
+            VersionMatchStatus::Exact
+                | VersionMatchStatus::InRange
+                | VersionMatchStatus::NoConstraint
         )),
-        confidence_rank(*confidence),
+        confidence_rank(confidence),
         version_status_rank(version_status),
     )
 }
@@ -433,7 +438,10 @@ mod tests {
         let matches = collect_product_matches(&inventory, &cache);
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].matches[0].primary_id, "CVE-2026-9999");
-        assert_eq!(matches[0].matches[0].version_status, VersionMatchStatus::OutOfRange);
+        assert_eq!(
+            matches[0].matches[0].version_status,
+            VersionMatchStatus::OutOfRange
+        );
         assert!(!matches[0].matches[0].applies);
     }
 

--- a/src/advisory_match_status.rs
+++ b/src/advisory_match_status.rs
@@ -1,0 +1,459 @@
+use crate::advisory::{AdvisoryCache, AffectedProduct, VulnerabilityRecord};
+use crate::advisory_match::{
+    evaluate_cpe23_product_match, AffectedProductRef, CpeProductMatch, InstalledProductRef,
+    MatchConfidence, VersionMatchStatus,
+};
+use crate::software_inventory::{InstalledSoftware, InventorySource};
+use crate::storage::{InventoryStore, ProtectedJsonInventoryStore};
+use crate::version_compare::VersionSource;
+use std::path::PathBuf;
+
+const ADVISORY_CACHE_FILE: &str = "vigil-advisory-cache.json";
+const ADVISORY_CACHE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProductAdvisoryMatch {
+    installed: InstalledSoftware,
+    matches: Vec<RecordAdvisoryMatch>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RecordAdvisoryMatch {
+    primary_id: String,
+    summary: String,
+    source_kind: String,
+    known_exploited: bool,
+    cpe_uri: String,
+    matched_alias: String,
+    confidence: MatchConfidence,
+    version_status: VersionMatchStatus,
+    applies: bool,
+}
+
+pub fn run_cli() -> Result<(), String> {
+    let inventory = ProtectedJsonInventoryStore::new_default().load_inventory()?;
+    if inventory.is_empty() {
+        println!(
+            "Advisory match status: unavailable (no protected software inventory snapshot found)."
+        );
+        return Ok(());
+    }
+
+    let Some(cache) = load_advisory_cache()? else {
+        println!("Advisory match status: unavailable (no protected advisory cache found).");
+        return Ok(());
+    };
+
+    let product_matches = collect_product_matches(&inventory, &cache);
+    let matched_records = product_matches
+        .iter()
+        .map(|product| product.matches.len())
+        .sum::<usize>();
+    let applicable_records = product_matches
+        .iter()
+        .flat_map(|product| product.matches.iter())
+        .filter(|record| record.applies)
+        .count();
+
+    println!(
+        "Advisory match status: {} installed products, {} advisory records, {} matched products, {} matched advisories ({} applicable).",
+        inventory.len(),
+        cache.records.len(),
+        product_matches.len(),
+        matched_records,
+        applicable_records
+    );
+
+    for product in &product_matches {
+        let applicable = product.matches.iter().filter(|record| record.applies).count();
+        let version = product
+            .installed
+            .version_hint
+            .as_deref()
+            .unwrap_or("unknown");
+        println!(
+            "- {} [{}] version={} matches={} applicable={}",
+            product.installed.display_name,
+            inventory_source_label(product.installed.source),
+            version,
+            product.matches.len(),
+            applicable
+        );
+        println!(
+            "  product_key={} aliases={}",
+            product.installed.product_key,
+            product.installed.product_aliases.join(", ")
+        );
+        for record in &product.matches {
+            println!(
+                "  - {} [{}] confidence={} version={} applies={} alias={}",
+                record.primary_id,
+                record.source_kind,
+                confidence_label(record.confidence),
+                version_status_label(record.version_status),
+                yes_no(record.applies),
+                record.matched_alias
+            );
+            if record.known_exploited {
+                println!("    known_exploited=yes");
+            }
+            println!("    cpe={}", record.cpe_uri);
+            println!("    summary={}", condense_summary(&record.summary));
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_product_matches(
+    inventory: &[InstalledSoftware],
+    cache: &AdvisoryCache,
+) -> Vec<ProductAdvisoryMatch> {
+    let mut product_matches = inventory
+        .iter()
+        .filter_map(|installed| {
+            let matches = cache
+                .records
+                .iter()
+                .filter_map(|record| best_record_match(installed, record))
+                .collect::<Vec<_>>();
+            if matches.is_empty() {
+                None
+            } else {
+                Some(ProductAdvisoryMatch {
+                    installed: installed.clone(),
+                    matches: sort_record_matches(matches),
+                })
+            }
+        })
+        .collect::<Vec<_>>();
+
+    product_matches.sort_by(|left, right| {
+        right
+            .matches
+            .iter()
+            .filter(|record| record.applies)
+            .count()
+            .cmp(&left.matches.iter().filter(|record| record.applies).count())
+            .then_with(|| right.matches.len().cmp(&left.matches.len()))
+            .then_with(|| left.installed.display_name.cmp(&right.installed.display_name))
+            .then_with(|| left.installed.product_key.cmp(&right.installed.product_key))
+    });
+    product_matches
+}
+
+fn sort_record_matches(mut matches: Vec<RecordAdvisoryMatch>) -> Vec<RecordAdvisoryMatch> {
+    matches.sort_by(|left, right| {
+        right
+            .known_exploited
+            .cmp(&left.known_exploited)
+            .then_with(|| right.applies.cmp(&left.applies))
+            .then_with(|| match_rank(&right.confidence, right.version_status).cmp(&match_rank(&left.confidence, left.version_status)))
+            .then_with(|| left.primary_id.cmp(&right.primary_id))
+    });
+    matches
+}
+
+fn best_record_match(
+    installed: &InstalledSoftware,
+    record: &VulnerabilityRecord,
+) -> Option<RecordAdvisoryMatch> {
+    let installed_ref = InstalledProductRef {
+        product_key: &installed.product_key,
+        product_aliases: &installed.product_aliases,
+        vendor_key: installed.vendor_key.as_deref(),
+        version_hint: installed.version_hint.as_deref(),
+        version_source: version_source_for_inventory(installed.source),
+    };
+
+    let best = record
+        .affected_products
+        .iter()
+        .filter_map(|affected| {
+            evaluate_cpe23_product_match(&installed_ref, &affected_product_ref(affected))
+        })
+        .max_by_key(|matched| match_rank(&matched.confidence, matched.version_status))?;
+
+    Some(RecordAdvisoryMatch {
+        primary_id: record.primary_id.clone(),
+        summary: record.summary.clone(),
+        source_kind: record.provenance.source_kind.clone(),
+        known_exploited: record.known_exploited,
+        cpe_uri: best.cpe_uri,
+        matched_alias: best.matched_alias,
+        confidence: best.confidence,
+        version_status: best.version_status,
+        applies: best.applies,
+    })
+}
+
+fn affected_product_ref<'a>(affected: &'a AffectedProduct) -> AffectedProductRef<'a> {
+    AffectedProductRef {
+        criteria: &affected.criteria,
+        cpe_name: affected.cpe_name.as_deref(),
+        vulnerable: affected.vulnerable,
+        version_start_including: affected.version_start_including.as_deref(),
+        version_start_excluding: affected.version_start_excluding.as_deref(),
+        version_end_including: affected.version_end_including.as_deref(),
+        version_end_excluding: affected.version_end_excluding.as_deref(),
+    }
+}
+
+fn match_rank(confidence: &MatchConfidence, version_status: VersionMatchStatus) -> (u8, u8, u8) {
+    (
+        u8::from(matches!(
+            version_status,
+            VersionMatchStatus::Exact | VersionMatchStatus::InRange | VersionMatchStatus::NoConstraint
+        )),
+        confidence_rank(*confidence),
+        version_status_rank(version_status),
+    )
+}
+
+fn confidence_rank(confidence: MatchConfidence) -> u8 {
+    match confidence {
+        MatchConfidence::High => 2,
+        MatchConfidence::Medium => 1,
+    }
+}
+
+fn version_status_rank(status: VersionMatchStatus) -> u8 {
+    match status {
+        VersionMatchStatus::Exact => 6,
+        VersionMatchStatus::InRange => 5,
+        VersionMatchStatus::NoConstraint => 4,
+        VersionMatchStatus::MissingInstalledVersion => 3,
+        VersionMatchStatus::Unknown => 2,
+        VersionMatchStatus::OutOfRange => 1,
+    }
+}
+
+fn version_source_for_inventory(source: InventorySource) -> VersionSource {
+    match source {
+        InventorySource::LinuxDpkgStatus => VersionSource::DebianPackage,
+        InventorySource::LinuxRpmDatabase => VersionSource::RpmPackage,
+        InventorySource::LinuxApkInstalled => VersionSource::AlpinePackage,
+        InventorySource::RunningProcess
+        | InventorySource::WindowsUninstallRegistry
+        | InventorySource::RunningService => VersionSource::Default,
+    }
+}
+
+fn load_advisory_cache() -> Result<Option<AdvisoryCache>, String> {
+    let path = advisory_cache_path();
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let loaded: Option<AdvisoryCache> = crate::security::policy::load_struct_with_integrity(&path)
+        .map_err(|err| {
+            format!(
+                "failed to load protected advisory cache {}: {err}",
+                path.display()
+            )
+        })?;
+    let Some(cache) = loaded else {
+        return Ok(None);
+    };
+    if cache.schema_version != ADVISORY_CACHE_SCHEMA_VERSION {
+        return Err(format!(
+            "protected advisory cache {} used unsupported schema version {}",
+            path.display(),
+            cache.schema_version
+        ));
+    }
+    Ok(Some(cache))
+}
+
+fn advisory_cache_path() -> PathBuf {
+    crate::config::data_dir().join(ADVISORY_CACHE_FILE)
+}
+
+fn inventory_source_label(source: InventorySource) -> &'static str {
+    match source {
+        InventorySource::RunningProcess => "running-process",
+        InventorySource::LinuxDpkgStatus => "linux-dpkg-status",
+        InventorySource::LinuxRpmDatabase => "linux-rpm-database",
+        InventorySource::LinuxApkInstalled => "linux-apk-installed",
+        InventorySource::WindowsUninstallRegistry => "windows-uninstall-registry",
+        InventorySource::RunningService => "running-service",
+    }
+}
+
+fn confidence_label(confidence: MatchConfidence) -> &'static str {
+    match confidence {
+        MatchConfidence::High => "high",
+        MatchConfidence::Medium => "medium",
+    }
+}
+
+fn version_status_label(status: VersionMatchStatus) -> &'static str {
+    match status {
+        VersionMatchStatus::Exact => "exact",
+        VersionMatchStatus::InRange => "in_range",
+        VersionMatchStatus::NoConstraint => "no_constraint",
+        VersionMatchStatus::MissingInstalledVersion => "missing_installed_version",
+        VersionMatchStatus::OutOfRange => "out_of_range",
+        VersionMatchStatus::Unknown => "unknown",
+    }
+}
+
+fn yes_no(value: bool) -> &'static str {
+    if value {
+        "yes"
+    } else {
+        "no"
+    }
+}
+
+fn condense_summary(summary: &str) -> String {
+    summary.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::advisory::{AffectedProduct, VulnerabilityProvenance};
+
+    fn installed(
+        product_key: &str,
+        display_name: &str,
+        vendor_key: Option<&str>,
+        version_hint: Option<&str>,
+        aliases: &[&str],
+        source: InventorySource,
+    ) -> InstalledSoftware {
+        InstalledSoftware {
+            product_key: product_key.into(),
+            display_name: display_name.into(),
+            executable_path: String::new(),
+            publisher_hint: None,
+            version_hint: version_hint.map(str::to_string),
+            product_aliases: aliases.iter().map(|alias| (*alias).to_string()).collect(),
+            vendor_key: vendor_key.map(str::to_string),
+            source,
+        }
+    }
+
+    fn record(
+        primary_id: &str,
+        summary: &str,
+        known_exploited: bool,
+        affected_products: Vec<AffectedProduct>,
+    ) -> VulnerabilityRecord {
+        VulnerabilityRecord {
+            primary_id: primary_id.into(),
+            summary: summary.into(),
+            known_exploited,
+            affected_products,
+            provenance: VulnerabilityProvenance {
+                source_kind: "nvd".into(),
+                source_key: "nvd-cve".into(),
+                source_url: "https://services.nvd.nist.gov/rest/json/cves/2.0".into(),
+                imported_unix: 0,
+            },
+            ..VulnerabilityRecord::default()
+        }
+    }
+
+    fn affected(criteria: &str, cpe_name: Option<&str>) -> AffectedProduct {
+        AffectedProduct {
+            criteria: criteria.into(),
+            cpe_name: cpe_name.map(str::to_string),
+            vulnerable: true,
+            ..AffectedProduct::default()
+        }
+    }
+
+    #[test]
+    fn collect_product_matches_prefers_higher_confidence_match_for_same_record() {
+        let inventory = vec![installed(
+            "google-chrome",
+            "Google Chrome",
+            Some("google"),
+            Some("124.0.6367.91"),
+            &["chrome", "google-chrome"],
+            InventorySource::RunningProcess,
+        )];
+        let cache = AdvisoryCache {
+            schema_version: 1,
+            generated_unix: 0,
+            sources: vec![],
+            records: vec![record(
+                "CVE-2026-12345",
+                "Example Chrome issue",
+                false,
+                vec![
+                    affected("cpe:2.3:a:haxx:chrome:*:*:*:*:*:*:*:*", None),
+                    affected(
+                        "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
+                        Some("cpe:2.3:a:google:chrome:124.0.6367.91:*:*:*:*:*:*:*"),
+                    ),
+                ],
+            )],
+        };
+
+        let matches = collect_product_matches(&inventory, &cache);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].matches.len(), 1);
+        assert_eq!(matches[0].matches[0].matched_alias, "google-chrome");
+        assert_eq!(matches[0].matches[0].confidence, MatchConfidence::High);
+        assert_eq!(matches[0].matches[0].version_status, VersionMatchStatus::Exact);
+        assert!(matches[0].matches[0].applies);
+    }
+
+    #[test]
+    fn collect_product_matches_keeps_non_applicable_matches_explainable() {
+        let inventory = vec![installed(
+            "curl",
+            "curl",
+            Some("fedora"),
+            Some("8.8.0-1.fc40"),
+            &["curl", "fedora-curl"],
+            InventorySource::LinuxRpmDatabase,
+        )];
+        let cache = AdvisoryCache {
+            schema_version: 1,
+            generated_unix: 0,
+            sources: vec![],
+            records: vec![record(
+                "CVE-2026-9999",
+                "Out of range curl issue",
+                true,
+                vec![AffectedProduct {
+                    criteria: "cpe:2.3:a:haxx:curl:*:*:*:*:*:*:*:*".into(),
+                    vulnerable: true,
+                    version_start_including: Some("9.0.0-1.fc40".into()),
+                    version_end_excluding: Some("9.1.0-1.fc40".into()),
+                    ..AffectedProduct::default()
+                }],
+            )],
+        };
+
+        let matches = collect_product_matches(&inventory, &cache);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].matches[0].primary_id, "CVE-2026-9999");
+        assert_eq!(matches[0].matches[0].version_status, VersionMatchStatus::OutOfRange);
+        assert!(!matches[0].matches[0].applies);
+    }
+
+    #[test]
+    fn version_source_for_inventory_maps_package_formats() {
+        assert_eq!(
+            version_source_for_inventory(InventorySource::LinuxDpkgStatus),
+            VersionSource::DebianPackage
+        );
+        assert_eq!(
+            version_source_for_inventory(InventorySource::LinuxRpmDatabase),
+            VersionSource::RpmPackage
+        );
+        assert_eq!(
+            version_source_for_inventory(InventorySource::LinuxApkInstalled),
+            VersionSource::AlpinePackage
+        );
+        assert_eq!(
+            version_source_for_inventory(InventorySource::RunningProcess),
+            VersionSource::Default
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@
 
 mod advisory;
 mod advisory_history;
+mod advisory_match;
+mod advisory_match_status;
 mod advisory_ncsc_bsi;
 mod advisory_public_sources;
 mod advisory_status;
@@ -47,6 +49,7 @@ mod tls;
 mod tls_artifacts;
 mod types;
 mod ui;
+mod version_compare;
 
 pub use platform::{autostart, break_glass, service, tray};
 pub use security::{
@@ -282,6 +285,16 @@ fn main() {
         }
     }
 
+    if args.iter().any(|a| a == "--advisory-match-status") {
+        match advisory_match_status::run_cli() {
+            Ok(()) => std::process::exit(0),
+            Err(err) => {
+                eprintln!("{err}");
+                std::process::exit(1);
+            }
+        }
+    }
+
     if let Some(idx) = args.iter().position(|a| a == "--sync-nvd") {
         let force = args
             .iter()
@@ -495,7 +508,7 @@ fn main() {
                 i += 1;
             }
             "--help" | "-h" => {
-                println!("Vigil v{} — real-time network threat monitor\n\nUsage:  vigil [flags]\n\nFlags:\n  --install-service              register Vigil as a boot-time service\n  --uninstall-service            remove the boot-time service\n  --break-glass-recover          watchdog entrypoint for network recovery\n  --verify-update-manifest       MANIFEST SIG\n                                 verify a signed release manifest against the embedded trust anchor\n  --import-nvd-snapshot          SNAPSHOT.json [MORE.json ...]\n                                 import or merge one or more NVD CVE JSON snapshots into the protected advisory cache\n  --sync-nvd [--force]           fetch or incrementally refresh the protected NVD CVE cache from the live API\n  --advisory-cache-status        show advisory cache status and source health\n  --import-nvd-change-history    SNAPSHOT.json [MORE.json ...]\n                                 import or merge one or more NVD CVE change-history JSON snapshots into the protected change-history cache\n  --sync-nvd-change-history [--force]\n                                 fetch or incrementally refresh the protected NVD CVE change-history cache from the live API\n  --advisory-change-history-status\n                                 show NVD change-history cache status and source health\n  --import-euvd                  SNAPSHOT.json [MORE.json ...]\n                                 import or merge one or more operator-supplied EUVD JSON snapshots into the protected advisory cache\n  --import-jvn                   SNAPSHOT.json|RSS.xml [MORE ...]\n                                 import or merge one or more JVN / JVN iPedia JSON or JVNDBRSS XML snapshots into the protected advisory cache\n  --import-ncsc                  SNAPSHOT.json|RSS.xml [MORE ...]\n                                 import or merge one or more NCSC public advisory RSS or mirrored JSON snapshots into the protected advisory cache\n  --import-bsi                   SNAPSHOT.json|RSS.xml [MORE ...]\n                                 import or merge one or more BSI or CERT-Bund public advisory RSS or mirrored JSON snapshots into the protected advisory cache\n  --service-mode                 internal headless service entrypoint\n  --data-dir PATH                override Vigil data/config directory\n  -h, --help                     show this help and exit\n\nRun with no flags to launch the GUI.", env!("CARGO_PKG_VERSION"));
+                println!("Vigil v{} — real-time network threat monitor\n\nUsage:  vigil [flags]\n\nFlags:\n  --install-service              register Vigil as a boot-time service\n  --uninstall-service            remove the boot-time service\n  --break-glass-recover          watchdog entrypoint for network recovery\n  --verify-update-manifest       MANIFEST SIG\n                                 verify a signed release manifest against the embedded trust anchor\n  --import-nvd-snapshot          SNAPSHOT.json [MORE.json ...]\n                                 import or merge one or more NVD CVE JSON snapshots into the protected advisory cache\n  --sync-nvd [--force]           fetch or incrementally refresh the protected NVD CVE cache from the live API\n  --advisory-cache-status        show advisory cache status and source health\n  --import-nvd-change-history    SNAPSHOT.json [MORE.json ...]\n                                 import or merge one or more NVD CVE change-history JSON snapshots into the protected change-history cache\n  --sync-nvd-change-history [--force]\n                                 fetch or incrementally refresh the protected NVD CVE change-history cache from the live API\n  --advisory-change-history-status\n                                 show NVD change-history cache status and source health\n  --advisory-match-status        join the protected software inventory with the advisory cache\n                                 and print explainable local matches\n  --import-euvd                  SNAPSHOT.json [MORE.json ...]\n                                 import or merge one or more operator-supplied EUVD JSON snapshots into the protected advisory cache\n  --import-jvn                   SNAPSHOT.json|RSS.xml [MORE ...]\n                                 import or merge one or more JVN / JVN iPedia JSON or JVNDBRSS XML snapshots into the protected advisory cache\n  --import-ncsc                  SNAPSHOT.json|RSS.xml [MORE ...]\n                                 import or merge one or more NCSC public advisory RSS or mirrored JSON snapshots into the protected advisory cache\n  --import-bsi                   SNAPSHOT.json|RSS.xml [MORE ...]\n                                 import or merge one or more BSI or CERT-Bund public advisory RSS or mirrored JSON snapshots into the protected advisory cache\n  --service-mode                 internal headless service entrypoint\n  --data-dir PATH                override Vigil data/config directory\n  -h, --help                     show this help and exit\n\nRun with no flags to launch the GUI.", env!("CARGO_PKG_VERSION"));
                 std::process::exit(0);
             }
             _ => {}


### PR DESCRIPTION
## Summary
- wire the recently added advisory matching foundation into the main binary and expose it through a new `vigil --advisory-match-status` command
- add a read-only Phase 16 helper that joins the protected software inventory snapshot with the protected advisory cache and prints explainable product-to-advisory matches
- document the new CLI in `README.md`

## Why this task
PR #223 completed the low-level CPE/product evaluator but left it unused. The roadmap still shows `CPE / product matching pipeline` as the next unfinished dependency in Phase 16, and the smallest safe in-scope slice after that foundation is to make the protected caches joinable in a read-only, operator-visible way before guessing any Inspector UI, scoring, or response behavior.

## Validation
- added focused unit tests for best-match selection, conservative non-applicable matches, and package-version source mapping in `src/advisory_match_status.rs`
- could not run `cargo fmt`, `cargo clippy`, or `cargo test` in this scheduled-run environment because Rust tooling is not installed here, so CI still needs to compile and exercise the new code path

## Notes
- this does not mark the roadmap item complete yet: it surfaces explainable cache joins, but it does not yet correlate live connections back to installed software or integrate matches into the existing Inspector and Alerts workflows
