### PR TITLE
Surface source identifiers in advisory match status

### DIFF
--- a/src/advisory_match.rs
+++ b/src/advisory_match.rs
@@ -15,6 +15,7 @@ pub struct InstalledProductRef<'a> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct AffectedProductRef<'a> {
     pub criteria: &'a str,
+    pub match_criteria_id: Option<&'a str>,
     pub cpe_name: Option<&'a str>,
     pub vulnerable: bool,
     pub version_start_including: Option<&'a str>,
@@ -26,6 +27,7 @@ pub struct AffectedProductRef<'a> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CpeProductMatch {
     pub cpe_uri: String,
+    pub match_criteria_id: Option<String>,
     pub part: String,
     pub vendor: String,
     pub product: String,
@@ -105,6 +107,7 @@ pub fn evaluate_cpe23_product_match(
 
     Some(CpeProductMatch {
         cpe_uri: cpe.uri,
+        match_criteria_id: affected.match_criteria_id.map(str::to_string),
         part: cpe.part,
         vendor: vendor.clone(),
         product,
@@ -252,6 +255,7 @@ mod tests {
         };
         let affected = AffectedProductRef {
             criteria: "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
+            match_criteria_id: Some("nvd-match-1"),
             cpe_name: Some("cpe:2.3:a:google:chrome:124.0.6367.91:*:*:*:*:*:*:*"),
             vulnerable: true,
             ..AffectedProductRef::default()
@@ -261,6 +265,7 @@ mod tests {
         assert_eq!(matched.vendor, "google");
         assert_eq!(matched.product, "chrome");
         assert_eq!(matched.matched_alias, "google-chrome");
+        assert_eq!(matched.match_criteria_id.as_deref(), Some("nvd-match-1"));
         assert_eq!(matched.confidence, MatchConfidence::High);
         assert_eq!(matched.version_status, VersionMatchStatus::Exact);
         assert!(matched.applies);
@@ -284,6 +289,7 @@ mod tests {
             version_start_excluding: None,
             version_end_including: None,
             version_end_excluding: Some("8.8.0-1.fc41"),
+            ..AffectedProductRef::default()
         };
 
         let matched = evaluate_cpe23_product_match(&installed, &affected).unwrap();
@@ -311,6 +317,7 @@ mod tests {
             version_start_excluding: None,
             version_end_including: None,
             version_end_excluding: Some("125.0.0"),
+            ..AffectedProductRef::default()
         };
 
         let matched = evaluate_cpe23_product_match(&installed, &affected).unwrap();
@@ -365,6 +372,7 @@ mod tests {
             version_start_excluding: None,
             version_end_including: Some("2.4.9"),
             version_end_excluding: None,
+            ..AffectedProductRef::default()
         };
 
         let matched = evaluate_cpe23_product_match(&installed, &affected).unwrap();

--- a/src/advisory_match_status.rs
+++ b/src/advisory_match_status.rs
@@ -24,6 +24,10 @@ struct RecordAdvisoryMatch {
     source_kind: String,
     known_exploited: bool,
     cpe_uri: String,
+    match_criteria_id: Option<String>,
+    part: String,
+    vendor: String,
+    product: String,
     matched_alias: String,
     confidence: MatchConfidence,
     version_status: VersionMatchStatus,
@@ -102,6 +106,15 @@ pub fn run_cli() -> Result<(), String> {
                 println!("    known_exploited=yes");
             }
             println!("    cpe={}", record.cpe_uri);
+            println!(
+                "    source_product={}:{}:{}",
+                part_label(&record.part),
+                record.vendor,
+                record.product
+            );
+            if let Some(match_criteria_id) = &record.match_criteria_id {
+                println!("    match_criteria_id={match_criteria_id}");
+            }
             println!("    summary={}", condense_summary(&record.summary));
         }
     }
@@ -191,6 +204,10 @@ fn best_record_match(
         source_kind: record.provenance.source_kind.clone(),
         known_exploited: record.known_exploited,
         cpe_uri: best.cpe_uri,
+        match_criteria_id: best.match_criteria_id,
+        part: best.part,
+        vendor: best.vendor,
+        product: best.product,
         matched_alias: best.matched_alias,
         confidence: best.confidence,
         version_status: best.version_status,
@@ -201,6 +218,7 @@ fn best_record_match(
 fn affected_product_ref<'a>(affected: &'a AffectedProduct) -> AffectedProductRef<'a> {
     AffectedProductRef {
         criteria: &affected.criteria,
+        match_criteria_id: affected.match_criteria_id.as_deref(),
         cpe_name: affected.cpe_name.as_deref(),
         vulnerable: affected.vulnerable,
         version_start_including: affected.version_start_including.as_deref(),
@@ -311,6 +329,15 @@ fn version_status_label(status: VersionMatchStatus) -> &'static str {
     }
 }
 
+fn part_label(part: &str) -> &'static str {
+    match part {
+        "a" => "application",
+        "o" => "operating-system",
+        "h" => "hardware",
+        _ => "unknown",
+    }
+}
+
 fn yes_no(value: bool) -> &'static str {
     if value {
         "yes"
@@ -398,10 +425,15 @@ mod tests {
                 false,
                 vec![
                     affected("cpe:2.3:a:haxx:chrome:*:*:*:*:*:*:*:*", None),
-                    affected(
-                        "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
-                        Some("cpe:2.3:a:google:chrome:124.0.6367.91:*:*:*:*:*:*:*"),
-                    ),
+                    AffectedProduct {
+                        criteria: "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*".into(),
+                        match_criteria_id: Some("nvd-match-1".into()),
+                        cpe_name: Some(
+                            "cpe:2.3:a:google:chrome:124.0.6367.91:*:*:*:*:*:*:*".into(),
+                        ),
+                        vulnerable: true,
+                        ..AffectedProduct::default()
+                    },
                 ],
             )],
         };
@@ -410,6 +442,13 @@ mod tests {
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].matches.len(), 1);
         assert_eq!(matches[0].matches[0].matched_alias, "google-chrome");
+        assert_eq!(
+            matches[0].matches[0].match_criteria_id.as_deref(),
+            Some("nvd-match-1")
+        );
+        assert_eq!(matches[0].matches[0].part, "a");
+        assert_eq!(matches[0].matches[0].vendor, "google");
+        assert_eq!(matches[0].matches[0].product, "chrome");
         assert_eq!(matches[0].matches[0].confidence, MatchConfidence::High);
         assert_eq!(
             matches[0].matches[0].version_status,
@@ -454,6 +493,14 @@ mod tests {
             VersionMatchStatus::OutOfRange
         );
         assert!(!matches[0].matches[0].applies);
+    }
+
+    #[test]
+    fn part_label_maps_known_cpe_parts() {
+        assert_eq!(part_label("a"), "application");
+        assert_eq!(part_label("o"), "operating-system");
+        assert_eq!(part_label("h"), "hardware");
+        assert_eq!(part_label("?"), "unknown");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve source-side match identifiers such as NVD `matchCriteriaId` in the CPE matching result
- print the matched source product basis and source-side match identifier in `vigil --advisory-match-status`
- extend focused unit coverage around identifier preservation and explainability output helpers

## Why this task
The roadmap still shows Phase 16 `CPE / product matching pipeline` as the next unfinished item. PR #225 made product-to-advisory joins visible, but the CLI still dropped the source-native match identifier that Vigil already preserves in the normalized advisory cache. Surfacing that identifier is the smallest safe remaining slice inside the same roadmap item because it improves operator-visible explainability without jumping ahead into Inspector, scoring, or response behavior.

## Validation
- added focused unit assertions in `src/advisory_match.rs` to confirm `matchCriteriaId` survives the CPE match evaluation path
- added focused unit assertions in `src/advisory_match_status.rs` to confirm the status pipeline preserves source product identity and source-side match identifiers
- could not run `cargo fmt`, `cargo clippy`, or `cargo test` in this scheduled-run environment because Rust tooling is not available here, so CI still needs to compile and exercise the branch

## Notes
- this keeps scope inside Phase 16 matching explainability only; it does not yet correlate live connections to installed software or surface advisory matches in the Inspector