### PR TITLE
Phase 16: preserve remediation-tagged advisory guidance signals

### DIFF
--- a/docs/RESPONSE-RULES.md
+++ b/docs/RESPONSE-RULES.md
@@ -35,7 +35,7 @@ Supported advisory predicates:
 
 Supported `min_advisory_severity` values are `low`, `medium`, `high`, and `critical`.
 
-`require_advisory_mitigation_guidance` is intentionally narrow. Today it matches only when the same high-confidence advisory reason includes `mitigation guidance available`, which Vigil emits only when the matched advisory record already carries non-empty mitigation, remediation, workaround, or guidance text/URLs in the protected advisory cache. It does not classify authorship yet, so this is not a vendor-only guidance predicate.
+`require_advisory_mitigation_guidance` is intentionally narrow. Today it matches only when the same high-confidence advisory reason includes `mitigation guidance available`, which Vigil emits only when the matched advisory record already carries non-empty mitigation, remediation, workaround, or guidance text/URLs in the protected advisory cache, or a clearly remediation-tagged reference URL such as `Mitigation`, `Patch`, or `Workaround`. It does not classify authorship yet, so this is not a vendor-only guidance predicate.
 
 `require_advisory_public_internet_exposure` is intentionally narrow. Today it matches only when the same connection event is a `LISTEN` socket bound to an obviously globally routable local IP address. It does not infer exposure through NAT, wildcard binds, reverse proxies, or reachability beyond what Vigil can observe locally.
 

--- a/src/advisory_runtime_score.rs
+++ b/src/advisory_runtime_score.rs
@@ -1,4 +1,7 @@
-use crate::advisory::{AdvisoryCache, AffectedProduct, VulnerabilityRecord, VulnerabilitySeverity};
+use crate::advisory::{
+    AdvisoryCache, AffectedProduct, VulnerabilityRecord, VulnerabilityReference,
+    VulnerabilitySeverity,
+};
 use crate::advisory_match::{
     evaluate_affected_product_match, AffectedProductMatch, AffectedProductRef, InstalledProductRef,
     MatchConfidence, VersionMatchStatus,
@@ -228,6 +231,42 @@ fn has_mitigation_guidance(record: &VulnerabilityRecord) -> bool {
         .mitigations
         .iter()
         .any(|guidance| !guidance.trim().is_empty())
+        || record
+            .references
+            .iter()
+            .any(reference_has_mitigation_guidance)
+}
+
+fn reference_has_mitigation_guidance(reference: &VulnerabilityReference) -> bool {
+    !reference.url.trim().is_empty()
+        && reference
+            .tags
+            .iter()
+            .any(|tag| mitigation_reference_tag(tag))
+}
+
+fn mitigation_reference_tag(tag: &str) -> bool {
+    let normalized = tag
+        .trim()
+        .to_ascii_lowercase()
+        .replace(['-', '_', '/'], " ");
+    normalized.split_whitespace().any(|token| {
+        matches!(
+            token,
+            "mitigation"
+                | "mitigations"
+                | "remediation"
+                | "remediations"
+                | "workaround"
+                | "workarounds"
+                | "solution"
+                | "solutions"
+                | "fix"
+                | "fixes"
+                | "patch"
+                | "patches"
+        )
+    })
 }
 
 fn advisory_score_delta(known_exploited: bool, severity_rank: u8) -> u8 {
@@ -711,6 +750,92 @@ mod tests {
 
         assert_eq!(outcome.score_delta, 3);
         assert!(outcome.reasons[0].contains("mitigation guidance available"));
+    }
+
+    #[test]
+    fn mitigation_guidance_marks_reason_when_record_has_tagged_reference() {
+        let inventory = vec![installed(
+            "google-chrome",
+            "Google Chrome",
+            Some("google"),
+            Some("124.0.6367.91"),
+            &["chrome", "google-chrome"],
+            InventorySource::WindowsUninstallRegistry,
+        )];
+        let mut advisory = record(
+            "CVE-2026-43333",
+            true,
+            "CRITICAL",
+            9.8,
+            vec![affected(
+                "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
+                None,
+                None,
+                None,
+            )],
+        );
+        advisory.references = vec![VulnerabilityReference {
+            url: "https://example.test/patch".into(),
+            source: Some("nvd".into()),
+            tags: vec!["Patch".into()],
+        }];
+        let cache = cache(vec![advisory]);
+
+        let outcome = advisory_score_from_data(
+            &target(
+                "chrome.exe",
+                "C:/Program Files/Google/Chrome/chrome.exe",
+                "Google LLC",
+            ),
+            &inventory,
+            &cache,
+        );
+
+        assert_eq!(outcome.score_delta, 3);
+        assert!(outcome.reasons[0].contains("mitigation guidance available"));
+    }
+
+    #[test]
+    fn vendor_advisory_reference_without_remediation_tag_stays_unmatched() {
+        let inventory = vec![installed(
+            "google-chrome",
+            "Google Chrome",
+            Some("google"),
+            Some("124.0.6367.91"),
+            &["chrome", "google-chrome"],
+            InventorySource::WindowsUninstallRegistry,
+        )];
+        let mut advisory = record(
+            "CVE-2026-44445",
+            true,
+            "CRITICAL",
+            9.8,
+            vec![affected(
+                "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
+                None,
+                None,
+                None,
+            )],
+        );
+        advisory.references = vec![VulnerabilityReference {
+            url: "https://example.test/vendor-advisory".into(),
+            source: Some("nvd".into()),
+            tags: vec!["Vendor Advisory".into()],
+        }];
+        let cache = cache(vec![advisory]);
+
+        let outcome = advisory_score_from_data(
+            &target(
+                "chrome.exe",
+                "C:/Program Files/Google/Chrome/chrome.exe",
+                "Google LLC",
+            ),
+            &inventory,
+            &cache,
+        );
+
+        assert_eq!(outcome.score_delta, 3);
+        assert!(!outcome.reasons[0].contains("mitigation guidance available"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This follows the next unfinished roadmap item, **Mitigation-aware response rules**, with a small conservative slice that fits the data Vigil already preserves.

- treat clearly remediation-tagged advisory reference URLs as mitigation guidance in the runtime advisory signal
- keep the signal narrow by ignoring generic `Vendor Advisory` references without remediation tags
- document the expanded guidance signal in `docs/RESPONSE-RULES.md`
- add focused unit coverage for the new tagged-reference cases

## Why this task

There were no open PRs, review threads, failing checks, or open issues to follow up on. The roadmap's next unfinished item is still `Mitigation-aware response rules`, and the current implementation explicitly notes that the broader work remains open for richer guidance attribution and wider exposure inference.

This change stays within the already-shipped advisory-aware rule slice. It improves the existing `require_advisory_mitigation_guidance` signal using existing cached advisory metadata instead of introducing new schema, new trust assumptions, or wider exposure heuristics.

## Validation

- added unit tests covering remediation-tagged references and a non-remediation `Vendor Advisory` control case
- diff-checked the branch against `master` to keep the change limited to the advisory runtime signal and response-rules documentation

## Remaining scope

The broader roadmap item still remains open for vendor-specific guidance attribution and exposure inference beyond an obviously globally routable listener. I could not run the Rust test suite from this scheduled environment because the repository checkout is not available locally here, so this is left as a draft PR for normal CI to validate.
