### PR TITLE
Sync roadmap with shipped advisory matching foundations

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ Use free public vulnerability and advisory sources to help Vigil keep the local 
 - [x] **Local software inventory and version discovery** — fold Windows uninstall registry and Linux package-manager inventory into the main inventory model without adding startup risk.
 - [x] **Product normalization + vendor aliasing** — reconcile executable names, publishers, package names, services, and installer metadata into stable vendor/product identities.
 - [x] **Version comparison engine** — compare installed versions against advisory ranges conservatively across semver, vendor-specific, and OS package version formats.
-- [ ] **CPE / product matching pipeline** — map local software identities to CPEs or equivalent source-native product identifiers with confidence scoring and operator-visible explainability.
+- [x] **CPE / product matching pipeline foundations** — map local software identities to CPEs or equivalent source-native product identifiers with confidence scoring and operator-visible explainability in the advisory match pipeline and `--advisory-match-status` CLI.
 - [ ] **Connection-to-software correlation** — tie a live process or service back to the relevant installed product record so advisory matches can appear in the existing Inspector and Alerts workflows.
 
 ### Operator value and protection outcomes


### PR DESCRIPTION
## Summary
- mark the Phase 16 `CPE / product matching pipeline` foundations item complete in `ROADMAP.md`
- clarify that the shipped slice is the advisory match pipeline plus the `--advisory-match-status` explainability CLI
- leave the next unfinished item as `Connection-to-software correlation`

## Why this task
There were no open pull requests needing follow-up, and the roadmap’s first unfinished Phase 16 item no longer matched the code already merged on `master`.

The matching foundations are now present in the repository:
- `src/advisory_match.rs`
- `src/advisory_match_status.rs`
- recent merged PRs `#227`, `#229`, `#230`, `#231`, and `#232`

Updating the roadmap is the smallest safe in-scope change because it avoids duplicating already-shipped work and makes the next real implementation target visible.

## Validation
- inspected the roadmap entry against the current `master` code and the recent merged advisory-matching PR history
- no code paths changed
- did not run local tests in this scheduled environment