### PR TITLE
Add mitigation-guidance advisory response predicate

### DIFF
--- a/docs/RESPONSE-RULES.md
+++ b/docs/RESPONSE-RULES.md
@@ -26,6 +26,7 @@ Supported advisory predicates:
 
 - `require_advisory_match: true`
 - `require_known_exploited_advisory: true`
+- `require_advisory_mitigation_guidance: true`
 - `require_missing_advisory_fix_version: true`
 - `advisory_id_contains: "CVE-2026-12345"`
 - `advisory_product_contains: "chrome"`
@@ -33,15 +34,18 @@ Supported advisory predicates:
 
 Supported `min_advisory_severity` values are `low`, `medium`, `high`, and `critical`.
 
+`require_advisory_mitigation_guidance` is intentionally narrow. Today it matches only when the same high-confidence advisory reason includes `mitigation guidance available`, which Vigil emits only when the matched advisory record already carries non-empty mitigation, remediation, workaround, or guidance text/URLs in the protected advisory cache. It does not classify authorship yet, so this is not a vendor-only guidance predicate.
+
 `require_missing_advisory_fix_version` is intentionally narrow. Today it matches only when the same high-confidence advisory reason includes `no fixed-version bound`, which Vigil emits only when the matched affected-product range has a lower version boundary but no upper version boundary. It does not guess from unconstrained rows or exact-version-only rows.
 
 ## Example
 
 ```yaml
 rules:
-  - name: exploited browser advisory without fix bound
+  - name: exploited browser advisory with guidance but no fix bound
     require_advisory_match: true
     require_known_exploited_advisory: true
+    require_advisory_mitigation_guidance: true
     require_missing_advisory_fix_version: true
     advisory_product_contains: chrome
     min_advisory_severity: critical
@@ -49,7 +53,7 @@ rules:
     duration: 24h
 ```
 
-This example only matches when Vigil already found one high-confidence applicable advisory reason for a Chrome-family product, marked it as known exploited, rated it at least critical, and could not find an upper fixed-version bound on the matched advisory range.
+This example only matches when Vigil already found one high-confidence applicable advisory reason for a Chrome-family product, marked it as known exploited, preserved that mitigation guidance is available in the protected advisory cache, rated it at least critical, and could not find an upper fixed-version bound on the matched advisory range.
 
 ## Current scope limits
 
@@ -61,9 +65,10 @@ Today the rule engine can match only these advisory attributes:
 - affected product text
 - known exploited flag
 - normalized severity floor
+- mitigation guidance availability in the protected advisory cache
 - missing fixed-version bound on the matched advisory range
 
-The broader roadmap item still remains open for attributes such as vendor guidance and exposure on the public internet.
+The broader roadmap item still remains open for attributes such as vendor-specific guidance and exposure on the public internet.
 
 ## Actions
 

--- a/src/advisory_runtime_score.rs
+++ b/src/advisory_runtime_score.rs
@@ -44,6 +44,7 @@ struct RuntimeAdvisoryCandidate {
     severity_label: Option<String>,
     severity_rank: u8,
     known_exploited: bool,
+    mitigation_guidance: bool,
     missing_fix_version: bool,
     score_delta: u8,
 }
@@ -169,6 +170,7 @@ fn build_candidate(
         severity_label: severity.map(|summary| summary.label),
         severity_rank,
         known_exploited: record.known_exploited,
+        mitigation_guidance: has_mitigation_guidance(record),
         missing_fix_version: matched.missing_fix_version,
         score_delta: advisory_score_delta(record.known_exploited, severity_rank),
     })
@@ -181,6 +183,9 @@ fn advisory_reason(candidate: &RuntimeAdvisoryCandidate) -> String {
     }
     if candidate.known_exploited {
         details.push("known exploited".to_string());
+    }
+    if candidate.mitigation_guidance {
+        details.push("mitigation guidance available".to_string());
     }
     if candidate.missing_fix_version {
         details.push("no fixed-version bound".to_string());
@@ -199,6 +204,13 @@ fn advisory_reason(candidate: &RuntimeAdvisoryCandidate) -> String {
             candidate.product_name
         )
     }
