### PR TITLE
Harden break-glass recovery against state-tamper fail-open

### DIFF
--- a/src/platform/break_glass.rs
+++ b/src/platform/break_glass.rs
@@ -51,27 +51,29 @@ pub fn recover_if_stale() -> i32 {
     let state = match load_state() {
         Ok(Some(state)) => state,
         Ok(None) => {
-            if active_response::status().isolated {
-                return attempt_fail_open_recovery(
-                    "missing protected break-glass state while machine is isolated",
-                    None,
-                );
-            }
-            return 0;
-        }
-        Err(err) => {
-            if active_response::status().isolated {
-                return attempt_fail_open_recovery(
-                    "failed to load protected break-glass state",
-                    Some(err),
-                );
-            }
+            let isolated = active_response::status().isolated;
             audit::record(
                 "break_glass_recovery",
                 "error",
-                json!({ "error": err, "reason": "failed to load protected break-glass state" }),
+                json!({
+                    "error": "protected break-glass state is missing",
+                    "isolated": isolated,
+                }),
             );
-            return 1;
+            return if isolated { 1 } else { 0 };
+        }
+        Err(err) => {
+            let isolated = active_response::status().isolated;
+            audit::record(
+                "break_glass_recovery",
+                "error",
+                json!({
+                    "error": err,
+                    "reason": "failed to load protected break-glass state",
+                    "isolated": isolated,
+                }),
+            );
+            return if isolated { 1 } else { 0 };
         }
     };
     if !active_response::status().isolated {
@@ -108,38 +110,6 @@ pub fn recover_if_stale() -> i32 {
                     "error": err,
                     "heartbeat_age_secs": heartbeat_age,
                     "deadline_unix": state.deadline_unix,
-                }),
-            );
-            1
-        }
-    }
-}
-
-fn attempt_fail_open_recovery(reason: &str, error: Option<String>) -> i32 {
-    match active_response::restore_machine() {
-        Ok(message) => {
-            audit::record(
-                "break_glass_recovery",
-                "success",
-                json!({
-                    "message": message,
-                    "reason": reason,
-                    "error": error,
-                    "fail_open_path": true,
-                }),
-            );
-            let _ = disarm();
-            0
-        }
-        Err(restore_err) => {
-            audit::record(
-                "break_glass_recovery",
-                "error",
-                json!({
-                    "reason": reason,
-                    "error": error,
-                    "restore_error": restore_err,
-                    "fail_open_path": true,
                 }),
             );
             1


### PR DESCRIPTION
### Motivation
- Prevent a tamper-triggered fail-open where deleting or corrupting the protected break-glass state file under `config::data_dir()` could cause immediate privileged network restoration when the host is isolated.
- Maintain containment semantics so that missing/invalid integrity-verified state does not bypass the configured deadline and heartbeat checks.

### Description
- In `recover_if_stale()` remove the fail-open branch that called `active_response::restore_machine()` for `Ok(None)` or `Err(...)` from `load_state()` and instead record an explicit audit error and return non-zero when the host is isolated.
- Stop treating missing/corrupt `vigil-break-glass.json` as a trigger to immediately disarm and restore networking, preserving the normal deadline + heartbeat recovery flow for valid state.
- Remove the `attempt_fail_open_recovery()` helper (which invoked the privileged `restore_machine()` path) so the tamper-triggered path is eliminated.
- Preserve existing behavior where `disarm()` is called only when `active_response::status().isolated` is false or after successful, validated recovery.

### Testing
- Ran `cargo test protected_break_glass_state_load_fails_when_existing_state_cannot_be_restored` which completed successfully (`ok`).
- Ran the unit test suite during `cargo test` which compiled and executed applicable tests; the relevant break-glass test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0078c493108328ab60ce95a1a00e5e)