### PR TITLE
Tighten Phase 16 vendor guidance matching for advisory response rules

### DIFF
--- a/docs/RESPONSE-RULES.md
+++ b/docs/RESPONSE-RULES.md
@@ -36,9 +36,9 @@ Supported advisory predicates:
 
 Supported `min_advisory_severity` values are `low`, `medium`, `high`, and `critical`.
 
-`require_advisory_mitigation_guidance` is intentionally narrow. Today it matches only when the same high-confidence advisory reason includes `mitigation guidance available`, which Vigil emits only when the matched advisory record already carries non-empty mitigation, remediation, workaround, or guidance text/URLs in the protected advisory cache, or a clearly remediation-tagged reference URL such as `Mitigation`, `Patch`, or `Workaround`. Vigil now also ignores bare fixed-version tokens like `124.0.6367.99`, so version-only fields do not get mistaken for operator guidance.
+`require_advisory_mitigation_guidance` is intentionally narrow. Today it matches only when the same high-confidence advisory reason includes `mitigation guidance available`, which Vigil emits only when the matched advisory record already carries non-empty mitigation, remediation, workaround, or guidance text/URLs in the protected advisory cache, or a clearly guidance- or remediation-tagged reference URL such as `Mitigation`, `Patch`, `Workaround`, or `Guidance`. Vigil now also ignores bare fixed-version tokens like `124.0.6367.99`, so version-only fields do not get mistaken for operator guidance.
 
-`require_advisory_vendor_mitigation_guidance` is intentionally narrower. Today it matches only when the same high-confidence advisory reason also includes `vendor guidance available`, which Vigil emits only when the matched advisory record already has a non-empty remediation-tagged reference URL and that same reference is also tagged as vendor-authored material such as `Vendor Advisory`. It does not infer authorship from arbitrary domains, free-form mitigation text, or untagged links.
+`require_advisory_vendor_mitigation_guidance` is intentionally narrower. Today it matches only when the same high-confidence advisory reason also includes `vendor guidance available`, which Vigil emits only when the matched advisory record already has a non-empty guidance- or remediation-tagged reference URL and that same reference is also tagged as vendor-authored material such as `Vendor Advisory`, `Vendor Fix`, `Vendor Patch`, or `Vendor Guidance`. It does not infer authorship from arbitrary domains, free-form mitigation text, or untagged links.
 
 `require_advisory_public_internet_exposure` is intentionally narrow. Today it matches only when the same connection event is a `LISTEN` socket bound to an obviously globally routable local IP address. It does not infer exposure through NAT, wildcard binds, reverse proxies, or reachability beyond what Vigil can observe locally.
 
@@ -77,7 +77,7 @@ Today the rule engine can match only these advisory attributes:
 - obvious public-internet exposure for a current listening socket bound to a globally routable local IP
 - missing fixed-version bound on the matched advisory range
 
-The broader roadmap item still remains open for richer guidance attribution beyond explicitly tagged vendor references and broader exposure inference beyond an obviously globally routable listener.
+The broader roadmap item still remains open for richer guidance attribution beyond explicit vendor-plus-guidance tags and broader exposure inference beyond an obviously globally routable listener.
 
 ## Actions
 

--- a/src/advisory_runtime_score.rs
+++ b/src/advisory_runtime_score.rs
@@ -313,7 +313,7 @@ fn reference_has_vendor_mitigation_guidance(reference: &VulnerabilityReference) 
         && reference
             .tags
             .iter()
-            .any(|tag| vendor_advisory_reference_tag(tag))
+            .any(|tag| vendor_guidance_reference_tag(tag))
 }
 
 fn mitigation_reference_tag(tag: &str) -> bool {
@@ -336,11 +336,13 @@ fn mitigation_reference_tag(tag: &str) -> bool {
                 | "fixes"
                 | "patch"
                 | "patches"
+                | "guidance"
+                | "guidances"
         )
     })
 }
 