+}
+
+fn has_mitigation_guidance(record: &VulnerabilityRecord) -> bool {
+    record
+        .mitigations
+        .iter()
+        .any(|guidance| !guidance.trim().is_empty())
 }
 
 fn advisory_score_delta(known_exploited: bool, severity_rank: u8) -> u8 {
@@ -538,6 +550,7 @@ mod tests {
         assert!(outcome.reasons[0].contains("CVE-2026-12345"));
         assert!(outcome.reasons[0].contains("known exploited"));
         assert!(outcome.reasons[0].contains("Google Chrome"));
+        assert!(!outcome.reasons[0].contains("mitigation guidance available"));
         assert!(!outcome.reasons[0].contains("no fixed-version bound"));
     }
 
@@ -642,6 +655,45 @@ mod tests {
 
         assert_eq!(outcome.score_delta, 2);
         assert!(outcome.reasons[0].contains("critical 9.1"));
+    }
+
+    #[test]
+    fn mitigation_guidance_marks_reason_when_record_has_guidance() {
+        let inventory = vec![installed(
+            "google-chrome",
+            "Google Chrome",
+            Some("google"),
+            Some("124.0.6367.91"),
+            &["chrome", "google-chrome"],
+            InventorySource::WindowsUninstallRegistry,
+        )];
+        let mut advisory = record(
+            "CVE-2026-42222",
+            true,
+            "CRITICAL",
+            9.8,
+            vec![affected(
+                "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
+                None,
+                None,
+                None,
+            )],
+        );
+        advisory.mitigations = vec!["https://example.test/vendor-guidance".into()];
+        let cache = cache(vec![advisory]);
+
+        let outcome = advisory_score_from_data(
+            &target(
+                "chrome.exe",
+                "C:/Program Files/Google/Chrome/chrome.exe",
+                "Google LLC",
+            ),
+            &inventory,
+            &cache,
+        );
+
+        assert_eq!(outcome.score_delta, 3);
+        assert!(outcome.reasons[0].contains("mitigation guidance available"));
     }
 
     #[test]

--- a/src/advisory_runtime_score.rs
+++ b/src/advisory_runtime_score.rs
@@ -136,6 +136,7 @@ fn advisory_score_from_data(
             .cmp(&left.known_exploited)
             .then_with(|| right.score_delta.cmp(&left.score_delta))
             .then_with(|| right.severity_rank.cmp(&left.severity_rank))
+            .then_with(|| right.mitigation_guidance.cmp(&left.mitigation_guidance))
             .then_with(|| left.primary_id.cmp(&right.primary_id))
     });
 
@@ -693,6 +694,58 @@ mod tests {
         );
 
         assert_eq!(outcome.score_delta, 3);
+        assert!(outcome.reasons[0].contains("mitigation guidance available"));
+    }
+
+    #[test]
+    fn mitigation_guidance_wins_ties_between_equally_ranked_matches() {
+        let inventory = vec![installed(
+            "google-chrome",
+            "Google Chrome",
+            Some("google"),
+            Some("124.0.6367.91"),
+            &["chrome", "google-chrome"],
+            InventorySource::WindowsUninstallRegistry,
+        )];
+        let without_guidance = record(
+            "CVE-2026-10000",
+            true,
+            "CRITICAL",
+            9.8,
+            vec![affected(
+                "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
+                None,
+                None,
+                None,
+            )],
+        );
+        let mut with_guidance = record(
+            "CVE-2026-99999",
+            true,
+            "CRITICAL",
+            9.8,
+            vec![affected(
+                "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
+                None,
+                None,
+                None,
+            )],
+        );
+        with_guidance.mitigations = vec!["https://example.test/vendor-guidance".into()];
+        let cache = cache(vec![without_guidance, with_guidance]);
+
+        let outcome = advisory_score_from_data(
+            &target(
+                "chrome.exe",
+                "C:/Program Files/Google/Chrome/chrome.exe",
+                "Google LLC",
+            ),
+            &inventory,
+            &cache,
+        );
+
+        assert_eq!(outcome.score_delta, 3);
+        assert!(outcome.reasons[0].contains("CVE-2026-99999"));
         assert!(outcome.reasons[0].contains("mitigation guidance available"));
     }
 

