### PR TITLE
Add missing-fix-version advisory response predicate

### DIFF
--- a/docs/RESPONSE-RULES.md
+++ b/docs/RESPONSE-RULES.md
@@ -33,7 +33,7 @@ Supported advisory predicates:
 
 Supported `min_advisory_severity` values are `low`, `medium`, `high`, and `critical`.
 
-`require_missing_advisory_fix_version` is intentionally narrow. Today it matches only when Vigil's high-confidence advisory reason includes `no fixed-version bound`, which Vigil emits only when the matched affected-product range has a lower version boundary but no upper version boundary. It does not guess from unconstrained rows or exact-version-only rows.
+`require_missing_advisory_fix_version` is intentionally narrow. Today it matches only when the same high-confidence advisory reason includes `no fixed-version bound`, which Vigil emits only when the matched affected-product range has a lower version boundary but no upper version boundary. It does not guess from unconstrained rows or exact-version-only rows.
 
 ## Example
 
@@ -49,7 +49,7 @@ rules:
     duration: 24h
 ```
 
-This example only matches when Vigil already found a high-confidence applicable advisory for a Chrome-family product, marked it as known exploited, rated it at least critical, and could not find an upper fixed-version bound on the matched advisory range.
+This example only matches when Vigil already found one high-confidence applicable advisory reason for a Chrome-family product, marked it as known exploited, rated it at least critical, and could not find an upper fixed-version bound on the matched advisory range.
 
 ## Current scope limits
 

--- a/docs/RESPONSE-RULES.md
+++ b/docs/RESPONSE-RULES.md
@@ -26,30 +26,34 @@ Supported advisory predicates:
 
 - `require_advisory_match: true`
 - `require_known_exploited_advisory: true`
+- `require_missing_advisory_fix_version: true`
 - `advisory_id_contains: "CVE-2026-12345"`
 - `advisory_product_contains: "chrome"`
 - `min_advisory_severity: high`
 
 Supported `min_advisory_severity` values are `low`, `medium`, `high`, and `critical`.
 
+`require_missing_advisory_fix_version` is intentionally narrow. Today it matches only when Vigil's high-confidence advisory reason includes `no fixed-version bound`, which Vigil emits only when the matched affected-product range has a lower version boundary but no upper version boundary. It does not guess from unconstrained rows or exact-version-only rows.
+
 ## Example
 
 ```yaml
 rules:
-  - name: exploited browser advisory
+  - name: exploited browser advisory without fix bound
     require_advisory_match: true
     require_known_exploited_advisory: true
