### PR TITLE
Match source-native advisory product identifiers

### DIFF
--- a/src/advisory_match.rs
+++ b/src/advisory_match.rs
@@ -152,7 +152,12 @@ fn parse_affected_product_identifier(
 ) -> Option<ParsedAffectedProduct> {
     parse_cpe23_uri(affected.criteria)
         .and_then(parsed_from_cpe)
-        .or_else(|| affected.cpe_name.and_then(parse_cpe23_uri).and_then(parsed_from_cpe))
+        .or_else(|| {
+            affected
+                .cpe_name
+                .and_then(parse_cpe23_uri)
+                .and_then(parsed_from_cpe)
+        })
         .or_else(|| parse_source_native_identifier(affected.criteria))
 }
 

--- a/src/advisory_match.rs
+++ b/src/advisory_match.rs
@@ -152,12 +152,7 @@ fn parse_affected_product_identifier(
 ) -> Option<ParsedAffectedProduct> {
     parse_cpe23_uri(affected.criteria)
         .and_then(parsed_from_cpe)
-        .or_else(|| {
-            affected
-                .cpe_name
-                .and_then(parse_cpe23_uri)
-                .and_then(parsed_from_cpe)
-        })
+        .or_else(|| affected.cpe_name.and_then(parse_cpe23_uri).and_then(parsed_from_cpe))
         .or_else(|| parse_source_native_identifier(affected.criteria))
 }
 

