### PR TITLE
docs: clarify roadmap status for advisory response rules

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,7 +35,7 @@ Use free public vulnerability and advisory sources to help Vigil keep the local 
 
 - [x] **Local advisory inspector** — show matched public advisories, CVEs, severity, known-exploitation flags, fixed versions, mitigation links, and source references for the selected process or installed product.
 - [x] **Conservative scoring hooks** — optionally raise score only when a live process or exposed service maps with high confidence to a severe or exploited public vulnerability, with clear reasons and low-noise defaults.
-- [ ] **Mitigation-aware response rules** — let operators build response rules around advisory attributes such as exploited status, vendor guidance, affected product, fixed-version absence, or exposure on the public internet.
+- [x] **Mitigation-aware response rules** — let operators build response rules around advisory attributes such as exploited status, vendor guidance, affected product, fixed-version absence, or exposure on the public internet.
 - [ ] **Public-source-to-blocklist/rule-pack conversion** — derive optional signed local IP, domain, hash, or process rule packs from high-confidence public advisories and NCSC/BSI technical content where indicators are explicitly published.
 - [ ] **Exposure-first prioritization** — prioritize vulnerabilities that are both relevant to the local machine and actually exposed through a running process, listening service, or browser-facing component.
 - [ ] **Offline-first and fail-open behaviour** — keep protection working from the last trusted cache, never weaken existing detection if source refresh fails, and surface stale or partial-source state clearly to the operator.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,7 +35,7 @@ Use free public vulnerability and advisory sources to help Vigil keep the local 
 
 - [x] **Local advisory inspector** — show matched public advisories, CVEs, severity, known-exploitation flags, fixed versions, mitigation links, and source references for the selected process or installed product.
 - [x] **Conservative scoring hooks** — optionally raise score only when a live process or exposed service maps with high confidence to a severe or exploited public vulnerability, with clear reasons and low-noise defaults.
-- [x] **Mitigation-aware response rules** — let operators build response rules around advisory attributes such as exploited status, vendor guidance, affected product, fixed-version absence, or exposure on the public internet.
+- [ ] **Mitigation-aware response rules** — the initial conservative advisory-aware predicate slice is shipped, but broader roadmap work remains for richer guidance attribution and wider exposure inference.
 - [ ] **Public-source-to-blocklist/rule-pack conversion** — derive optional signed local IP, domain, hash, or process rule packs from high-confidence public advisories and NCSC/BSI technical content where indicators are explicitly published.
 - [ ] **Exposure-first prioritization** — prioritize vulnerabilities that are both relevant to the local machine and actually exposed through a running process, listening service, or browser-facing component.
 - [ ] **Offline-first and fail-open behaviour** — keep protection working from the last trusted cache, never weaken existing detection if source refresh fails, and surface stale or partial-source state clearly to the operator.


### PR DESCRIPTION
## Summary
- keep the Phase 16 mitigation-aware response-rules roadmap item open
- clarify that the initial conservative advisory-aware predicate slice is already shipped
- align the roadmap wording with the current code and operator docs

## Why
`src/security/response_rules.rs`, `src/advisory_runtime_score.rs`, and `docs/RESPONSE-RULES.md` show that an initial advisory-aware response-rule slice is implemented. They also show that the broader roadmap item remains open for richer guidance attribution and wider exposure inference, so the roadmap should not mark the entire item complete yet.

## Validation relied on
- inspected the current `master` implementation for the shipped advisory-aware rule predicates and tests
- confirmed the operator docs still describe the broader roadmap item as intentionally unfinished

## Risk
Documentation-only change. No runtime behavior changes.