--- a/src/security/response_rules.rs
+++ b/src/security/response_rules.rs
@@ -64,6 +64,8 @@ pub struct ResponseRule {
     #[serde(default)]
     pub require_known_exploited_advisory: bool,
     #[serde(default)]
+    pub require_advisory_mitigation_guidance: bool,
+    #[serde(default)]
     pub require_missing_advisory_fix_version: bool,
     #[serde(default)]
     pub advisory_id_contains: Option<String>,
@@ -102,6 +104,7 @@ struct ParsedAdvisoryReason<'a> {
     product_name: &'a str,
     severity: Option<AdvisorySeverity>,
     known_exploited: bool,
+    mitigation_guidance: bool,
     missing_fix_version: bool,
 }
 
@@ -277,6 +280,7 @@ fn matches_advisory_filters(
 ) -> bool {
     let has_advisory_filter = rule.require_advisory_match
         || rule.require_known_exploited_advisory
+        || rule.require_advisory_mitigation_guidance
         || rule.require_missing_advisory_fix_version
         || rule.advisory_id_contains.is_some()
         || rule.advisory_product_contains.is_some()
@@ -308,6 +312,7 @@ fn matches_advisory_filters(
 
     advisory_reasons.iter().any(|reason| {
         (!rule.require_known_exploited_advisory || reason.known_exploited)
+            && (!rule.require_advisory_mitigation_guidance || reason.mitigation_guidance)
             && (!rule.require_missing_advisory_fix_version || reason.missing_fix_version)
             && advisory_id_contains
                 .as_ref()
@@ -350,6 +355,7 @@ fn parse_advisory_reason(reason: &str) -> Option<ParsedAdvisoryReason<'_>> {
 
     let mut severity = None;
     let mut known_exploited = false;
+    let mut mitigation_guidance = false;
     let mut missing_fix_version = false;
     if let Some(detail_block) = detail_block {
         for detail in detail_block
@@ -359,6 +365,10 @@ fn parse_advisory_reason(reason: &str) -> Option<ParsedAdvisoryReason<'_>> {
         {
             if detail.eq_ignore_ascii_case("known exploited") {
                 known_exploited = true;
+                continue;
+            }
+            if detail.eq_ignore_ascii_case("mitigation guidance available") {
+                mitigation_guidance = true;
                 continue;
             }
             if detail.eq_ignore_ascii_case("no fixed-version bound") {
@@ -376,6 +386,7 @@ fn parse_advisory_reason(reason: &str) -> Option<ParsedAdvisoryReason<'_>> {
         product_name,
         severity,
         known_exploited,
+        mitigation_guidance,
         missing_fix_version,
     })
 }
@@ -609,9 +620,9 @@ mod tests {
     }
 
     #[test]
-    fn parses_advisory_reason_with_known_exploited_severity_and_fix_bound_marker() {
+    fn parses_advisory_reason_with_known_exploited_guidance_severity_and_fix_bound_marker() {
         let parsed = parse_advisory_reason(
-            "High-confidence advisory match: CVE-2026-12345 (critical 9.8, known exploited, no fixed-version bound) applies to Google Chrome",
+            "High-confidence advisory match: CVE-2026-12345 (critical 9.8, known exploited, mitigation guidance available, no fixed-version bound) applies to Google Chrome",
         )
         .unwrap();
 
@@ -619,6 +630,7 @@ mod tests {
         assert_eq!(parsed.product_name, "Google Chrome");
         assert_eq!(parsed.severity, Some(AdvisorySeverity::Critical));
         assert!(parsed.known_exploited);
+        assert!(parsed.mitigation_guidance);
         assert!(parsed.missing_fix_version);
     }
 
@@ -626,7 +638,7 @@ mod tests {
     fn advisory_filters_match_high_confidence_reason() {
         let mut conn = sample_conn();
         conn.reasons = vec![
-            "High-confidence advisory match: CVE-2026-12345 (critical 9.8, known exploited, no fixed-version bound) applies to Google Chrome".into(),
+            "High-confidence advisory match: CVE-2026-12345 (critical 9.8, known exploited, mitigation guidance available, no fixed-version bound) applies to Google Chrome".into(),
         ];
 
         let rule = ResponseRule {
@@ -642,6 +654,7 @@ mod tests {
             require_long_lived: false,
             require_advisory_match: true,
             require_known_exploited_advisory: true,
+            require_advisory_mitigation_guidance: true,
             require_missing_advisory_fix_version: true,
             advisory_id_contains: Some("CVE-2026-12345".into()),
             advisory_product_contains: Some("chrome".into()),
@@ -658,12 +671,13 @@ mod tests {
         let mut conn = sample_conn();
         conn.reasons = vec![
             "High-confidence advisory match: CVE-2026-12345 (critical 9.8, known exploited) applies to Google Chrome".into(),
-            "High-confidence advisory match: CVE-2026-99999 (medium 5.4, no fixed-version bound) applies to Example Agent".into(),
+            "High-confidence advisory match: CVE-2026-99999 (medium 5.4, mitigation guidance available, no fixed-version bound) applies to Example Agent".into(),
         ];
 
         let rule = ResponseRule {
             require_advisory_match: true,
             require_known_exploited_advisory: true,
+            require_advisory_mitigation_guidance: true,
             require_missing_advisory_fix_version: true,
             advisory_id_contains: Some("CVE-2026-12345".into()),
             advisory_product_contains: Some("chrome".into()),
@@ -685,6 +699,7 @@ mod tests {
         let exploited_rule = ResponseRule {
             require_advisory_match: true,
             require_known_exploited_advisory: true,
+            require_advisory_mitigation_guidance: true,
             require_missing_advisory_fix_version: true,
             min_advisory_severity: Some(AdvisorySeverity::High),
             advisory_product_contains: Some("chrome".into()),
@@ -746,6 +761,7 @@ mod tests {
             require_long_lived: false,
             require_advisory_match: false,
             require_known_exploited_advisory: false,
+            require_advisory_mitigation_guidance: false,
             require_missing_advisory_fix_version: false,
             advisory_id_contains: None,
             advisory_product_contains: None,


### PR DESCRIPTION
## Summary
- extend the current Phase 16 mitigation-aware response-rule slice with `require_advisory_mitigation_guidance`
- carry a conservative `mitigation guidance available` marker into high-confidence runtime advisory reasons when the matched advisory record already has non-empty mitigation/remediation/guidance text or URLs in the protected cache
- document the new predicate and its intentionally narrow semantics in `docs/RESPONSE-RULES.md`

## Why this task
`ROADMAP.md` still shows `Mitigation-aware response rules` as the next unfinished Phase 16 item, and there were no open PR blockers, review threads, or failing checks to follow up first.

The prior merged slices already covered advisory ID, product text, exploited state, severity, and missing fixed-version bounds. The next smallest safe continuation is to let operators react to mitigation guidance that Vigil already preserves in the protected advisory cache, without adding new live cache lookups or claiming vendor-specific authorship that the current normalized model does not prove.

## Validation
- added unit coverage in `src/advisory_runtime_score.rs` for emitting the mitigation-guidance marker only when the matched advisory record carries guidance data
- added unit coverage in `src/security/response_rules.rs` for parsing and matching the new mitigation-guidance predicate alongside the existing advisory filters
- not run locally in this environment because the repository could not be cloned into the workspace here, so GitHub CI should be treated as the first compile/test pass

## Scope note
This still does not complete the broader roadmap item. Vendor-specific guidance predicates and public-internet exposure predicates remain follow-up work.