### PR TITLE
Add conservative public-exposure advisory rule predicate

### DIFF
--- a/docs/RESPONSE-RULES.md
+++ b/docs/RESPONSE-RULES.md
@@ -27,6 +27,7 @@ Supported advisory predicates:
 - `require_advisory_match: true`
 - `require_known_exploited_advisory: true`
 - `require_advisory_mitigation_guidance: true`
+- `require_advisory_public_internet_exposure: true`
 - `require_missing_advisory_fix_version: true`
 - `advisory_id_contains: "CVE-2026-12345"`
 - `advisory_product_contains: "chrome"`
@@ -35,6 +36,8 @@ Supported advisory predicates:
 Supported `min_advisory_severity` values are `low`, `medium`, `high`, and `critical`.
 
 `require_advisory_mitigation_guidance` is intentionally narrow. Today it matches only when the same high-confidence advisory reason includes `mitigation guidance available`, which Vigil emits only when the matched advisory record already carries non-empty mitigation, remediation, workaround, or guidance text/URLs in the protected advisory cache. It does not classify authorship yet, so this is not a vendor-only guidance predicate.
+
+`require_advisory_public_internet_exposure` is intentionally narrow. Today it matches only when the same connection event is a `LISTEN` socket bound to an obviously globally routable local IP address. It does not infer exposure through NAT, wildcard binds, reverse proxies, or reachability beyond what Vigil can observe locally.
 
 `require_missing_advisory_fix_version` is intentionally narrow. Today it matches only when the same high-confidence advisory reason includes `no fixed-version bound`, which Vigil emits only when the matched affected-product range has a lower version boundary but no upper version boundary. It does not guess from unconstrained rows or exact-version-only rows.
 
@@ -66,9 +69,10 @@ Today the rule engine can match only these advisory attributes:
 - known exploited flag
 - normalized severity floor
 - mitigation guidance availability in the protected advisory cache
+- obvious public-internet exposure for a current listening socket bound to a globally routable local IP
 - missing fixed-version bound on the matched advisory range
 
-The broader roadmap item still remains open for attributes such as vendor-specific guidance and exposure on the public internet.
+The broader roadmap item still remains open for attributes such as vendor-specific guidance and broader exposure inference beyond an obviously globally routable listener.
 
 ## Actions
 

