### PR TITLE
Explain advisory match confidence basis

### DIFF
--- a/src/advisory_match.rs
+++ b/src/advisory_match.rs
@@ -429,7 +429,7 @@ mod tests {
         assert_eq!(matched.matched_alias, "microsoft-edge-update");
         assert_eq!(
             matched.match_basis,
-            MatchBasis::ProductAliasWithVendorConfirmation
+            MatchBasis::ProductAliasWithVendorConfirmation,
         );
         assert_eq!(matched.version_status, VersionMatchStatus::Exact);
         assert!(matched.applies);

--- a/src/advisory_match.rs
+++ b/src/advisory_match.rs
@@ -32,6 +32,7 @@ pub struct CpeProductMatch {
     pub vendor: String,
     pub product: String,
     pub matched_alias: String,
+    pub match_basis: MatchBasis,
     pub confidence: MatchConfidence,
     pub version_status: VersionMatchStatus,
     pub applies: bool,
@@ -41,6 +42,13 @@ pub struct CpeProductMatch {
 pub enum MatchConfidence {
     High,
     Medium,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchBasis {
+    VendorQualifiedAlias,
+    ProductAliasWithVendorConfirmation,
+    ProductAliasOnly,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -89,12 +97,24 @@ pub fn evaluate_cpe23_product_match(
         .as_deref()
         .is_some_and(|installed_vendor| installed_vendor == vendor);
 
-    let (matched_alias, confidence) = if aliases.contains(&vendor_qualified) {
-        (vendor_qualified, MatchConfidence::High)
+    let (matched_alias, match_basis, confidence) = if aliases.contains(&vendor_qualified) {
+        (
+            vendor_qualified,
+            MatchBasis::VendorQualifiedAlias,
+            MatchConfidence::High,
+        )
     } else if vendor_matches && aliases.contains(&product) {
-        (product.clone(), MatchConfidence::High)
+        (
+            product.clone(),
+            MatchBasis::ProductAliasWithVendorConfirmation,
+            MatchConfidence::High,
+        )
     } else if aliases.contains(&product) {
-        (product.clone(), MatchConfidence::Medium)
+        (
+            product.clone(),
+            MatchBasis::ProductAliasOnly,
+            MatchConfidence::Medium,
+        )
     } else {
         return None;
     };
@@ -112,6 +132,7 @@ pub fn evaluate_cpe23_product_match(
         vendor: vendor.clone(),
         product,
         matched_alias,
+        match_basis,
         confidence,
         version_status,
         applies,
@@ -265,6 +286,7 @@ mod tests {
         assert_eq!(matched.vendor, "google");
         assert_eq!(matched.product, "chrome");
         assert_eq!(matched.matched_alias, "google-chrome");
+        assert_eq!(matched.match_basis, MatchBasis::VendorQualifiedAlias);
         assert_eq!(matched.match_criteria_id.as_deref(), Some("nvd-match-1"));
         assert_eq!(matched.confidence, MatchConfidence::High);
         assert_eq!(matched.version_status, VersionMatchStatus::Exact);
@@ -294,6 +316,7 @@ mod tests {
 
         let matched = evaluate_cpe23_product_match(&installed, &affected).unwrap();
         assert_eq!(matched.matched_alias, "curl");
+        assert_eq!(matched.match_basis, MatchBasis::ProductAliasOnly);
         assert_eq!(matched.confidence, MatchConfidence::Medium);
         assert_eq!(matched.version_status, VersionMatchStatus::InRange);
         assert!(matched.applies);
@@ -321,6 +344,7 @@ mod tests {
         };
 
         let matched = evaluate_cpe23_product_match(&installed, &affected).unwrap();
+        assert_eq!(matched.match_basis, MatchBasis::VendorQualifiedAlias);
         assert_eq!(matched.confidence, MatchConfidence::High);
         assert_eq!(matched.version_status, VersionMatchStatus::OutOfRange);
         assert!(!matched.applies);
@@ -376,6 +400,7 @@ mod tests {
         };
 
         let matched = evaluate_cpe23_product_match(&installed, &affected).unwrap();
+        assert_eq!(matched.match_basis, MatchBasis::VendorQualifiedAlias);
         assert_eq!(
             matched.version_status,
             VersionMatchStatus::MissingInstalledVersion
@@ -402,6 +427,10 @@ mod tests {
 
         let matched = evaluate_cpe23_product_match(&installed, &affected).unwrap();
         assert_eq!(matched.matched_alias, "microsoft-edge-update");
+        assert_eq!(
+            matched.match_basis,
+            MatchBasis::ProductAliasWithVendorConfirmation
+        );
         assert_eq!(matched.version_status, VersionMatchStatus::Exact);
         assert!(matched.applies);
     }

--- a/src/advisory_match_status.rs
+++ b/src/advisory_match_status.rs
@@ -1,7 +1,7 @@
 use crate::advisory::{AdvisoryCache, AffectedProduct, VulnerabilityRecord};
 use crate::advisory_match::{
-    evaluate_cpe23_product_match, AffectedProductRef, InstalledProductRef, MatchConfidence,
-    VersionMatchStatus,
+    evaluate_cpe23_product_match, AffectedProductRef, InstalledProductRef, MatchBasis,
+    MatchConfidence, VersionMatchStatus,
 };
 use crate::software_inventory::{InstalledSoftware, InventorySource};
 use crate::storage::{InventoryStore, ProtectedJsonInventoryStore};
@@ -29,6 +29,7 @@ struct RecordAdvisoryMatch {
     vendor: String,
     product: String,
     matched_alias: String,
+    match_basis: MatchBasis,
     confidence: MatchConfidence,
     version_status: VersionMatchStatus,
     applies: bool,
@@ -112,6 +113,7 @@ pub fn run_cli() -> Result<(), String> {
                 record.vendor,
                 record.product
             );
+            println!("    match_basis={}", match_basis_label(record.match_basis));
             if let Some(match_criteria_id) = &record.match_criteria_id {
                 println!("    match_criteria_id={match_criteria_id}");
             }
@@ -209,6 +211,7 @@ fn best_record_match(
         vendor: best.vendor,
         product: best.product,
         matched_alias: best.matched_alias,
+        match_basis: best.match_basis,
         confidence: best.confidence,
         version_status: best.version_status,
         applies: best.applies,
@@ -315,6 +318,16 @@ fn confidence_label(confidence: MatchConfidence) -> &'static str {
     match confidence {
         MatchConfidence::High => "high",
         MatchConfidence::Medium => "medium",
+    }
+}
+
+fn match_basis_label(match_basis: MatchBasis) -> &'static str {
+    match match_basis {
+        MatchBasis::VendorQualifiedAlias => "vendor_qualified_alias",
+        MatchBasis::ProductAliasWithVendorConfirmation => {
+            "product_alias_with_vendor_confirmation"
+        }
+        MatchBasis::ProductAliasOnly => "product_alias_only",
     }
 }
 
@@ -442,6 +455,7 @@ mod tests {
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].matches.len(), 1);
         assert_eq!(matches[0].matches[0].matched_alias, "google-chrome");
+        assert_eq!(matches[0].matches[0].match_basis, MatchBasis::VendorQualifiedAlias);
         assert_eq!(
             matches[0].matches[0].match_criteria_id.as_deref(),
             Some("nvd-match-1")
@@ -488,11 +502,28 @@ mod tests {
         let matches = collect_product_matches(&inventory, &cache);
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].matches[0].primary_id, "CVE-2026-9999");
+        assert_eq!(matches[0].matches[0].match_basis, MatchBasis::ProductAliasOnly);
         assert_eq!(
             matches[0].matches[0].version_status,
             VersionMatchStatus::OutOfRange
         );
         assert!(!matches[0].matches[0].applies);
+    }
+
+    #[test]
+    fn match_basis_label_maps_known_match_bases() {
+        assert_eq!(
+            match_basis_label(MatchBasis::VendorQualifiedAlias),
+            "vendor_qualified_alias"
+        );
+        assert_eq!(
+            match_basis_label(MatchBasis::ProductAliasWithVendorConfirmation),
+            "product_alias_with_vendor_confirmation"
+        );
+        assert_eq!(
+            match_basis_label(MatchBasis::ProductAliasOnly),
+            "product_alias_only"
+        );
     }
 
     #[test]

--- a/src/advisory_match_status.rs
+++ b/src/advisory_match_status.rs
@@ -326,7 +326,7 @@ fn match_basis_label(match_basis: MatchBasis) -> &'static str {
         MatchBasis::VendorQualifiedAlias => "vendor_qualified_alias",
         MatchBasis::ProductAliasWithVendorConfirmation => {
             "product_alias_with_vendor_confirmation"
-        }
+        },
         MatchBasis::ProductAliasOnly => "product_alias_only",
     }
 }


### PR DESCRIPTION
## Summary
- record the basis for each CPE product match alongside the existing confidence score
- print that match basis in `vigil --advisory-match-status` so operators can see why a match was treated as high or medium confidence
- extend focused unit coverage for the new explainability field in both the matcher and status output pipeline

## Why this task
`ROADMAP.md` still marks Phase 16 `CPE / product matching pipeline` as the next unfinished dependency. PR #227 was merged on May 10, 2026 and completed the source-identifier slice inside that roadmap item. The next smallest safe slice is to expose the basis behind the existing confidence score without jumping ahead to connection correlation, Inspector integration, or scoring changes.

## Validation
- added matcher tests for vendor-qualified alias, vendor-confirmed product alias, and product-alias-only match basis cases
- added advisory status tests to confirm the best-match pipeline preserves and labels the new match-basis field
- could not run `cargo fmt`, `cargo clippy`, or `cargo test` in this scheduled-run environment because Rust tooling is unavailable here, so CI still needs to compile and exercise the branch

## Notes
- this keeps scope inside Phase 16 matching explainability only; it does not yet correlate live connections to installed software or surface advisories in the Inspector