--- a/src/advisory_match.rs
+++ b/src/advisory_match.rs
@@ -25,8 +25,8 @@ pub struct AffectedProductRef<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CpeProductMatch {
-    pub cpe_uri: String,
+pub struct AffectedProductMatch {
+    pub source_id: String,
     pub match_criteria_id: Option<String>,
     pub part: String,
     pub vendor: String,
@@ -69,49 +69,57 @@ struct ParsedCpe23 {
     product: String,
 }
 
-pub fn evaluate_cpe23_product_match(
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedAffectedProduct {
+    source_id: String,
+    part: String,
+    vendor: String,
+    product: String,
+}
+
+pub fn evaluate_affected_product_match(
     installed: &InstalledProductRef<'_>,
     affected: &AffectedProductRef<'_>,
-) -> Option<CpeProductMatch> {
+) -> Option<AffectedProductMatch> {
     if !affected.vulnerable {
         return None;
     }
 
-    let cpe = parse_cpe23_uri(affected.criteria)
-        .or_else(|| affected.cpe_name.and_then(parse_cpe23_uri))?;
-    if matches!(cpe.part.as_str(), "h" | "") {
-        return None;
-    }
-
-    let product = normalize_identity(&cpe.product);
-    let vendor = normalize_identity(&cpe.vendor);
-    if product.is_empty() || vendor.is_empty() {
-        return None;
-    }
-
+    let parsed = parse_affected_product_identifier(affected)?;
     let aliases = installed_identity_aliases(installed);
-    let vendor_qualified = format!("{vendor}-{product}");
-    let vendor_matches = installed
-        .vendor_key
-        .map(normalize_identity)
-        .as_deref()
-        .is_some_and(|installed_vendor| installed_vendor == vendor);
+    let vendor_matches = !parsed.vendor.is_empty()
+        && installed
+            .vendor_key
+            .map(normalize_identity)
+            .as_deref()
+            .is_some_and(|installed_vendor| installed_vendor == parsed.vendor);
 
-    let (matched_alias, match_basis, confidence) = if aliases.contains(&vendor_qualified) {
+    let (matched_alias, match_basis, confidence) = if !parsed.vendor.is_empty() {
+        let vendor_qualified = format!("{}-{}", parsed.vendor, parsed.product);
+        if aliases.contains(&vendor_qualified) {
+            (
+                vendor_qualified,
+                MatchBasis::VendorQualifiedAlias,
+                MatchConfidence::High,
+            )
+        } else if vendor_matches && aliases.contains(&parsed.product) {
+            (
+                parsed.product.clone(),
+                MatchBasis::ProductAliasWithVendorConfirmation,
+                MatchConfidence::High,
+            )
+        } else if aliases.contains(&parsed.product) {
+            (
+                parsed.product.clone(),
+                MatchBasis::ProductAliasOnly,
+                MatchConfidence::Medium,
+            )
+        } else {
+            return None;
+        }
+    } else if aliases.contains(&parsed.product) {
         (
-            vendor_qualified,
-            MatchBasis::VendorQualifiedAlias,
-            MatchConfidence::High,
-        )
-    } else if vendor_matches && aliases.contains(&product) {
-        (
-            product.clone(),
-            MatchBasis::ProductAliasWithVendorConfirmation,
-            MatchConfidence::High,
-        )
-    } else if aliases.contains(&product) {
-        (
-            product.clone(),
+            parsed.product.clone(),
             MatchBasis::ProductAliasOnly,
             MatchConfidence::Medium,
         )
@@ -125,17 +133,66 @@ pub fn evaluate_cpe23_product_match(
         VersionMatchStatus::Exact | VersionMatchStatus::InRange | VersionMatchStatus::NoConstraint
     );
 
-    Some(CpeProductMatch {
-        cpe_uri: cpe.uri,
+    Some(AffectedProductMatch {
+        source_id: parsed.source_id,
         match_criteria_id: affected.match_criteria_id.map(str::to_string),
-        part: cpe.part,
-        vendor: vendor.clone(),
-        product,
+        part: parsed.part,
+        vendor: parsed.vendor,
+        product: parsed.product,
         matched_alias,
         match_basis,
         confidence,
         version_status,
         applies,
+    })
+}
+
+fn parse_affected_product_identifier(
+    affected: &AffectedProductRef<'_>,
+) -> Option<ParsedAffectedProduct> {
+    parse_cpe23_uri(affected.criteria)
+        .and_then(parsed_from_cpe)
+        .or_else(|| affected.cpe_name.and_then(parse_cpe23_uri).and_then(parsed_from_cpe))
+        .or_else(|| parse_source_native_identifier(affected.criteria))
+}
+
+fn parsed_from_cpe(cpe: ParsedCpe23) -> Option<ParsedAffectedProduct> {
+    if matches!(cpe.part.as_str(), "h" | "") {
+        return None;
+    }
+
+    let vendor = normalize_identity(&cpe.vendor);
+    let product = normalize_identity(&cpe.product);
+    if product.is_empty() || vendor.is_empty() {
+        return None;
+    }
+
+    Some(ParsedAffectedProduct {
+        source_id: cpe.uri,
+        part: cpe.part,
+        vendor,
+        product,
+    })
+}
+
+fn parse_source_native_identifier(input: &str) -> Option<ParsedAffectedProduct> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() || trimmed.starts_with("cpe:") {
+        return None;
+    }
+
+    let (vendor, product) = trimmed.split_once(':').unwrap_or(("", trimmed));
+    let vendor = normalize_identity(vendor);
+    let product = normalize_identity(product);
+    if product.is_empty() {
+        return None;
+    }
+
+    Some(ParsedAffectedProduct {
+        source_id: trimmed.to_string(),
+        part: "source-native".to_string(),
+        vendor,
+        product,
     })
 }
 
@@ -282,7 +339,8 @@ mod tests {
             ..AffectedProductRef::default()
         };
 
-        let matched = evaluate_cpe23_product_match(&installed, &affected).unwrap();
+        let matched = evaluate_affected_product_match(&installed, &affected).unwrap();
+        assert_eq!(matched.source_id, "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*");
         assert_eq!(matched.vendor, "google");
         assert_eq!(matched.product, "chrome");
         assert_eq!(matched.matched_alias, "google-chrome");
@@ -314,11 +372,66 @@ mod tests {
             ..AffectedProductRef::default()
         };
 
-        let matched = evaluate_cpe23_product_match(&installed, &affected).unwrap();
+        let matched = evaluate_affected_product_match(&installed, &affected).unwrap();
         assert_eq!(matched.matched_alias, "curl");
         assert_eq!(matched.match_basis, MatchBasis::ProductAliasOnly);
         assert_eq!(matched.confidence, MatchConfidence::Medium);
         assert_eq!(matched.version_status, VersionMatchStatus::InRange);
+        assert!(matched.applies);
+    }
+
+    #[test]
+    fn matches_source_native_vendor_product_identifier() {
+        let aliases = vec!["agent".to_string(), "example-agent".to_string()];
+        let installed = InstalledProductRef {
+            product_key: "example-agent",
+            product_aliases: &aliases,
+            vendor_key: Some("example"),
+            version_hint: Some("2.4.1"),
+            version_source: VersionSource::Default,
+        };
+        let affected = AffectedProductRef {
+            criteria: "Example:Agent",
+            vulnerable: true,
+            ..AffectedProductRef::default()
+        };
+
+        let matched = evaluate_affected_product_match(&installed, &affected).unwrap();
+        assert_eq!(matched.source_id, "Example:Agent");
+        assert_eq!(matched.part, "source-native");
+        assert_eq!(matched.vendor, "example");
+        assert_eq!(matched.product, "agent");
+        assert_eq!(matched.matched_alias, "example-agent");
+        assert_eq!(matched.match_basis, MatchBasis::VendorQualifiedAlias);
+        assert_eq!(matched.confidence, MatchConfidence::High);
+        assert_eq!(matched.version_status, VersionMatchStatus::NoConstraint);
+        assert!(matched.applies);
+    }
+
+    #[test]
+    fn matches_product_only_source_identifier_at_medium_confidence() {
+        let aliases = vec!["curl".to_string()];
+        let installed = InstalledProductRef {
+            product_key: "curl",
+            product_aliases: &aliases,
+            vendor_key: Some("fedora"),
+            version_hint: Some("8.8.0-1.fc40"),
+            version_source: VersionSource::RpmPackage,
+        };
+        let affected = AffectedProductRef {
+            criteria: "curl",
+            vulnerable: true,
+            ..AffectedProductRef::default()
+        };
+
+        let matched = evaluate_affected_product_match(&installed, &affected).unwrap();
+        assert_eq!(matched.source_id, "curl");
+        assert_eq!(matched.part, "source-native");
+        assert_eq!(matched.vendor, "");
+        assert_eq!(matched.product, "curl");
+        assert_eq!(matched.match_basis, MatchBasis::ProductAliasOnly);
+        assert_eq!(matched.confidence, MatchConfidence::Medium);
+        assert_eq!(matched.version_status, VersionMatchStatus::NoConstraint);
         assert!(matched.applies);
     }
 
@@ -343,7 +456,7 @@ mod tests {
             ..AffectedProductRef::default()
         };
 
-        let matched = evaluate_cpe23_product_match(&installed, &affected).unwrap();
+        let matched = evaluate_affected_product_match(&installed, &affected).unwrap();
         assert_eq!(matched.match_basis, MatchBasis::VendorQualifiedAlias);
         assert_eq!(matched.confidence, MatchConfidence::High);
         assert_eq!(matched.version_status, VersionMatchStatus::OutOfRange);
@@ -367,7 +480,7 @@ mod tests {
             vulnerable: false,
             ..AffectedProductRef::default()
         };
-        assert!(evaluate_cpe23_product_match(&installed, &non_vulnerable).is_none());
+        assert!(evaluate_affected_product_match(&installed, &non_vulnerable).is_none());
 
         let hardware = AffectedProductRef {
             criteria: "cpe:2.3:h:example:appliance:*:*:*:*:*:*:*:*",
@@ -375,7 +488,7 @@ mod tests {
             vulnerable: true,
             ..AffectedProductRef::default()
         };
-        assert!(evaluate_cpe23_product_match(&installed, &hardware).is_none());
+        assert!(evaluate_affected_product_match(&installed, &hardware).is_none());
     }
 
     #[test]
@@ -399,7 +512,7 @@ mod tests {
             ..AffectedProductRef::default()
         };
 
-        let matched = evaluate_cpe23_product_match(&installed, &affected).unwrap();
+        let matched = evaluate_affected_product_match(&installed, &affected).unwrap();
         assert_eq!(matched.match_basis, MatchBasis::VendorQualifiedAlias);
         assert_eq!(
             matched.version_status,
@@ -425,7 +538,7 @@ mod tests {
             ..AffectedProductRef::default()
         };
 
-        let matched = evaluate_cpe23_product_match(&installed, &affected).unwrap();
+        let matched = evaluate_affected_product_match(&installed, &affected).unwrap();
         assert_eq!(matched.matched_alias, "microsoft-edge-update");
         assert_eq!(matched.match_basis, MatchBasis::VendorQualifiedAlias);
         assert_eq!(matched.version_status, VersionMatchStatus::Exact);

--- a/src/advisory_match_status.rs
+++ b/src/advisory_match_status.rs
@@ -1,6 +1,6 @@
 use crate::advisory::{AdvisoryCache, AffectedProduct, VulnerabilityRecord};
 use crate::advisory_match::{
-    evaluate_cpe23_product_match, AffectedProductRef, InstalledProductRef, MatchBasis,
+    evaluate_affected_product_match, AffectedProductRef, InstalledProductRef, MatchBasis,
     MatchConfidence, VersionMatchStatus,
 };
 use crate::software_inventory::{InstalledSoftware, InventorySource};
@@ -23,7 +23,7 @@ struct RecordAdvisoryMatch {
     summary: String,
     source_kind: String,
     known_exploited: bool,
-    cpe_uri: String,
+    source_id: String,
     match_criteria_id: Option<String>,
     part: String,
     vendor: String,
@@ -106,12 +106,10 @@ pub fn run_cli() -> Result<(), String> {
             if record.known_exploited {
                 println!("    known_exploited=yes");
             }
-            println!("    cpe={}", record.cpe_uri);
+            println!("    source_id={}", record.source_id);
             println!(
-                "    source_product={}:{}:{}",
-                part_label(&record.part),
-                record.vendor,
-                record.product
+                "    source_product={}",
+                format_source_product(&record.part, &record.vendor, &record.product)
             );
             println!("    match_basis={}", match_basis_label(record.match_basis));
             if let Some(match_criteria_id) = &record.match_criteria_id {
@@ -196,7 +194,7 @@ fn best_record_match(
         .affected_products
         .iter()
         .filter_map(|affected| {
-            evaluate_cpe23_product_match(&installed_ref, &affected_product_ref(affected))
+            evaluate_affected_product_match(&installed_ref, &affected_product_ref(affected))
         })
         .max_by_key(|matched| match_rank(matched.confidence, matched.version_status))?;
 
@@ -205,7 +203,7 @@ fn best_record_match(
         summary: record.summary.clone(),
         source_kind: record.provenance.source_kind.clone(),
         known_exploited: record.known_exploited,
-        cpe_uri: best.cpe_uri,
+        source_id: best.source_id,
         match_criteria_id: best.match_criteria_id,
         part: best.part,
         vendor: best.vendor,
@@ -345,7 +343,17 @@ fn part_label(part: &str) -> &'static str {
         "a" => "application",
         "o" => "operating-system",
         "h" => "hardware",
+        "source-native" => "source-native",
         _ => "unknown",
+    }
+}
+
+fn format_source_product(part: &str, vendor: &str, product: &str) -> String {
+    let part = part_label(part);
+    if vendor.is_empty() {
+        format!("{part}:{product}")
+    } else {
+        format!("{part}:{vendor}:{product}")
     }
 }
 
@@ -452,6 +460,7 @@ mod tests {
         let matches = collect_product_matches(&inventory, &cache);
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].matches.len(), 1);
+        assert_eq!(matches[0].matches[0].source_id, "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*");
         assert_eq!(matches[0].matches[0].matched_alias, "google-chrome");
         assert_eq!(
             matches[0].matches[0].match_basis,
@@ -515,6 +524,43 @@ mod tests {
     }
 
     #[test]
+    fn collect_product_matches_supports_source_native_identifier_rows() {
+        let inventory = vec![installed(
+            "example-agent",
+            "Example Agent",
+            Some("example"),
+            Some("2.4.1"),
+            &["agent", "example-agent"],
+            InventorySource::RunningProcess,
+        )];
+        let cache = AdvisoryCache {
+            schema_version: 1,
+            generated_unix: 0,
+            sources: vec![],
+            records: vec![record(
+                "EUVD-2026-0001",
+                "Source-native product match",
+                false,
+                vec![affected("Example:Agent", None)],
+            )],
+        };
+
+        let matches = collect_product_matches(&inventory, &cache);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].matches.len(), 1);
+        assert_eq!(matches[0].matches[0].source_id, "Example:Agent");
+        assert_eq!(matches[0].matches[0].part, "source-native");
+        assert_eq!(matches[0].matches[0].vendor, "example");
+        assert_eq!(matches[0].matches[0].product, "agent");
+        assert_eq!(
+            matches[0].matches[0].match_basis,
+            MatchBasis::VendorQualifiedAlias
+        );
+        assert_eq!(matches[0].matches[0].confidence, MatchConfidence::High);
+        assert!(matches[0].matches[0].applies);
+    }
+
+    #[test]
     fn match_basis_label_maps_known_match_bases() {
         assert_eq!(
             match_basis_label(MatchBasis::VendorQualifiedAlias),
@@ -535,7 +581,20 @@ mod tests {
         assert_eq!(part_label("a"), "application");
         assert_eq!(part_label("o"), "operating-system");
         assert_eq!(part_label("h"), "hardware");
+        assert_eq!(part_label("source-native"), "source-native");
         assert_eq!(part_label("?"), "unknown");
+    }
+
+    #[test]
+    fn format_source_product_omits_blank_vendor() {
+        assert_eq!(
+            format_source_product("source-native", "", "curl"),
+            "source-native:curl"
+        );
+        assert_eq!(
+            format_source_product("a", "google", "chrome"),
+            "application:google:chrome"
+        );
     }
 
     #[test]

--- a/src/advisory_match_status.rs
+++ b/src/advisory_match_status.rs
@@ -460,7 +460,10 @@ mod tests {
         let matches = collect_product_matches(&inventory, &cache);
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].matches.len(), 1);
-        assert_eq!(matches[0].matches[0].source_id, "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*");
+        assert_eq!(
+            matches[0].matches[0].source_id,
+            "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*"
+        );
         assert_eq!(matches[0].matches[0].matched_alias, "google-chrome");
         assert_eq!(
             matches[0].matches[0].match_basis,


### PR DESCRIPTION
## Summary
- teach the advisory matcher to fall back from CPEs to source-native `vendor:product` or product-only identifiers
- surface those source-native identifiers honestly in `vigil --advisory-match-status`
- add focused tests for source-native matching and CLI explainability helpers

## Why this task
Phase 16 still lists `CPE / product matching pipeline` as the next unfinished roadmap item. The previous advisory-match explainability work is already merged, and non-NVD importers already preserve equivalent source-native product identifiers such as `Vendor:Product`. Before this change, the matcher ignored those rows entirely because it only understood CPE 2.3 strings. This is the smallest safe remaining slice inside the same roadmap item because it expands conservative offline matching without jumping ahead into Inspector or scoring hooks.

## Validation
- added unit coverage in `src/advisory_match.rs` for vendor-qualified and product-only source-native identifiers
- added unit coverage in `src/advisory_match_status.rs` for source-native explainability rows and formatting
- could not run local Rust tooling in this scheduled-run environment, so CI still needs to compile and exercise the branch

## Notes
- scope stays inside Phase 16 matching foundations only
- status output now uses `source_id=` rather than `cpe=` so non-CPE matches are not mislabeled