### PR TITLE
Phase 16: add vendor guidance advisory rule matching

### DIFF
--- a/docs/RESPONSE-RULES.md
+++ b/docs/RESPONSE-RULES.md
@@ -27,6 +27,7 @@ Supported advisory predicates:
 - `require_advisory_match: true`
 - `require_known_exploited_advisory: true`
 - `require_advisory_mitigation_guidance: true`
+- `require_advisory_vendor_mitigation_guidance: true`
 - `require_advisory_public_internet_exposure: true`
 - `require_missing_advisory_fix_version: true`
 - `advisory_id_contains: "CVE-2026-12345"`
@@ -35,7 +36,9 @@ Supported advisory predicates:
 
 Supported `min_advisory_severity` values are `low`, `medium`, `high`, and `critical`.
 
-`require_advisory_mitigation_guidance` is intentionally narrow. Today it matches only when the same high-confidence advisory reason includes `mitigation guidance available`, which Vigil emits only when the matched advisory record already carries non-empty mitigation, remediation, workaround, or guidance text/URLs in the protected advisory cache, or a clearly remediation-tagged reference URL such as `Mitigation`, `Patch`, or `Workaround`. Vigil now also ignores bare fixed-version tokens like `124.0.6367.99`, so version-only fields do not get mistaken for operator guidance. It still does not classify authorship yet, so this is not a vendor-only guidance predicate.
+`require_advisory_mitigation_guidance` is intentionally narrow. Today it matches only when the same high-confidence advisory reason includes `mitigation guidance available`, which Vigil emits only when the matched advisory record already carries non-empty mitigation, remediation, workaround, or guidance text/URLs in the protected advisory cache, or a clearly remediation-tagged reference URL such as `Mitigation`, `Patch`, or `Workaround`. Vigil now also ignores bare fixed-version tokens like `124.0.6367.99`, so version-only fields do not get mistaken for operator guidance.
+
+`require_advisory_vendor_mitigation_guidance` is intentionally narrower. Today it matches only when the same high-confidence advisory reason also includes `vendor guidance available`, which Vigil emits only when the matched advisory record already has a non-empty remediation-tagged reference URL and that same reference is also tagged as vendor-authored material such as `Vendor Advisory`. It does not infer authorship from arbitrary domains, free-form mitigation text, or untagged links.
 
 `require_advisory_public_internet_exposure` is intentionally narrow. Today it matches only when the same connection event is a `LISTEN` socket bound to an obviously globally routable local IP address. It does not infer exposure through NAT, wildcard binds, reverse proxies, or reachability beyond what Vigil can observe locally.
 
@@ -45,10 +48,11 @@ Supported `min_advisory_severity` values are `low`, `medium`, `high`, and `criti
 
 ```yaml
 rules:
-  - name: exploited browser advisory with guidance but no fix bound
+  - name: exploited browser advisory with vendor guidance but no fix bound
     require_advisory_match: true
     require_known_exploited_advisory: true
     require_advisory_mitigation_guidance: true
+    require_advisory_vendor_mitigation_guidance: true
     require_missing_advisory_fix_version: true
     advisory_product_contains: chrome
     min_advisory_severity: critical
