### PR TITLE
Phase 16: ignore version-only advisory guidance tokens

### DIFF
--- a/docs/RESPONSE-RULES.md
+++ b/docs/RESPONSE-RULES.md
@@ -35,7 +35,7 @@ Supported advisory predicates:
 
 Supported `min_advisory_severity` values are `low`, `medium`, `high`, and `critical`.
 
-`require_advisory_mitigation_guidance` is intentionally narrow. Today it matches only when the same high-confidence advisory reason includes `mitigation guidance available`, which Vigil emits only when the matched advisory record already carries non-empty mitigation, remediation, workaround, or guidance text/URLs in the protected advisory cache, or a clearly remediation-tagged reference URL such as `Mitigation`, `Patch`, or `Workaround`. It does not classify authorship yet, so this is not a vendor-only guidance predicate.
+`require_advisory_mitigation_guidance` is intentionally narrow. Today it matches only when the same high-confidence advisory reason includes `mitigation guidance available`, which Vigil emits only when the matched advisory record already carries non-empty mitigation, remediation, workaround, or guidance text/URLs in the protected advisory cache, or a clearly remediation-tagged reference URL such as `Mitigation`, `Patch`, or `Workaround`. Vigil now also ignores bare fixed-version tokens like `124.0.6367.99`, so version-only fields do not get mistaken for operator guidance. It still does not classify authorship yet, so this is not a vendor-only guidance predicate.
 
 `require_advisory_public_internet_exposure` is intentionally narrow. Today it matches only when the same connection event is a `LISTEN` socket bound to an obviously globally routable local IP address. It does not infer exposure through NAT, wildcard binds, reverse proxies, or reachability beyond what Vigil can observe locally.
 

--- a/src/advisory_runtime_score.rs
+++ b/src/advisory_runtime_score.rs
@@ -230,11 +230,57 @@ fn has_mitigation_guidance(record: &VulnerabilityRecord) -> bool {
     record
         .mitigations
         .iter()
-        .any(|guidance| !guidance.trim().is_empty())
+        .any(|guidance| guidance_text_has_mitigation_guidance(guidance))
         || record
             .references
             .iter()
             .any(reference_has_mitigation_guidance)
+}
+
+// Bare fixed-version tokens are version metadata, not actionable mitigation guidance.
+fn guidance_text_has_mitigation_guidance(text: &str) -> bool {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        return true;
+    }
+    !looks_like_bare_version_hint(trimmed)
+}
+
+fn looks_like_bare_version_hint(text: &str) -> bool {
+    let mut saw_token = false;
+    for token in text
+        .split(|ch: char| ch.is_whitespace() || matches!(ch, ',' | ';' | '/'))
+        .filter(|token| !token.is_empty())
+    {
+        saw_token = true;
+        if !version_like_token(token) {
+            return false;
+        }
+    }
+    saw_token
+}
+
+fn version_like_token(token: &str) -> bool {
+    let token = token.trim_matches(|ch: char| matches!(ch, '(' | ')' | '[' | ']'));
+    let token = token
+        .strip_prefix('v')
+        .or_else(|| token.strip_prefix('V'))
+        .unwrap_or(token);
+    let mut saw_digit = false;
+    for ch in token.chars() {
+        if ch.is_ascii_digit() {
+            saw_digit = true;
+            continue;
+        }
+        if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_' | '+') {
+            continue;
+        }
+        return false;
+    }
+    saw_digit
 }
 
 fn reference_has_mitigation_guidance(reference: &VulnerabilityReference) -> bool {
@@ -736,6 +782,84 @@ mod tests {
             )],
         );
         advisory.mitigations = vec!["https://example.test/vendor-guidance".into()];
+        let cache = cache(vec![advisory]);
+
+        let outcome = advisory_score_from_data(
+            &target(
+                "chrome.exe",
+                "C:/Program Files/Google/Chrome/chrome.exe",
+                "Google LLC",
+            ),
+            &inventory,
+            &cache,
+        );
+
+        assert_eq!(outcome.score_delta, 3);
+        assert!(outcome.reasons[0].contains("mitigation guidance available"));
+    }
+
+    #[test]
+    fn mitigation_guidance_ignores_bare_fixed_version_text() {
+        let inventory = vec![installed(
+            "google-chrome",
+            "Google Chrome",
+            Some("google"),
+            Some("124.0.6367.91"),
+            &["chrome", "google-chrome"],
+            InventorySource::WindowsUninstallRegistry,
+        )];
+        let mut advisory = record(
+            "CVE-2026-42223",
+            true,
+            "CRITICAL",
+            9.8,
+            vec![affected(
+                "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
+                None,
+                None,
+                None,
+            )],
+        );
+        advisory.mitigations = vec!["124.0.6367.99".into()];
+        let cache = cache(vec![advisory]);
+
+        let outcome = advisory_score_from_data(
+            &target(
+                "chrome.exe",
+                "C:/Program Files/Google/Chrome/chrome.exe",
+                "Google LLC",
+            ),
+            &inventory,
+            &cache,
+        );
+
+        assert_eq!(outcome.score_delta, 3);
+        assert!(!outcome.reasons[0].contains("mitigation guidance available"));
+    }
+
+    #[test]
+    fn mitigation_guidance_keeps_descriptive_fixed_version_text() {
+        let inventory = vec![installed(
+            "google-chrome",
+            "Google Chrome",
+            Some("google"),
+            Some("124.0.6367.91"),
+            &["chrome", "google-chrome"],
+            InventorySource::WindowsUninstallRegistry,
+        )];
+        let mut advisory = record(
+            "CVE-2026-42224",
+            true,
+            "CRITICAL",
+            9.8,
+            vec![affected(
+                "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
+                None,
+                None,
+                None,
+            )],
+        );
+        advisory.mitigations = vec!["Upgrade to 124.0.6367.99 or later".into()];
         let cache = cache(vec![advisory]);
 
         let outcome = advisory_score_from_data(


### PR DESCRIPTION
## Summary

This continues the next unfinished roadmap item, **Mitigation-aware response rules**, with a small conservative correctness fix.

- treat bare fixed-version tokens such as `124.0.6367.99` as version metadata rather than operator guidance in the runtime advisory signal
- keep descriptive guidance text such as `Upgrade to 124.0.6367.99 or later` and remediation-tagged reference URLs matched as before
- document the tighter guidance rule in `docs/RESPONSE-RULES.md`
- add focused unit coverage for the version-only and descriptive-text cases

## Why this task

There were no open PR blockers, review threads, requested changes, or failing checks to follow up on, and the roadmap still shows `Mitigation-aware response rules` as the next unfinished Phase 16 item.

This slice stays inside the shipped advisory-aware rule path and makes it more conservative. Some imported public-source records can preserve fixed-version fields as mitigation text, and a bare version string alone is not strong enough to claim operator guidance. Tightening that signal reduces false positives without adding new schema, new trust assumptions, or wider exposure heuristics.

## Validation

- added unit coverage in `src/advisory_runtime_score.rs` for a bare fixed-version token that must stay unmatched
- added unit coverage in `src/advisory_runtime_score.rs` for descriptive upgrade guidance that must remain matched
- reviewed the branch diff to keep the change limited to the runtime advisory signal and response-rules documentation

## Remaining scope

The broader roadmap item still remains open for richer guidance attribution and broader exposure inference beyond an obviously globally routable listener. I could not run the Rust test suite from this scheduled environment because the repository is not available as a local checkout here, so this stays a draft PR for normal CI to validate.