### PR TITLE
Phase 16: recognize explicit Vendor Mitigation tags

### DIFF
--- a/docs/RESPONSE-RULES.md
+++ b/docs/RESPONSE-RULES.md
@@ -38,7 +38,7 @@ Supported `min_advisory_severity` values are `low`, `medium`, `high`, and `criti
 
 `require_advisory_mitigation_guidance` is intentionally narrow. Today it matches only when the same high-confidence advisory reason includes `mitigation guidance available`, which Vigil emits only when the matched advisory record already carries non-empty mitigation, remediation, workaround, or guidance text/URLs in the protected advisory cache, or a clearly guidance- or remediation-tagged reference URL such as `Mitigation`, `Patch`, `Update`, `Upgrade`, `Workaround`, or `Guidance`. Vigil now also ignores bare fixed-version tokens like `124.0.6367.99`, so version-only fields do not get mistaken for operator guidance.
 
-`require_advisory_vendor_mitigation_guidance` is intentionally narrower. Today it matches only when the same high-confidence advisory reason also includes `vendor guidance available`, which Vigil emits only when the matched advisory record already has a non-empty guidance- or remediation-tagged reference URL and that same reference is also tagged as vendor-authored material such as `Vendor Advisory`, `Vendor Fix`, `Vendor Patch`, `Vendor Update`, `Vendor Upgrade`, or `Vendor Guidance`. It does not infer authorship from arbitrary domains, free-form mitigation text, or untagged links.
+`require_advisory_vendor_mitigation_guidance` is intentionally narrower. Today it matches only when the same high-confidence advisory reason also includes `vendor guidance available`, which Vigil emits only when the matched advisory record already has a non-empty guidance- or remediation-tagged reference URL and that same reference is also tagged as vendor-authored material such as `Vendor Advisory`, `Vendor Mitigation`, `Vendor Fix`, `Vendor Patch`, `Vendor Update`, `Vendor Upgrade`, or `Vendor Guidance`. It does not infer authorship from arbitrary domains, free-form mitigation text, or untagged links.
 
 `require_advisory_public_internet_exposure` is intentionally narrow. Today it matches only when the same connection event is a `LISTEN` socket bound to an obviously globally routable local IP address. It does not infer exposure through NAT, wildcard binds, reverse proxies, or reachability beyond what Vigil can observe locally.
 
@@ -77,7 +77,7 @@ Today the rule engine can match only these advisory attributes:
 - obvious public-internet exposure for a current listening socket bound to a globally routable local IP
 - missing fixed-version bound on the matched advisory range
 
-The broader roadmap item still remains open for richer guidance attribution beyond explicit vendor-plus-guidance tags and broader exposure inference beyond an obviously globally routable listener.
+The broader roadmap item still remains open for richer guidance attribution beyond explicit vendor-plus-remediation tags and broader exposure inference beyond an obviously globally routable listener.
 
 ## Actions
 

--- a/src/advisory_runtime_score.rs
+++ b/src/advisory_runtime_score.rs
@@ -362,6 +362,8 @@ fn vendor_guidance_reference_tag(tag: &str) -> bool {
                     | "bulletins"
                     | "notice"
                     | "notices"
+                    | "mitigation"
+                    | "mitigations"
                     | "fix"
                     | "fixes"
                     | "patch"
@@ -1256,7 +1258,7 @@ mod tests {
     }
 
     #[test]
-    fn vendor_update_reference_tag_marks_vendor_guidance_without_advisory_word() {
+    fn vendor_mitigation_reference_tag_marks_vendor_guidance_without_advisory_word() {
         let inventory = vec![installed(
             "google-chrome",
             "Google Chrome",
@@ -1267,6 +1269,50 @@ mod tests {
         )];
         let mut advisory = record(
             "CVE-2026-44448",
+            true,
+            "CRITICAL",
+            9.8,
+            vec![affected(
+                "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
+                None,
+                None,
+                None,
+            )],
+        );
+        advisory.references = vec![VulnerabilityReference {
+            url: "https://example.test/vendor-mitigation".into(),
+            source: Some("nvd".into()),
+            tags: vec!["Vendor Mitigation".into()],
+        }];
+        let cache = cache(vec![advisory]);
+
+        let outcome = advisory_score_from_data(
+            &target(
+                "chrome.exe",
+                "C:/Program Files/Google/Chrome/chrome.exe",
+                "Google LLC",
+            ),
+            &inventory,
+            &cache,
+        );
+
+        assert_eq!(outcome.score_delta, 3);
+        assert!(outcome.reasons[0].contains("mitigation guidance available"));
+        assert!(outcome.reasons[0].contains("vendor guidance available"));
+    }
+
+    #[test]
+    fn vendor_update_reference_tag_marks_vendor_guidance_without_advisory_word() {
+        let inventory = vec![installed(
+            "google-chrome",
+            "Google Chrome",
+            Some("google"),
+            Some("124.0.6367.91"),
+            &["chrome", "google-chrome"],
+            InventorySource::WindowsUninstallRegistry,
+        )];
+        let mut advisory = record(
+            "CVE-2026-44449",
             true,
             "CRITICAL",
             9.8,
@@ -1310,7 +1356,7 @@ mod tests {
             InventorySource::WindowsUninstallRegistry,
         )];
         let mut advisory = record(
-            "CVE-2026-44449",
+            "CVE-2026-44450",
             true,
             "CRITICAL",
             9.8,


### PR DESCRIPTION
## Summary

This follows the next unfinished Phase 16 roadmap item around mitigation-aware response rules with another narrow, conservative guidance-attribution slice.

- treat explicit `Vendor Mitigation` reference tags as vendor mitigation guidance for advisory-aware response rules
- keep the existing trust boundary: no inference from arbitrary domains, untagged links, or free-form mitigation text
- document the recognized `Vendor Mitigation` tag behavior in `docs/RESPONSE-RULES.md`
- add focused unit coverage for the explicit-tag case in `src/advisory_runtime_score.rs`

## Why this task

There were no open pull requests, unresolved review threads, requested changes, open issues, or failing CI signals to follow up on in `YMRYMR/vigil`.

The roadmap still shows **Phase 16: Mitigation-aware response rules** as the next unfinished item, and `Vendor Mitigation` was the next small explicit-tag gap inside the current trusted-tag model. Plain `Mitigation` already counted as remediation guidance, and other explicit vendor-tagged remediation variants such as `Vendor Fix`, `Vendor Update`, and `Vendor Upgrade` were already supported.

## Validation

- reviewed the branch diff against `master` to keep the change limited to advisory guidance-tag matching, one regression test, and the corresponding operator docs
- confirmed the new branch contains no unrelated file changes

## Notes

- I could not run `cargo test` locally in this scheduled environment because the repository checkout is not available inside the workspace and direct GitHub cloning is blocked here.
- The PR is left as a draft so normal CI can validate the branch before merge.
