### PR TITLE
Phase 16: preserve main inventory identity-hint follow-ups

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,12 +32,12 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e
         with:
           languages: rust
           build-mode: none
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e
         with:
           category: /language:rust

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -38,6 +38,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           sarif_file: results.sarif

--- a/src/bin/vigil_inventory.rs
+++ b/src/bin/vigil_inventory.rs
@@ -506,6 +506,7 @@ fn first_existing_file(paths: &[&'static str]) -> Option<&'static str> {
     paths.iter().copied().find(|path| Path::new(path).is_file())
 }
 
+#[cfg(any(windows, test))]
 fn preferred_registry_path(display_icon: &str, install_location: &str) -> String {
     let display_icon = clean_display_icon_path(display_icon);
     if !display_icon.is_empty() {
@@ -520,6 +521,7 @@ fn preferred_registry_path(display_icon: &str, install_location: &str) -> String
     String::new()
 }
 
+#[cfg(any(windows, test))]
 fn registry_install_location_looks_executable(value: &str) -> bool {
     let trimmed = value.trim().trim_matches('"');
     if trimmed.is_empty() {
@@ -536,6 +538,7 @@ fn registry_install_location_looks_executable(value: &str) -> bool {
     )
 }
 
+#[cfg(any(windows, test))]
 fn clean_display_icon_path(value: &str) -> String {
     let trimmed = value.trim();
     if trimmed.is_empty() {

--- a/src/platform/service.rs
+++ b/src/platform/service.rs
@@ -21,6 +21,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+#[cfg(any(windows, test))]
 use std::time::Duration;
 
 /// Result of an install / uninstall command.  `Ok(msg)` is printed verbatim
@@ -117,6 +118,7 @@ fn spawn_deferred_disarm_worker() -> Result<(), String> {
         .map_err(|err| format!("failed to spawn pre-login guard handoff thread: {err}"))
 }
 
+#[cfg(any(windows, test))]
 fn drive_prelogin_guard_until_login<FCheck, FDisarm>(
     poll_interval: Duration,
     mut still_pre_login: FCheck,

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -162,6 +162,7 @@ fn primary_service_name_map(
         .collect()
 }
 
+#[cfg(any(windows, test))]
 fn remember_service_name(
     map: &mut std::collections::HashMap<u32, Vec<String>>,
     pid: u32,

--- a/src/software_inventory.rs
+++ b/src/software_inventory.rs
@@ -14,6 +14,30 @@ use sysinfo::System;
 
 const STARTUP_INVENTORY_DELAY: Duration = Duration::from_secs(15);
 const STARTUP_INVENTORY_MAX_ENTRIES: usize = 512;
+const VENDOR_SUFFIXES: &[&str] = &[
+    "ab",
+    "ag",
+    "bv",
+    "co",
+    "company",
+    "corp",
+    "corporation",
+    "gmbh",
+    "inc",
+    "incorporated",
+    "kg",
+    "kgaa",
+    "limited",
+    "llc",
+    "ltd",
+    "oy",
+    "oyj",
+    "plc",
+    "pte",
+    "sa",
+    "sarl",
+    "spa",
+];
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InstalledSoftware {
@@ -24,6 +48,10 @@ pub struct InstalledSoftware {
     pub publisher_hint: Option<String>,
     #[serde(default)]
     pub version_hint: Option<String>,
+    #[serde(default)]
+    pub product_aliases: Vec<String>,
+    #[serde(default)]
+    pub vendor_key: Option<String>,
     pub source: InventorySource,
 }
 
@@ -54,6 +82,7 @@ pub fn collect_startup_inventory() -> Vec<InstalledSoftware> {
     collect_installed_software_limited(STARTUP_INVENTORY_MAX_ENTRIES)
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn collect_installed_software() -> Vec<InstalledSoftware> {
     collect_installed_software_limited(usize::MAX)
 }
@@ -435,6 +464,7 @@ fn registry_string(key: &winreg::RegKey, name: &str) -> Option<String> {
         .and_then(inventory_hint)
 }
 
+#[cfg(any(windows, test))]
 fn preferred_registry_path(display_icon: &str, install_location: &str) -> String {
     let display_icon = clean_display_icon_path(display_icon);
     if !display_icon.is_empty() {
@@ -449,6 +479,7 @@ fn preferred_registry_path(display_icon: &str, install_location: &str) -> String
     String::new()
 }
 
+#[cfg(any(windows, test))]
 fn registry_install_location_looks_executable(value: &str) -> bool {
     let trimmed = value.trim().trim_matches('"');
     if trimmed.is_empty() {
@@ -468,6 +499,7 @@ fn registry_install_location_looks_executable(value: &str) -> bool {
     )
 }
 
+#[cfg(any(windows, test))]
 fn clean_display_icon_path(value: &str) -> String {
     let trimmed = value.trim();
     if trimmed.is_empty() {
@@ -496,12 +528,19 @@ where
             continue;
         }
         let product_key = derive_product_key(&entry.display_name, &entry.executable_path);
+        let product_aliases = collect_product_aliases(&entry.display_name, &entry.executable_path);
+        let vendor_key = entry
+            .publisher_hint
+            .as_deref()
+            .and_then(normalize_vendor_key);
         let candidate = InstalledSoftware {
             product_key: product_key.clone(),
             display_name: entry.display_name,
             executable_path: entry.executable_path,
             publisher_hint: entry.publisher_hint,
             version_hint: entry.version_hint,
+            product_aliases,
+            vendor_key,
             source: entry.source,
         };
         by_key
@@ -558,6 +597,34 @@ fn merge_missing_inventory_fields(target: &mut InstalledSoftware, source: &Insta
     if target.version_hint.is_none() {
         target.version_hint = source.version_hint.clone();
     }
+    if target.vendor_key.is_none() {
+        target.vendor_key = source.vendor_key.clone();
+    }
+    merge_product_aliases(&mut target.product_aliases, &source.product_aliases);
+}
+
+fn merge_product_aliases(target: &mut Vec<String>, source: &[String]) {
+    let mut aliases = target.iter().cloned().collect::<BTreeSet<_>>();
+    aliases.extend(source.iter().cloned());
+    *target = aliases.into_iter().collect();
+}
+
+fn collect_product_aliases(display_name: &str, executable_path: &str) -> Vec<String> {
+    let mut aliases = BTreeSet::new();
+
+    let normalized_name = normalize_name(display_name);
+    if !normalized_name.is_empty() {
+        aliases.insert(normalized_name);
+    }
+
+    if let Some(file_name) = std::path::Path::new(executable_path).file_stem() {
+        let candidate = normalize_name(&file_name.to_string_lossy());
+        if !candidate.is_empty() {
+            aliases.insert(candidate);
+        }
+    }
+
+    aliases.into_iter().collect()
 }
 
 fn derive_product_key(display_name: &str, executable_path: &str) -> String {
@@ -576,15 +643,42 @@ fn derive_product_key(display_name: &str, executable_path: &str) -> String {
     "unknown-product".to_string()
 }
 
+fn normalize_vendor_key(publisher: &str) -> Option<String> {
+    let publisher = publisher.split('<').next().unwrap_or(publisher).trim();
+    let mut tokens = tokenize_identity(publisher);
+    while tokens
+        .last()
+        .is_some_and(|token| VENDOR_SUFFIXES.contains(&token.as_str()))
+    {
+        tokens.pop();
+    }
+
+    if tokens.is_empty() {
+        let normalized = normalize_name(publisher);
+        if normalized.is_empty() {
+            None
+        } else {
+            Some(normalized)
+        }
+    } else {
+        Some(tokens.join("-"))
+    }
+}
+
 fn normalize_name(input: &str) -> String {
+    tokenize_identity(input).join("-")
+}
+
+fn tokenize_identity(input: &str) -> Vec<String> {
     let lower = input.trim().to_lowercase();
     let no_ext = lower.strip_suffix(".exe").unwrap_or(&lower);
     no_ext
         .chars()
-        .map(|c| if c.is_alphanumeric() { c } else { '-' })
+        .map(|ch| if ch.is_alphanumeric() { ch } else { ' ' })
         .collect::<String>()
-        .trim_matches('-')
-        .to_string()
+        .split_whitespace()
+        .map(str::to_string)
+        .collect()
 }
 
 fn inventory_hint(value: String) -> Option<String> {
@@ -625,6 +719,28 @@ mod tests {
     fn normalize_name_preserves_unicode_letters() {
         assert_eq!(normalize_name("Программа.EXE"), "программа");
         assert_eq!(normalize_name("監視ツール.exe"), "監視ツール");
+    }
+
+    #[test]
+    fn normalize_vendor_key_strips_suffixes_and_contact_details() {
+        assert_eq!(
+            normalize_vendor_key("Example Corporation <sec@example.com>"),
+            Some("example".to_string())
+        );
+        assert_eq!(
+            normalize_vendor_key("Microsoft Corporation"),
+            Some("microsoft".to_string())
+        );
+    }
+
+    #[test]
+    fn collect_product_aliases_uses_display_name_and_executable_stem() {
+        let aliases =
+            collect_product_aliases("Google Chrome", "C:/Program Files/Google/Chrome/chrome.exe");
+        assert_eq!(
+            aliases,
+            vec!["chrome".to_string(), "google-chrome".to_string()]
+        );
     }
 
     #[test]
@@ -790,6 +906,7 @@ mod tests {
         let inventory = collect_from_entries(entries);
         assert_eq!(inventory.len(), 1);
         assert_eq!(inventory[0].product_key, "agentd");
+        assert_eq!(inventory[0].product_aliases, vec!["agentd".to_string()]);
     }
 
     #[test]
@@ -797,7 +914,7 @@ mod tests {
         let entries = vec![
             seed(
                 "",
-                "/opt/vendor/chrome",
+                "/opt/vendor/google-chrome",
                 None,
                 None,
                 InventorySource::RunningProcess,
@@ -825,6 +942,10 @@ mod tests {
             inventory[0].executable_path,
             "/Applications/Google Chrome.app"
         );
+        assert_eq!(
+            inventory[0].product_aliases,
+            vec!["chrome".to_string(), "google-chrome".to_string()]
+        );
     }
 
     #[test]
@@ -850,6 +971,11 @@ mod tests {
         assert_eq!(inventory[0].product_key, "example-agent");
         assert_eq!(inventory[0].publisher_hint.as_deref(), Some("Example Corp"));
         assert_eq!(inventory[0].version_hint.as_deref(), Some("2.4.1"));
+        assert_eq!(inventory[0].vendor_key.as_deref(), Some("example"));
+        assert_eq!(
+            inventory[0].product_aliases,
+            vec!["agent".to_string(), "example-agent".to_string()]
+        );
         assert_eq!(
             inventory[0].executable_path,
             "/Applications/Example Agent.app"
@@ -879,6 +1005,11 @@ mod tests {
         assert_eq!(inventory[0].product_key, "example-agent");
         assert_eq!(inventory[0].publisher_hint.as_deref(), Some("Example Corp"));
         assert_eq!(inventory[0].version_hint.as_deref(), Some("2.4.1"));
+        assert_eq!(inventory[0].vendor_key.as_deref(), Some("example"));
+        assert_eq!(
+            inventory[0].product_aliases,
+            vec!["agent".to_string(), "example-agent".to_string()]
+        );
         assert_eq!(inventory[0].executable_path, "/opt/example/agent");
     }
 
@@ -906,6 +1037,10 @@ mod tests {
         assert_eq!(
             inventory[0].publisher_hint.as_deref(),
             Some("Debian curl maintainers")
+        );
+        assert_eq!(
+            inventory[0].vendor_key.as_deref(),
+            Some("debian-curl-maintainers")
         );
         assert_eq!(inventory[0].version_hint.as_deref(), Some("8.8.0-1"));
         assert_eq!(inventory[0].executable_path, "/usr/bin/curl");
@@ -936,6 +1071,7 @@ mod tests {
             inventory[0].publisher_hint.as_deref(),
             Some("Fedora Project")
         );
+        assert_eq!(inventory[0].vendor_key.as_deref(), Some("fedora-project"));
         assert_eq!(inventory[0].version_hint.as_deref(), Some("8.8.0-1.fc40"));
         assert_eq!(inventory[0].executable_path, "/usr/bin/curl");
     }
@@ -963,6 +1099,10 @@ mod tests {
         assert_eq!(inventory[0].source, InventorySource::LinuxApkInstalled);
         assert_eq!(
             inventory[0].publisher_hint.as_deref(),
+            Some("alpine-baselayout")
+        );
+        assert_eq!(
+            inventory[0].vendor_key.as_deref(),
             Some("alpine-baselayout")
         );
         assert_eq!(inventory[0].version_hint.as_deref(), Some("1.36.1-r7"));
@@ -994,7 +1134,12 @@ mod tests {
             InventorySource::WindowsUninstallRegistry
         );
         assert_eq!(inventory[0].publisher_hint.as_deref(), Some("Example Corp"));
+        assert_eq!(inventory[0].vendor_key.as_deref(), Some("example"));
         assert_eq!(inventory[0].version_hint.as_deref(), Some("2.4.1"));
+        assert_eq!(
+            inventory[0].product_aliases,
+            vec!["agent".to_string(), "example-agent".to_string()]
+        );
         assert_eq!(
             inventory[0].executable_path,
             "C:/Program Files/Example/agent.exe"
@@ -1022,10 +1167,14 @@ mod tests {
         let inventory = collect_from_entries(entries);
         assert_eq!(inventory.len(), 2);
         assert!(inventory.iter().any(|row| {
-            row.product_key == "svchost" && row.source == InventorySource::RunningProcess
+            row.product_key == "svchost"
+                && row.product_aliases == vec!["svchost".to_string()]
+                && row.source == InventorySource::RunningProcess
         }));
         assert!(inventory.iter().any(|row| {
-            row.product_key == "dnscache" && row.source == InventorySource::RunningService
+            row.product_key == "dnscache"
+                && row.product_aliases == vec!["dnscache".to_string(), "svchost".to_string()]
+                && row.source == InventorySource::RunningService
         }));
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -7,6 +7,7 @@ const SOFTWARE_INVENTORY_SCHEMA_VERSION: u32 = 1;
 
 pub trait InventoryStore {
     fn replace_inventory(&self, entries: &[InstalledSoftware]) -> Result<(), String>;
+    #[cfg_attr(not(test), allow(dead_code))]
     fn load_inventory(&self) -> Result<Vec<InstalledSoftware>, String>;
 }
 
@@ -102,6 +103,8 @@ mod tests {
             executable_path: "/usr/bin/curl".into(),
             publisher_hint: Some("curl project".into()),
             version_hint: Some("8.8.0".into()),
+            product_aliases: vec!["curl".into()],
+            vendor_key: Some("curl-project".into()),
             source: crate::software_inventory::InventorySource::RunningProcess,
         }];
         store.replace_inventory(&rows).unwrap();
@@ -109,6 +112,8 @@ mod tests {
         assert!(loaded.iter().any(|r| r.product_key == "curl"));
         assert_eq!(loaded[0].publisher_hint.as_deref(), Some("curl project"));
         assert_eq!(loaded[0].version_hint.as_deref(), Some("8.8.0"));
+        assert_eq!(loaded[0].product_aliases, vec!["curl".to_string()]);
+        assert_eq!(loaded[0].vendor_key.as_deref(), Some("curl-project"));
         std::fs::remove_dir_all(dir).unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- preserve the current unmerged follow-up work on `codex/phase16-main-inventory-identity-hints-ready` in a reviewable PR
- carry additional main-inventory identity-hint updates across `src/software_inventory.rs`, related startup inventory paths, and the `vigil_inventory` helper
- include the branch’s workflow follow-ups in `.github/workflows/codeql.yml` and `.github/workflows/ossf-scorecard.yml`

## Why
There were no open pull requests in `YMRYMR/vigil`, but this branch still contains meaningful unmerged work on top of already-merged PR #210. Opening a fresh PR keeps that remaining work visible, reviewable, and eligible for normal CI instead of leaving it stranded on a stale branch.

## Validation
- compared `codex/phase16-main-inventory-identity-hints-ready` against `master`
- confirmed the branch still carries a focused diff across seven files
- did not run local Rust checks in this scheduled environment because the repository checkout is not available in the workspace here

## Notes
- this PR is intentionally opened as draft so normal GitHub checks can validate the branch first
- the branch has diverged from `master`, so reviewers should treat this PR as preservation of remaining work rather than as a claim that it is immediately merge-ready