### PR TITLE
Docs: surface advisory-aware response rule examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ contract and startup-safety rule.
 ## Documentation
 
 - [User guide](docs/USER-GUIDE.md) — released functionality and operator workflows
+- [Response rules](docs/RESPONSE-RULES.md) — YAML syntax, advisory-aware predicates, and example rule patterns
 - [Supported platforms](docs/SUPPORTED-PLATFORMS.md) — Windows/Linux support contract
 - [Security policy](SECURITY.md) — vulnerability reporting and security contacts
 - [OpenSSF Best Practices controls](docs/OPENSSF-BEST-PRACTICES.md) — repository controls and maintainer settings
@@ -132,6 +133,11 @@ exist locally, print explainable product-to-advisory matches with:
 ```bash
 vigil --advisory-match-status
 ```
+
+Use [`docs/RESPONSE-RULES.md`](docs/RESPONSE-RULES.md) together with
+[`response-rules.example.yaml`](response-rules.example.yaml) when you want to
+turn those high-confidence advisory matches into conservative operator-managed
+response rules.
 
 Use `--sync-nvd --force` only when you need to override the normal 2-hour
 minimum interval. Provide an API key via `VIGIL_NVD_API_KEY` if the deployment

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -93,7 +93,7 @@ The Settings tab stores changes automatically. Common settings include:
 - autostart at login
 - trusted processes
 - allowlist-only mode
-- user-defined response rules
+- user-defined response rules, including conservative advisory-aware predicates
 - scheduled lockdown
 - break-glass recovery timeout
 - forensic capture options
@@ -106,6 +106,8 @@ Configured blocklists and response-rule YAML stay operator-managed: Vigil can ve
 By default, Vigil also requires an extra typed confirmation before turning on disruptive protections such as auto response, allowlist-only mode, scheduled lockdown, or decoy-triggered auto-isolation. That guardrail is there so a non-expert user does not enable a feature that can cut off normal software or network access without pausing to review the consequences.
 
 The Trusted Processes section now includes a short onboarding tutorial. It explains how to keep the shipped baseline, learn from Activity and the Inspector, and add only stable apps you already recognize.
+
+Response rules can also match high-confidence advisory context conservatively, including known-exploited status, mitigation-guidance availability, missing fixed-version bounds, affected-product text, and obvious public-internet exposure for a globally routable listening socket. See [Response rules](RESPONSE-RULES.md) and `response-rules.example.yaml` for the exact YAML fields and example patterns.
 
 ### Help
 
@@ -207,6 +209,8 @@ vigil --import-bsi certbund-feed.xml bsi-advisories.json
 ```
 
 The NCSC and BSI/CERT-Bund importers accept either RSS snapshots or mirrored JSON, then preserve source links, identifiers, timestamps, and other provenance fields in the same protected advisory cache as the other Phase 16 sources.
+
+Once Vigil has both the protected advisory cache and a local software inventory snapshot, you can also use those matches as conservative inputs for operator-managed response rules. The dedicated [Response rules](RESPONSE-RULES.md) guide and `response-rules.example.yaml` show how to keep that automation explainable and fail-open.
 
 ## Local software inventory
 

--- a/response-rules.example.yaml
+++ b/response-rules.example.yaml
@@ -23,3 +23,13 @@ rules:
     remote_contains: .example
     action: block_process
     duration: 1h
+
+  - name: block_known_exploited_browser_without_fix_bound
+    require_advisory_match: true
+    require_known_exploited_advisory: true
+    require_advisory_mitigation_guidance: true
+    require_missing_advisory_fix_version: true
+    advisory_product_contains: chrome
+    min_advisory_severity: critical
+    action: block_process
+    duration: 24h


### PR DESCRIPTION
## Summary

This follow-up keeps the shipped Phase 16 advisory-aware response-rule slice discoverable and usable for operators.

- refresh `response-rules.example.yaml` with a concrete advisory-aware rule example
- link the dedicated response-rules guide from the README
- call out the conservative advisory-aware predicates in the user guide and point readers to the exact YAML reference

## Why this task

There were no open PRs, review threads, or CI blockers to follow up on. The roadmap's next unfinished item is **Mitigation-aware response rules**, and the codebase already ships the initial conservative predicate slice plus dedicated docs. The missing piece was operator-facing discoverability outside the dedicated doc.

## Validation

- compared branch diff against `master` to confirm the change stays documentation-only and in scope
- relied on existing `docs/RESPONSE-RULES.md` and `src/security/response_rules.rs` behavior as the source of truth for the example fields

## Remaining scope

The broader roadmap item still remains open for richer guidance attribution and wider exposure inference, as already noted in `ROADMAP.md` and `docs/RESPONSE-RULES.md`.