+    require_missing_advisory_fix_version: true
     advisory_product_contains: chrome
     min_advisory_severity: critical
     action: block_process
     duration: 24h
 ```
 
-This example only matches when Vigil already found a high-confidence applicable advisory for a Chrome-family product, marked it as known exploited, and rated it at least critical.
+This example only matches when Vigil already found a high-confidence applicable advisory for a Chrome-family product, marked it as known exploited, rated it at least critical, and could not find an upper fixed-version bound on the matched advisory range.
 
 ## Current scope limits
 
-This is an intentionally narrow first slice of mitigation-aware response rules.
+This is still an intentionally narrow slice of mitigation-aware response rules.
 
 Today the rule engine can match only these advisory attributes:
 
@@ -57,8 +61,9 @@ Today the rule engine can match only these advisory attributes:
 - affected product text
 - known exploited flag
 - normalized severity floor
+- missing fixed-version bound on the matched advisory range
 
-The broader roadmap item still remains open for attributes such as vendor guidance, fixed-version absence, and exposure on the public internet.
+The broader roadmap item still remains open for attributes such as vendor guidance and exposure on the public internet.
 
 ## Actions
 

--- a/src/advisory_runtime_score.rs
+++ b/src/advisory_runtime_score.rs
@@ -44,6 +44,7 @@ struct RuntimeAdvisoryCandidate {
     severity_label: Option<String>,
     severity_rank: u8,
     known_exploited: bool,
+    missing_fix_version: bool,
     score_delta: u8,
 }
 
@@ -51,6 +52,12 @@ struct RuntimeAdvisoryCandidate {
 struct SeveritySummary {
     label: String,
     rank: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuntimeAdvisoryMatch {
+    matched: AffectedProductMatch,
+    missing_fix_version: bool,
 }
 
 static ADVISORY_SCORE_CACHE: OnceLock<RwLock<Option<CachedAdvisoryScore>>> = OnceLock::new();
@@ -146,7 +153,7 @@ fn build_candidate(
     record: &VulnerabilityRecord,
 ) -> Option<RuntimeAdvisoryCandidate> {
     let matched = best_record_match(installed, record)?;
-    if matched.confidence != MatchConfidence::High || !matched.applies {
+    if matched.matched.confidence != MatchConfidence::High || !matched.matched.applies {
         return None;
     }
 
@@ -162,31 +169,35 @@ fn build_candidate(
         severity_label: severity.map(|summary| summary.label),
         severity_rank,
         known_exploited: record.known_exploited,
+        missing_fix_version: matched.missing_fix_version,
         score_delta: advisory_score_delta(record.known_exploited, severity_rank),
     })
 }
 
 fn advisory_reason(candidate: &RuntimeAdvisoryCandidate) -> String {
-    match (
-        candidate.severity_label.as_deref(),
-        candidate.known_exploited,
-    ) {
-        (Some(severity), true) => format!(
-            "High-confidence advisory match: {} ({severity}, known exploited) applies to {}",
-            candidate.primary_id, candidate.product_name
-        ),
-        (Some(severity), false) => format!(
-            "High-confidence advisory match: {} ({severity}) applies to {}",
-            candidate.primary_id, candidate.product_name
-        ),
-        (None, true) => format!(
-            "High-confidence advisory match: {} (known exploited) applies to {}",
-            candidate.primary_id, candidate.product_name
-        ),
-        (None, false) => format!(
+    let mut details = Vec::new();
+    if let Some(severity) = candidate.severity_label.as_deref() {
+        details.push(severity.to_string());
+    }
+    if candidate.known_exploited {
+        details.push("known exploited".to_string());
+    }
+    if candidate.missing_fix_version {
+        details.push("no fixed-version bound".to_string());
+    }
+
+    if details.is_empty() {
+        format!(
             "High-confidence advisory match: {} applies to {}",
             candidate.primary_id, candidate.product_name
-        ),
+        )
+    } else {
+        format!(
+            "High-confidence advisory match: {} ({}) applies to {}",
+            candidate.primary_id,
+            details.join(", "),
+            candidate.product_name
+        )
     }
 }
 
@@ -203,7 +214,7 @@ fn advisory_score_delta(known_exploited: bool, severity_rank: u8) -> u8 {
 fn best_record_match(
     installed: &InstalledSoftware,
     record: &VulnerabilityRecord,
-) -> Option<AffectedProductMatch> {
+) -> Option<RuntimeAdvisoryMatch> {
     let installed_ref = InstalledProductRef {
         product_key: &installed.product_key,
         product_aliases: &installed.product_aliases,
@@ -216,14 +227,34 @@ fn best_record_match(
         .affected_products
         .iter()
         .filter_map(|affected| {
-            evaluate_affected_product_match(&installed_ref, &affected_product_ref(affected))
+            let matched =
+                evaluate_affected_product_match(&installed_ref, &affected_product_ref(affected))?;
+            Some(RuntimeAdvisoryMatch {
+                matched,
+                missing_fix_version: missing_fix_version_bound(affected),
+            })
         })
-        .max_by_key(|matched| {
+        .max_by_key(|candidate| {
             (
-                advisory_match_rank(matched.confidence, matched.version_status),
-                source_explainability_rank(matched),
+                advisory_match_rank(
+                    candidate.matched.confidence,
+                    candidate.matched.version_status,
+                ),
+                source_explainability_rank(&candidate.matched),
             )
         })
+}
+
+fn missing_fix_version_bound(affected: &AffectedProduct) -> bool {
+    has_lower_version_bound(affected) && !has_upper_version_bound(affected)
+}
+
+fn has_lower_version_bound(affected: &AffectedProduct) -> bool {
+    affected.version_start_including.is_some() || affected.version_start_excluding.is_some()
+}
+
+fn has_upper_version_bound(affected: &AffectedProduct) -> bool {
+    affected.version_end_including.is_some() || affected.version_end_excluding.is_some()
 }
 
 fn affected_product_ref<'a>(affected: &'a AffectedProduct) -> AffectedProductRef<'a> {
@@ -507,6 +538,7 @@ mod tests {
         assert!(outcome.reasons[0].contains("CVE-2026-12345"));
         assert!(outcome.reasons[0].contains("known exploited"));
         assert!(outcome.reasons[0].contains("Google Chrome"));
+        assert!(!outcome.reasons[0].contains("no fixed-version bound"));
     }
 
     #[test]
@@ -610,6 +642,80 @@ mod tests {
 
         assert_eq!(outcome.score_delta, 2);
         assert!(outcome.reasons[0].contains("critical 9.1"));
+    }
+
+    #[test]
+    fn open_ended_range_marks_reason_as_missing_fix_version_bound() {
+        let inventory = vec![installed(
+            "google-chrome",
+            "Google Chrome",
+            Some("google"),
+            Some("124.0.6367.91"),
+            &["chrome", "google-chrome"],
+            InventorySource::WindowsUninstallRegistry,
+        )];
+        let cache = cache(vec![record(
+            "CVE-2026-44444",
+            true,
+            "CRITICAL",
+            9.8,
+            vec![affected(
+                "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
+                None,
+                Some("124.0.0"),
+                None,
+            )],
+        )]);
+
+        let outcome = advisory_score_from_data(
+            &target(
+                "chrome.exe",
+                "C:/Program Files/Google/Chrome/chrome.exe",
+                "Google LLC",
+            ),
+            &inventory,
+            &cache,
+        );
+
+        assert_eq!(outcome.score_delta, 3);
+        assert!(outcome.reasons[0].contains("no fixed-version bound"));
+    }
+
+    #[test]
+    fn bounded_range_does_not_mark_reason_as_missing_fix_version_bound() {
+        let inventory = vec![installed(
+            "google-chrome",
+            "Google Chrome",
+            Some("google"),
+            Some("124.0.6367.91"),
+            &["chrome", "google-chrome"],
+            InventorySource::WindowsUninstallRegistry,
+        )];
+        let cache = cache(vec![record(
+            "CVE-2026-55555",
+            true,
+            "CRITICAL",
+            9.8,
+            vec![affected(
+                "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
+                None,
+                Some("124.0.0"),
+                Some("125.0.0"),
+            )],
+        )]);
+
+        let outcome = advisory_score_from_data(
+            &target(
+                "chrome.exe",
+                "C:/Program Files/Google/Chrome/chrome.exe",
+                "Google LLC",
+            ),
+            &inventory,
+            &cache,
+        );
+
+        assert_eq!(outcome.score_delta, 3);
+        assert!(!outcome.reasons[0].contains("no fixed-version bound"));
     }
 
     #[test]

--- a/src/security/response_rules.rs
+++ b/src/security/response_rules.rs
@@ -246,48 +246,8 @@ fn matches_rule(rule: &ResponseRule, conn: &ConnInfo) -> bool {
     }
 
     let advisory_reasons = parse_advisory_reasons(&conn.reasons);
-    if rule.require_advisory_match && advisory_reasons.is_empty() {
+    if !matches_advisory_filters(rule, &advisory_reasons) {
         return false;
-    }
-    if rule.require_known_exploited_advisory
-        && !advisory_reasons.iter().any(|reason| reason.known_exploited)
-    {
-        return false;
-    }
-    if rule.require_missing_advisory_fix_version
-        && !advisory_reasons
-            .iter()
-            .any(|reason| reason.missing_fix_version)
-    {
-        return false;
-    }
-    if let Some(text) = rule.advisory_id_contains.as_ref() {
-        let text = text.trim().to_ascii_lowercase();
-        if text.is_empty()
-            || !advisory_reasons
-                .iter()
-                .any(|reason| reason.primary_id.to_ascii_lowercase().contains(&text))
-        {
-            return false;
-        }
-    }
-    if let Some(text) = rule.advisory_product_contains.as_ref() {
-        let text = normalise_name(text);
-        if text.is_empty()
-            || !advisory_reasons
-                .iter()
-                .any(|reason| normalise_name(reason.product_name).contains(&text))
-        {
-            return false;
-        }
-    }
-    if let Some(min) = rule.min_advisory_severity {
-        if !advisory_reasons
-            .iter()
-            .any(|reason| reason.severity.is_some_and(|severity| severity >= min))
-        {
-            return false;
-        }
     }
 
     if let Some(text) = rule.process_name_contains.as_ref() {
@@ -309,6 +269,56 @@ fn matches_rule(rule: &ResponseRule, conn: &ConnInfo) -> bool {
         }
     }
     true
+}
+
+fn matches_advisory_filters(
+    rule: &ResponseRule,
+    advisory_reasons: &[ParsedAdvisoryReason<'_>],
+) -> bool {
+    let has_advisory_filter = rule.require_advisory_match
+        || rule.require_known_exploited_advisory
+        || rule.require_missing_advisory_fix_version
+        || rule.advisory_id_contains.is_some()
+        || rule.advisory_product_contains.is_some()
+        || rule.min_advisory_severity.is_some();
+    if !has_advisory_filter {
+        return true;
+    }
+    if advisory_reasons.is_empty() {
+        return false;
+    }
+
+    let advisory_id_contains = rule
+        .advisory_id_contains
+        .as_ref()
+        .map(|text| text.trim().to_ascii_lowercase())
+        .filter(|text| !text.is_empty());
+    if rule.advisory_id_contains.is_some() && advisory_id_contains.is_none() {
+        return false;
+    }
+
+    let advisory_product_contains = rule
+        .advisory_product_contains
+        .as_ref()
+        .map(|text| normalise_name(text))
+        .filter(|text| !text.is_empty());
+    if rule.advisory_product_contains.is_some() && advisory_product_contains.is_none() {
+        return false;
+    }
+
+    advisory_reasons.iter().any(|reason| {
+        (!rule.require_known_exploited_advisory || reason.known_exploited)
+            && (!rule.require_missing_advisory_fix_version || reason.missing_fix_version)
+            && advisory_id_contains
+                .as_ref()
+                .is_none_or(|text| reason.primary_id.to_ascii_lowercase().contains(text))
+            && advisory_product_contains
+                .as_ref()
+                .is_none_or(|text| normalise_name(reason.product_name).contains(text))
+            && rule
+                .min_advisory_severity
+                .is_none_or(|min| reason.severity.is_some_and(|severity| severity >= min))
+    })
 }
 
 fn parse_advisory_reasons<'a>(reasons: &'a [String]) -> Vec<ParsedAdvisoryReason<'a>> {
@@ -641,6 +651,27 @@ mod tests {
         };
 
         assert!(matches_rule(&rule, &conn));
+    }
+
+    #[test]
+    fn advisory_filters_do_not_mix_signals_from_different_reasons() {
+        let mut conn = sample_conn();
+        conn.reasons = vec![
+            "High-confidence advisory match: CVE-2026-12345 (critical 9.8, known exploited) applies to Google Chrome".into(),
+            "High-confidence advisory match: CVE-2026-99999 (medium 5.4, no fixed-version bound) applies to Example Agent".into(),
+        ];
+
+        let rule = ResponseRule {
+            require_advisory_match: true,
+            require_known_exploited_advisory: true,
+            require_missing_advisory_fix_version: true,
+            advisory_id_contains: Some("CVE-2026-12345".into()),
+            advisory_product_contains: Some("chrome".into()),
+            min_advisory_severity: Some(AdvisorySeverity::Critical),
+            ..sample_rule()
+        };
+
+        assert!(!matches_rule(&rule, &conn));
     }
 
     #[test]

--- a/src/security/response_rules.rs
+++ b/src/security/response_rules.rs
@@ -9,7 +9,7 @@
 //!
 //! Advisory-aware predicates intentionally consume only the normalized,
 //! high-confidence advisory reason strings already attached to a connection.
-//! This keeps the initial Phase 16 slice conservative: no extra live cache
+//! This keeps the Phase 16 rule slice conservative: no extra live cache
 //! lookups happen in the rule engine, and a missing or unparsable advisory
 //! reason simply leaves the advisory predicates unmatched instead of guessing.
 
@@ -64,6 +64,8 @@ pub struct ResponseRule {
     #[serde(default)]
     pub require_known_exploited_advisory: bool,
     #[serde(default)]
+    pub require_missing_advisory_fix_version: bool,
+    #[serde(default)]
     pub advisory_id_contains: Option<String>,
     #[serde(default)]
     pub advisory_product_contains: Option<String>,
@@ -100,6 +102,7 @@ struct ParsedAdvisoryReason<'a> {
     product_name: &'a str,
     severity: Option<AdvisorySeverity>,
     known_exploited: bool,
+    missing_fix_version: bool,
 }
 
 pub fn maybe_apply(conn: &ConnInfo, cfg: &Config, state: &mut EngineState) -> Option<String> {
@@ -251,6 +254,13 @@ fn matches_rule(rule: &ResponseRule, conn: &ConnInfo) -> bool {
     {
         return false;
     }
+    if rule.require_missing_advisory_fix_version
+        && !advisory_reasons
+            .iter()
+            .any(|reason| reason.missing_fix_version)
+    {
+        return false;
+    }
     if let Some(text) = rule.advisory_id_contains.as_ref() {
         let text = text.trim().to_ascii_lowercase();
         if text.is_empty()
@@ -330,6 +340,7 @@ fn parse_advisory_reason(reason: &str) -> Option<ParsedAdvisoryReason<'_>> {
 
     let mut severity = None;
     let mut known_exploited = false;
+    let mut missing_fix_version = false;
     if let Some(detail_block) = detail_block {
         for detail in detail_block
             .split(',')
@@ -338,6 +349,10 @@ fn parse_advisory_reason(reason: &str) -> Option<ParsedAdvisoryReason<'_>> {
         {
             if detail.eq_ignore_ascii_case("known exploited") {
                 known_exploited = true;
+                continue;
+            }
+            if detail.eq_ignore_ascii_case("no fixed-version bound") {
+                missing_fix_version = true;
                 continue;
             }
             if severity.is_none() {
@@ -351,6 +366,7 @@ fn parse_advisory_reason(reason: &str) -> Option<ParsedAdvisoryReason<'_>> {
         product_name,
         severity,
         known_exploited,
+        missing_fix_version,
     })
 }
 
@@ -583,9 +599,9 @@ mod tests {
     }
 
     #[test]
-    fn parses_advisory_reason_with_known_exploited_and_severity() {
+    fn parses_advisory_reason_with_known_exploited_severity_and_fix_bound_marker() {
         let parsed = parse_advisory_reason(
-            "High-confidence advisory match: CVE-2026-12345 (critical 9.8, known exploited) applies to Google Chrome",
+            "High-confidence advisory match: CVE-2026-12345 (critical 9.8, known exploited, no fixed-version bound) applies to Google Chrome",
         )
         .unwrap();
 
@@ -593,13 +609,14 @@ mod tests {
         assert_eq!(parsed.product_name, "Google Chrome");
         assert_eq!(parsed.severity, Some(AdvisorySeverity::Critical));
         assert!(parsed.known_exploited);
+        assert!(parsed.missing_fix_version);
     }
 
     #[test]
     fn advisory_filters_match_high_confidence_reason() {
         let mut conn = sample_conn();
         conn.reasons = vec![
-            "High-confidence advisory match: CVE-2026-12345 (critical 9.8, known exploited) applies to Google Chrome".into(),
+            "High-confidence advisory match: CVE-2026-12345 (critical 9.8, known exploited, no fixed-version bound) applies to Google Chrome".into(),
         ];
 
         let rule = ResponseRule {
@@ -615,6 +632,7 @@ mod tests {
             require_long_lived: false,
             require_advisory_match: true,
             require_known_exploited_advisory: true,
+            require_missing_advisory_fix_version: true,
             advisory_id_contains: Some("CVE-2026-12345".into()),
             advisory_product_contains: Some("chrome".into()),
             min_advisory_severity: Some(AdvisorySeverity::Critical),
@@ -636,6 +654,7 @@ mod tests {
         let exploited_rule = ResponseRule {
             require_advisory_match: true,
             require_known_exploited_advisory: true,
+            require_missing_advisory_fix_version: true,
             min_advisory_severity: Some(AdvisorySeverity::High),
             advisory_product_contains: Some("chrome".into()),
             ..sample_rule()
@@ -696,6 +715,7 @@ mod tests {
             require_long_lived: false,
             require_advisory_match: false,
             require_known_exploited_advisory: false,
+            require_missing_advisory_fix_version: false,
             advisory_id_contains: None,
             advisory_product_contains: None,
             min_advisory_severity: None,


### PR DESCRIPTION
## Summary
- extend the current Phase 16 mitigation-aware response-rule slice with `require_missing_advisory_fix_version`
- carry a conservative `no fixed-version bound` marker into high-confidence runtime advisory reasons only when the matched affected-product range has a lower bound and no upper bound
- document the new predicate and its intentionally narrow semantics in `docs/RESPONSE-RULES.md`

## Why this task
`ROADMAP.md` still shows `Mitigation-aware response rules` as the next unfinished Phase 16 item. PR #237 merged the earlier advisory ID / product / exploited / severity slice, and there were no open PR blockers, review threads, or failing checks to follow up, so this is the next smallest safe continuation of the same roadmap item.

## Validation
- added unit coverage in `src/advisory_runtime_score.rs` for open-ended versus bounded advisory ranges in the emitted reason text
- added unit coverage in `src/security/response_rules.rs` for parsing and matching the new advisory fix-version predicate
- not run locally in this environment because the repository was not available as a local checkout

## Scope note
This still does not complete the broader roadmap item. Vendor-guidance predicates and public-internet exposure predicates remain follow-up work.