-fn vendor_advisory_reference_tag(tag: &str) -> bool {
+fn vendor_guidance_reference_tag(tag: &str) -> bool {
     let normalized = tag
         .trim()
         .to_ascii_lowercase()
@@ -350,7 +352,26 @@ fn vendor_advisory_reference_tag(tag: &str) -> bool {
         && tokens.iter().any(|token| {
             matches!(
                 *token,
-                "advisory" | "advisories" | "bulletin" | "bulletins" | "notice" | "notices"
+                "advisory"
+                    | "advisories"
+                    | "bulletin"
+                    | "bulletins"
+                    | "notice"
+                    | "notices"
+                    | "fix"
+                    | "fixes"
+                    | "patch"
+                    | "patches"
+                    | "update"
+                    | "updates"
+                    | "solution"
+                    | "solutions"
+                    | "remediation"
+                    | "remediations"
+                    | "workaround"
+                    | "workarounds"
+                    | "guidance"
+                    | "guidances"
             )
         })
 }
@@ -965,6 +986,50 @@ mod tests {
     }
 
     #[test]
+    fn guidance_reference_tag_marks_reason_when_reference_uses_guidance_word() {
+        let inventory = vec![installed(
+            "google-chrome",
+            "Google Chrome",
+            Some("google"),
+            Some("124.0.6367.91"),
+            &["chrome", "google-chrome"],
+            InventorySource::WindowsUninstallRegistry,
+        )];
+        let mut advisory = record(
+            "CVE-2026-43334",
+            true,
+            "CRITICAL",
+            9.8,
+            vec![affected(
+                "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
+                None,
+                None,
+                None,
+            )],
+        );
+        advisory.references = vec![VulnerabilityReference {
+            url: "https://example.test/guidance".into(),
+            source: Some("nvd".into()),
+            tags: vec!["Guidance".into()],
+        }];
+        let cache = cache(vec![advisory]);
+
+        let outcome = advisory_score_from_data(
+            &target(
+                "chrome.exe",
+                "C:/Program Files/Google/Chrome/chrome.exe",
+                "Google LLC",
+            ),
+            &inventory,
+            &cache,
+        );
+
+        assert_eq!(outcome.score_delta, 3);
+        assert!(outcome.reasons[0].contains("mitigation guidance available"));
+        assert!(!outcome.reasons[0].contains("vendor guidance available"));
+    }
+
+    #[test]
     fn vendor_advisory_reference_without_remediation_tag_stays_unmatched() {
         let inventory = vec![installed(
             "google-chrome",
@@ -1034,6 +1099,50 @@ mod tests {
             url: "https://example.test/vendor-advisory".into(),
             source: Some("nvd".into()),
             tags: vec!["Vendor Advisory".into(), "Mitigation".into()],
+        }];
+        let cache = cache(vec![advisory]);
+
+        let outcome = advisory_score_from_data(
+            &target(
+                "chrome.exe",
+                "C:/Program Files/Google/Chrome/chrome.exe",
+                "Google LLC",
+            ),
+            &inventory,
+            &cache,
+        );
+
+        assert_eq!(outcome.score_delta, 3);
+        assert!(outcome.reasons[0].contains("mitigation guidance available"));
+        assert!(outcome.reasons[0].contains("vendor guidance available"));
+    }
+
+    #[test]
+    fn vendor_fix_reference_tag_marks_vendor_guidance_without_advisory_word() {
+        let inventory = vec![installed(
+            "google-chrome",
+            "Google Chrome",
+            Some("google"),
+            Some("124.0.6367.91"),
+            &["chrome", "google-chrome"],
+            InventorySource::WindowsUninstallRegistry,
+        )];
+        let mut advisory = record(
+            "CVE-2026-44447",
+            true,
+            "CRITICAL",
+            9.8,
+            vec![affected(
+                "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
+                None,
+                None,
+                None,
+            )],
+        );
+        advisory.references = vec![VulnerabilityReference {
+            url: "https://example.test/vendor-fix".into(),
+            source: Some("nvd".into()),
+            tags: vec!["Vendor Fix".into()],
         }];
         let cache = cache(vec![advisory]);
 


### PR DESCRIPTION
## Summary

This follows the next unfinished Phase 16 roadmap item around mitigation-aware response rules with a narrow, conservative slice.

- recognize explicit remediation guidance tags such as `Guidance` alongside the existing mitigation/fix/patch tags
- treat explicit vendor remediation tags such as `Vendor Fix`, `Vendor Patch`, and `Vendor Guidance` as vendor-authored guidance for advisory-aware response rules
- keep the existing safety boundary: no inference from arbitrary domains, untagged links, or free-form text
- document the new tag handling in `docs/RESPONSE-RULES.md`

## Why this task

There were no open PR follow-ups to handle, and the next unchecked roadmap item is the Phase 16 mitigation-aware response-rule work. This change is a small, in-scope step inside that item that improves guidance attribution without widening the trust boundary.

## Validation

- added unit coverage for `Guidance` tags and `Vendor Fix` tags in `src/advisory_runtime_score.rs`
- GitHub-side diff review to confirm the branch only changes the advisory scoring logic and the response-rule guide

## Notes

- I could not run `cargo test` locally in this scheduled environment because the repository checkout was not available inside the workspace and direct GitHub network cloning was blocked.
- The PR is left as a draft so CI can validate the branch before merge.