@@ -56,7 +60,7 @@ rules:
     duration: 24h
 ```
 
-This example only matches when Vigil already found one high-confidence applicable advisory reason for a Chrome-family product, marked it as known exploited, preserved that mitigation guidance is available in the protected advisory cache, rated it at least critical, and could not find an upper fixed-version bound on the matched advisory range.
+This example only matches when Vigil already found one high-confidence applicable advisory reason for a Chrome-family product, marked it as known exploited, preserved that mitigation guidance is available in the protected advisory cache, confirmed that the matching remediation link is explicitly vendor-tagged, rated it at least critical, and could not find an upper fixed-version bound on the matched advisory range.
 
 ## Current scope limits
 
@@ -69,10 +73,11 @@ Today the rule engine can match only these advisory attributes:
 - known exploited flag
 - normalized severity floor
 - mitigation guidance availability in the protected advisory cache
+- explicitly vendor-tagged mitigation guidance references in the protected advisory cache
 - obvious public-internet exposure for a current listening socket bound to a globally routable local IP
 - missing fixed-version bound on the matched advisory range
 
-The broader roadmap item still remains open for attributes such as vendor-specific guidance and broader exposure inference beyond an obviously globally routable listener.
+The broader roadmap item still remains open for richer guidance attribution beyond explicitly tagged vendor references and broader exposure inference beyond an obviously globally routable listener.
 
 ## Actions
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -107,7 +107,7 @@ By default, Vigil also requires an extra typed confirmation before turning on di
 
 The Trusted Processes section now includes a short onboarding tutorial. It explains how to keep the shipped baseline, learn from Activity and the Inspector, and add only stable apps you already recognize.
 
-Response rules can also match high-confidence advisory context conservatively, including known-exploited status, mitigation-guidance availability, missing fixed-version bounds, affected-product text, and obvious public-internet exposure for a globally routable listening socket. See [Response rules](RESPONSE-RULES.md) and `response-rules.example.yaml` for the exact YAML fields and example patterns.
+Response rules can also match high-confidence advisory context conservatively, including known-exploited status, mitigation-guidance availability, explicitly vendor-tagged guidance references, missing fixed-version bounds, affected-product text, and obvious public-internet exposure for a globally routable listening socket. See [Response rules](RESPONSE-RULES.md) and `response-rules.example.yaml` for the exact YAML fields and example patterns.
 
 ### Help
 

--- a/response-rules.example.yaml
+++ b/response-rules.example.yaml
@@ -24,10 +24,11 @@ rules:
     action: block_process
     duration: 1h
 
-  - name: block_known_exploited_browser_without_fix_bound
+  - name: block_known_exploited_browser_with_vendor_guidance_and_no_fix_bound
     require_advisory_match: true
     require_known_exploited_advisory: true
     require_advisory_mitigation_guidance: true
+    require_advisory_vendor_mitigation_guidance: true
     require_missing_advisory_fix_version: true
     advisory_product_contains: chrome
     min_advisory_severity: critical

--- a/src/advisory_runtime_score.rs
+++ b/src/advisory_runtime_score.rs
@@ -48,6 +48,7 @@ struct RuntimeAdvisoryCandidate {
     severity_rank: u8,
     known_exploited: bool,
     mitigation_guidance: bool,
+    vendor_mitigation_guidance: bool,
     missing_fix_version: bool,
     score_delta: u8,
 }
@@ -141,6 +142,11 @@ fn advisory_score_from_data(
             .then_with(|| right.severity_rank.cmp(&left.severity_rank))
             .then_with(|| right.missing_fix_version.cmp(&left.missing_fix_version))
             .then_with(|| right.mitigation_guidance.cmp(&left.mitigation_guidance))
+            .then_with(|| {
+                right
+                    .vendor_mitigation_guidance
+                    .cmp(&left.vendor_mitigation_guidance)
+            })
             .then_with(|| left.primary_id.cmp(&right.primary_id))
     });
 
@@ -183,6 +189,7 @@ fn build_candidate(
         severity_rank,
         known_exploited: record.known_exploited,
         mitigation_guidance: has_mitigation_guidance(record),
+        vendor_mitigation_guidance: has_vendor_mitigation_guidance(record),
         missing_fix_version: matched.missing_fix_version,
         score_delta: advisory_score_delta(record.known_exploited, severity_rank),
     })
@@ -198,6 +205,9 @@ fn advisory_reason(candidate: &RuntimeAdvisoryCandidate) -> String {
     }
     if candidate.mitigation_guidance {
         details.push("mitigation guidance available".to_string());
+    }
+    if candidate.vendor_mitigation_guidance {
+        details.push("vendor guidance available".to_string());
     }
     if candidate.missing_fix_version {
         details.push("no fixed-version bound".to_string());
@@ -235,6 +245,13 @@ fn has_mitigation_guidance(record: &VulnerabilityRecord) -> bool {
             .references
             .iter()
             .any(reference_has_mitigation_guidance)
+}
+
+fn has_vendor_mitigation_guidance(record: &VulnerabilityRecord) -> bool {
+    record
+        .references
+        .iter()
+        .any(reference_has_vendor_mitigation_guidance)
 }
 
 // Bare fixed-version tokens are version metadata, not actionable mitigation guidance.
@@ -291,6 +308,14 @@ fn reference_has_mitigation_guidance(reference: &VulnerabilityReference) -> bool
             .any(|tag| mitigation_reference_tag(tag))
 }
 
+fn reference_has_vendor_mitigation_guidance(reference: &VulnerabilityReference) -> bool {
+    reference_has_mitigation_guidance(reference)
+        && reference
+            .tags
+            .iter()
+            .any(|tag| vendor_advisory_reference_tag(tag))
+}
+
 fn mitigation_reference_tag(tag: &str) -> bool {
     let normalized = tag
         .trim()
@@ -313,6 +338,26 @@ fn mitigation_reference_tag(tag: &str) -> bool {
                 | "patches"
         )
     })
+}
+
+fn vendor_advisory_reference_tag(tag: &str) -> bool {
+    let normalized = tag
+        .trim()
+        .to_ascii_lowercase()
+        .replace(['-', '_', '/'], " ");
+    let tokens = normalized.split_whitespace().collect::<Vec<_>>();
+    tokens.contains(&"vendor")
+        && tokens.iter().any(|token| {
+            matches!(
+                *token,
+                "advisory"
+                    | "advisories"
+                    | "bulletin"
+                    | "bulletins"
+                    | "notice"
+                    | "notices"
+            )
+        })
 }
 
 fn advisory_score_delta(known_exploited: bool, severity_rank: u8) -> u8 {
@@ -653,6 +698,7 @@ mod tests {
         assert!(outcome.reasons[0].contains("known exploited"));
         assert!(outcome.reasons[0].contains("Google Chrome"));
         assert!(!outcome.reasons[0].contains("mitigation guidance available"));
+        assert!(!outcome.reasons[0].contains("vendor guidance available"));
         assert!(!outcome.reasons[0].contains("no fixed-version bound"));
     }
 
@@ -796,6 +842,7 @@ mod tests {
 
         assert_eq!(outcome.score_delta, 3);
         assert!(outcome.reasons[0].contains("mitigation guidance available"));
+        assert!(!outcome.reasons[0].contains("vendor guidance available"));
     }
 
     #[test]
@@ -835,6 +882,7 @@ mod tests {
 
         assert_eq!(outcome.score_delta, 3);
         assert!(!outcome.reasons[0].contains("mitigation guidance available"));
+        assert!(!outcome.reasons[0].contains("vendor guidance available"));
     }
 
     #[test]
@@ -874,6 +922,7 @@ mod tests {
 
         assert_eq!(outcome.score_delta, 3);
         assert!(outcome.reasons[0].contains("mitigation guidance available"));
+        assert!(!outcome.reasons[0].contains("vendor guidance available"));
     }
 
     #[test]
@@ -917,6 +966,7 @@ mod tests {
 
         assert_eq!(outcome.score_delta, 3);
         assert!(outcome.reasons[0].contains("mitigation guidance available"));
+        assert!(!outcome.reasons[0].contains("vendor guidance available"));
     }
 
     #[test]
@@ -960,6 +1010,51 @@ mod tests {
 
         assert_eq!(outcome.score_delta, 3);
         assert!(!outcome.reasons[0].contains("mitigation guidance available"));
+        assert!(!outcome.reasons[0].contains("vendor guidance available"));
+    }
+
+    #[test]
+    fn vendor_mitigation_guidance_marks_reason_when_reference_has_vendor_and_remediation_tags() {
+        let inventory = vec![installed(
+            "google-chrome",
+            "Google Chrome",
+            Some("google"),
+            Some("124.0.6367.91"),
+            &["chrome", "google-chrome"],
+            InventorySource::WindowsUninstallRegistry,
+        )];
+        let mut advisory = record(
+            "CVE-2026-44446",
+            true,
+            "CRITICAL",
+            9.8,
+            vec![affected(
+                "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
+                None,
+                None,
+                None,
+            )],
+        );
+        advisory.references = vec![VulnerabilityReference {
+            url: "https://example.test/vendor-advisory".into(),
+            source: Some("nvd".into()),
+            tags: vec!["Vendor Advisory".into(), "Mitigation".into()],
+        }];
+        let cache = cache(vec![advisory]);
+
+        let outcome = advisory_score_from_data(
+            &target(
+                "chrome.exe",
+                "C:/Program Files/Google/Chrome/chrome.exe",
+                "Google LLC",
+            ),
+            &inventory,
+            &cache,
+        );
+
+        assert_eq!(outcome.score_delta, 3);
+        assert!(outcome.reasons[0].contains("mitigation guidance available"));
+        assert!(outcome.reasons[0].contains("vendor guidance available"));
     }
 
     #[test]

--- a/src/advisory_runtime_score.rs
+++ b/src/advisory_runtime_score.rs
@@ -350,12 +350,7 @@ fn vendor_advisory_reference_tag(tag: &str) -> bool {
         && tokens.iter().any(|token| {
             matches!(
                 *token,
-                "advisory"
-                    | "advisories"
-                    | "bulletin"
-                    | "bulletins"
-                    | "notice"
-                    | "notices"
+                "advisory" | "advisories" | "bulletin" | "bulletins" | "notice" | "notices"
             )
         })
 }

--- a/src/security/response_rules.rs
+++ b/src/security/response_rules.rs
@@ -67,6 +67,8 @@ pub struct ResponseRule {
     #[serde(default)]
     pub require_advisory_mitigation_guidance: bool,
     #[serde(default)]
+    pub require_advisory_vendor_mitigation_guidance: bool,
+    #[serde(default)]
     pub require_advisory_public_internet_exposure: bool,
     #[serde(default)]
     pub require_missing_advisory_fix_version: bool,
@@ -108,6 +110,7 @@ struct ParsedAdvisoryReason<'a> {
     severity: Option<AdvisorySeverity>,
     known_exploited: bool,
     mitigation_guidance: bool,
+    vendor_mitigation_guidance: bool,
     missing_fix_version: bool,
 }
 
@@ -285,6 +288,7 @@ fn matches_advisory_filters(
     let has_advisory_filter = rule.require_advisory_match
         || rule.require_known_exploited_advisory
         || rule.require_advisory_mitigation_guidance
+        || rule.require_advisory_vendor_mitigation_guidance
         || rule.require_advisory_public_internet_exposure
         || rule.require_missing_advisory_fix_version
         || rule.advisory_id_contains.is_some()
@@ -322,6 +326,8 @@ fn matches_advisory_filters(
     advisory_reasons.iter().any(|reason| {
         (!rule.require_known_exploited_advisory || reason.known_exploited)
             && (!rule.require_advisory_mitigation_guidance || reason.mitigation_guidance)
+            && (!rule.require_advisory_vendor_mitigation_guidance
+                || reason.vendor_mitigation_guidance)
             && (!rule.require_missing_advisory_fix_version || reason.missing_fix_version)
             && advisory_id_contains
                 .as_ref()
@@ -365,6 +371,7 @@ fn parse_advisory_reason(reason: &str) -> Option<ParsedAdvisoryReason<'_>> {
     let mut severity = None;
     let mut known_exploited = false;
     let mut mitigation_guidance = false;
+    let mut vendor_mitigation_guidance = false;
     let mut missing_fix_version = false;
     if let Some(detail_block) = detail_block {
         for detail in detail_block
@@ -378,6 +385,10 @@ fn parse_advisory_reason(reason: &str) -> Option<ParsedAdvisoryReason<'_>> {
             }
             if detail.eq_ignore_ascii_case("mitigation guidance available") {
                 mitigation_guidance = true;
+                continue;
+            }
+            if detail.eq_ignore_ascii_case("vendor guidance available") {
+                vendor_mitigation_guidance = true;
                 continue;
             }
             if detail.eq_ignore_ascii_case("no fixed-version bound") {
@@ -396,6 +407,7 @@ fn parse_advisory_reason(reason: &str) -> Option<ParsedAdvisoryReason<'_>> {
         severity,
         known_exploited,
         mitigation_guidance,
+        vendor_mitigation_guidance,
         missing_fix_version,
     })
 }
@@ -702,9 +714,9 @@ mod tests {
     }
 
     #[test]
-    fn parses_advisory_reason_with_known_exploited_guidance_severity_and_fix_bound_marker() {
+    fn parses_advisory_reason_with_known_exploited_vendor_guidance_severity_and_fix_bound_marker() {
         let parsed = parse_advisory_reason(
-            "High-confidence advisory match: CVE-2026-12345 (critical 9.8, known exploited, mitigation guidance available, no fixed-version bound) applies to Google Chrome",
+            "High-confidence advisory match: CVE-2026-12345 (critical 9.8, known exploited, mitigation guidance available, vendor guidance available, no fixed-version bound) applies to Google Chrome",
         )
         .unwrap();
 
@@ -713,6 +725,7 @@ mod tests {
         assert_eq!(parsed.severity, Some(AdvisorySeverity::Critical));
         assert!(parsed.known_exploited);
         assert!(parsed.mitigation_guidance);
+        assert!(parsed.vendor_mitigation_guidance);
         assert!(parsed.missing_fix_version);
     }
 
@@ -720,7 +733,7 @@ mod tests {
     fn advisory_filters_match_high_confidence_reason() {
         let mut conn = sample_conn();
         conn.reasons = vec![
-            "High-confidence advisory match: CVE-2026-12345 (critical 9.8, known exploited, mitigation guidance available, no fixed-version bound) applies to Google Chrome".into(),
+            "High-confidence advisory match: CVE-2026-12345 (critical 9.8, known exploited, mitigation guidance available, vendor guidance available, no fixed-version bound) applies to Google Chrome".into(),
         ];
 
         let rule = ResponseRule {
@@ -737,6 +750,7 @@ mod tests {
             require_advisory_match: true,
             require_known_exploited_advisory: true,
             require_advisory_mitigation_guidance: true,
+            require_advisory_vendor_mitigation_guidance: true,
             require_advisory_public_internet_exposure: false,
             require_missing_advisory_fix_version: true,
             advisory_id_contains: Some("CVE-2026-12345".into()),
@@ -753,7 +767,7 @@ mod tests {
     fn advisory_filters_do_not_mix_signals_from_different_reasons() {
         let mut conn = sample_conn();
         conn.reasons = vec![
-            "High-confidence advisory match: CVE-2026-12345 (critical 9.8, known exploited) applies to Google Chrome".into(),
+            "High-confidence advisory match: CVE-2026-12345 (critical 9.8, known exploited, vendor guidance available) applies to Google Chrome".into(),
             "High-confidence advisory match: CVE-2026-99999 (medium 5.4, mitigation guidance available, no fixed-version bound) applies to Example Agent".into(),
         ];
 
@@ -761,6 +775,7 @@ mod tests {
             require_advisory_match: true,
             require_known_exploited_advisory: true,
             require_advisory_mitigation_guidance: true,
+            require_advisory_vendor_mitigation_guidance: true,
             require_missing_advisory_fix_version: true,
             advisory_id_contains: Some("CVE-2026-12345".into()),
             advisory_product_contains: Some("chrome".into()),
@@ -818,6 +833,7 @@ mod tests {
             require_advisory_match: true,
             require_known_exploited_advisory: true,
             require_advisory_mitigation_guidance: true,
+            require_advisory_vendor_mitigation_guidance: true,
             require_missing_advisory_fix_version: true,
             min_advisory_severity: Some(AdvisorySeverity::High),
             advisory_product_contains: Some("chrome".into()),
@@ -880,6 +896,7 @@ mod tests {
             require_advisory_match: false,
             require_known_exploited_advisory: false,
             require_advisory_mitigation_guidance: false,
+            require_advisory_vendor_mitigation_guidance: false,
             require_advisory_public_internet_exposure: false,
             require_missing_advisory_fix_version: false,
             advisory_id_contains: None,


### PR DESCRIPTION
## Summary
- add a narrower `require_advisory_vendor_mitigation_guidance` response-rule predicate
- classify `vendor guidance available` only from remediation-tagged advisory references that are also explicitly vendor-tagged
- document the new predicate in the response-rules guide, user guide, and example YAML

## Why
The next unfinished Phase 16 roadmap item is mitigation-aware response rules. Vigil already supported generic mitigation-guidance matching, but the roadmap still called out richer guidance attribution. This PR adds a small conservative slice of that work without guessing authorship from domains or free-form text.

## Validation
- relied on targeted unit tests added alongside the advisory scoring and response-rule parsing logic
- did not run the test suite in the container because the repository is not available as a local checkout in this environment

## Scope limits
- vendor guidance matches only explicit vendor-tagged remediation references in the protected advisory cache
- no broader authorship inference or expanded exposure inference is included here