--- a/src/security/response_rules.rs
+++ b/src/security/response_rules.rs
@@ -22,6 +22,7 @@ use crate::{
 use serde::Deserialize;
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::path::Path;
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
@@ -65,6 +66,8 @@ pub struct ResponseRule {
     pub require_known_exploited_advisory: bool,
     #[serde(default)]
     pub require_advisory_mitigation_guidance: bool,
+    #[serde(default)]
+    pub require_advisory_public_internet_exposure: bool,
     #[serde(default)]
     pub require_missing_advisory_fix_version: bool,
     #[serde(default)]
@@ -249,7 +252,7 @@ fn matches_rule(rule: &ResponseRule, conn: &ConnInfo) -> bool {
     }
 
     let advisory_reasons = parse_advisory_reasons(&conn.reasons);
-    if !matches_advisory_filters(rule, &advisory_reasons) {
+    if !matches_advisory_filters(rule, conn, &advisory_reasons) {
         return false;
     }
 
@@ -276,11 +279,13 @@ fn matches_rule(rule: &ResponseRule, conn: &ConnInfo) -> bool {
 
 fn matches_advisory_filters(
     rule: &ResponseRule,
+    conn: &ConnInfo,
     advisory_reasons: &[ParsedAdvisoryReason<'_>],
 ) -> bool {
     let has_advisory_filter = rule.require_advisory_match
         || rule.require_known_exploited_advisory
         || rule.require_advisory_mitigation_guidance
+        || rule.require_advisory_public_internet_exposure
         || rule.require_missing_advisory_fix_version
         || rule.advisory_id_contains.is_some()
         || rule.advisory_product_contains.is_some()
@@ -289,6 +294,11 @@ fn matches_advisory_filters(
         return true;
     }
     if advisory_reasons.is_empty() {
+        return false;
+    }
+    if rule.require_advisory_public_internet_exposure
+        && !is_public_internet_exposed_listener(conn)
+    {
         return false;
     }
 
@@ -400,6 +410,79 @@ fn parse_advisory_severity(text: &str) -> Option<AdvisorySeverity> {
         "critical" => Some(AdvisorySeverity::Critical),
         _ => None,
     }
+}
+
+fn is_public_internet_exposed_listener(conn: &ConnInfo) -> bool {
+    if !conn.status.eq_ignore_ascii_case("LISTEN") {
+        return false;
+    }
+    let Some(host) = conn
+        .local_addr
+        .rsplit_once(':')
+        .map(|(host, _)| host.trim_matches(['[', ']']))
+    else {
+        return false;
+    };
+    let Ok(ip) = host.parse::<IpAddr>() else {
+        return false;
+    };
+    is_globally_routable_ip(ip)
+}
+
+fn is_globally_routable_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ipv4) => is_globally_routable_ipv4(ipv4),
+        IpAddr::V6(ipv6) => is_globally_routable_ipv6(ipv6),
+    }
+}
+
+fn is_globally_routable_ipv4(ip: Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    if ip.is_private()
+        || ip.is_loopback()
+        || ip.is_link_local()
+        || ip.is_broadcast()
+        || ip.is_unspecified()
+        || octets[0] == 0
+        || octets[0] >= 224
+    {
+        return false;
+    }
+
+    let shared_address_space = octets[0] == 100 && (64..=127).contains(&octets[1]);
+    let iana_protocol_assignments = octets[0] == 192 && octets[1] == 0 && octets[2] == 0;
+    let deprecated_relay = octets[0] == 192 && octets[1] == 88 && octets[2] == 99;
+    let documentation = matches!(
+        (octets[0], octets[1], octets[2]),
+        (192, 0, 2) | (198, 51, 100) | (203, 0, 113)
+    );
+    let benchmarking = octets[0] == 198 && (octets[1] == 18 || octets[1] == 19);
+
+    !(shared_address_space
+        || iana_protocol_assignments
+        || deprecated_relay
+        || documentation
+        || benchmarking)
+}
+
+fn is_globally_routable_ipv6(ip: Ipv6Addr) -> bool {
+    if let Some(mapped) = ip.to_ipv4() {
+        return is_globally_routable_ipv4(mapped);
+    }
+
+    let segments = ip.segments();
+    let unique_local = (segments[0] & 0xfe00) == 0xfc00;
+    let unicast_link_local = (segments[0] & 0xffc0) == 0xfe80;
+    let deprecated_site_local = (segments[0] & 0xffc0) == 0xfec0;
+    let documentation = segments[0] == 0x2001 && segments[1] == 0x0db8;
+
+    !(ip.is_loopback()
+        || ip.is_unspecified()
+        || ip.is_multicast()
+        || unique_local
+        || unicast_link_local
+        || deprecated_site_local
+        || documentation)
 }
 
 #[derive(Debug, Clone)]
@@ -655,6 +738,7 @@ mod tests {
             require_advisory_match: true,
             require_known_exploited_advisory: true,
             require_advisory_mitigation_guidance: true,
+            require_advisory_public_internet_exposure: false,
             require_missing_advisory_fix_version: true,
             advisory_id_contains: Some("CVE-2026-12345".into()),
             advisory_product_contains: Some("chrome".into()),
@@ -685,6 +769,41 @@ mod tests {
             ..sample_rule()
         };
 
+        assert!(!matches_rule(&rule, &conn));
+    }
+
+    #[test]
+    fn advisory_public_internet_exposure_matches_only_global_listeners() {
+        let mut conn = sample_conn();
+        conn.status = "LISTEN".into();
+        conn.remote_addr = "LISTEN".into();
+        conn.reasons = vec![
+            "High-confidence advisory match: CVE-2026-12345 (critical 9.8, known exploited) applies to Google Chrome".into(),
+        ];
+
+        let rule = ResponseRule {
+            require_advisory_match: true,
+            require_advisory_public_internet_exposure: true,
+            ..sample_rule()
+        };
+
+        conn.local_addr = "8.8.8.8:443".into();
+        assert!(matches_rule(&rule, &conn));
+
+        conn.local_addr = "10.0.0.5:443".into();
+        assert!(!matches_rule(&rule, &conn));
+
+        conn.local_addr = "0.0.0.0:443".into();
+        assert!(!matches_rule(&rule, &conn));
+
+        conn.local_addr = "2607:f8b0:4005:80a::200e:443".into();
+        assert!(matches_rule(&rule, &conn));
+
+        conn.local_addr = "2001:db8::1:443".into();
+        assert!(!matches_rule(&rule, &conn));
+
+        conn.local_addr = "8.8.8.8:443".into();
+        conn.status = "ESTABLISHED".into();
         assert!(!matches_rule(&rule, &conn));
     }
 
@@ -762,6 +881,7 @@ mod tests {
             require_advisory_match: false,
             require_known_exploited_advisory: false,
             require_advisory_mitigation_guidance: false,
+            require_advisory_public_internet_exposure: false,
             require_missing_advisory_fix_version: false,
             advisory_id_contains: None,
             advisory_product_contains: None,

--- a/src/security/response_rules.rs
+++ b/src/security/response_rules.rs
@@ -296,8 +296,7 @@ fn matches_advisory_filters(
     if advisory_reasons.is_empty() {
         return false;
     }
-    if rule.require_advisory_public_internet_exposure
-        && !is_public_internet_exposed_listener(conn)
+    if rule.require_advisory_public_internet_exposure && !is_public_internet_exposed_listener(conn)
     {
         return false;
     }


### PR DESCRIPTION
## Summary
- add `require_advisory_public_internet_exposure` to the response-rule engine
- match that predicate only for advisory-bearing `LISTEN` events bound to obviously globally routable local IPs
- add focused regression coverage for public vs private, wildcard, IPv6 documentation, and non-listener cases
- document the new predicate and its intentionally narrow semantics in `docs/RESPONSE-RULES.md`

## Why this task
`ROADMAP.md` still leaves `Mitigation-aware response rules` open as the next unfinished Phase 16 item. With no open PR follow-up work left in the repo, the next smallest safe slice was the roadmap’s remaining `exposure on the public internet` attribute.

This implementation stays conservative on purpose:
- no new advisory cache lookups in the rule engine
- no NAT, wildcard-bind, or reverse-proxy inference
- only current listening sockets on obviously globally routable local IPs count as public exposure
- advisory matching still fail-opens when the event or reason text is missing or unparsable

## Validation
- added unit coverage for the new predicate across public IPv4, private IPv4, wildcard IPv4, global IPv6, documentation IPv6, and non-`LISTEN` events
- relied on GitHub-side diff inspection in this environment because the Vigil repository is not available as a local checkout here, so CI should be treated as the first compile/test pass

## Scope note
This does not complete the broader roadmap item. Vendor-specific guidance and broader exposure inference beyond an obviously globally routable listener remain follow-up slices.