### PR TITLE
Phase 16: add advisory public exposure rule examples

### DIFF
--- a/docs/RESPONSE-RULES.md
+++ b/docs/RESPONSE-RULES.md
@@ -62,6 +62,22 @@ rules:
 
 This example only matches when Vigil already found one high-confidence applicable advisory reason for a Chrome-family product, marked it as known exploited, preserved that mitigation guidance is available in the protected advisory cache, confirmed that the matching remediation link is explicitly vendor-tagged, rated it at least critical, and could not find an upper fixed-version bound on the matched advisory range.
 
+Another conservative pattern is to gate on obvious public-internet exposure for the same advisory-backed event:
+
+```yaml
+rules:
+  - name: quarantine_publicly_exposed_known_exploited_service_without_fix_bound
+    require_advisory_match: true
+    require_known_exploited_advisory: true
+    require_advisory_public_internet_exposure: true
+    require_missing_advisory_fix_version: true
+    min_advisory_severity: critical
+    action: quarantine
+    duration: 24h
+```
+
+This second example still stays within the current trust boundary. It matches only when Vigil already found a high-confidence applicable advisory reason, the affected service is currently listening on an obviously globally routable local IP address, the advisory is known exploited, the matched severity is at least critical, and the matched advisory range still has no upper fixed-version bound.
+
 ## Current scope limits
 
 This is still an intentionally narrow slice of mitigation-aware response rules.

--- a/response-rules.example.yaml
+++ b/response-rules.example.yaml
@@ -34,3 +34,12 @@ rules:
     min_advisory_severity: critical
     action: block_process
     duration: 24h
+
+  - name: quarantine_publicly_exposed_known_exploited_service_without_fix_bound
+    require_advisory_match: true
+    require_known_exploited_advisory: true
+    require_advisory_public_internet_exposure: true
+    require_missing_advisory_fix_version: true
+    min_advisory_severity: critical
+    action: quarantine
+    duration: 24h


### PR DESCRIPTION
## Summary

- add a second mitigation-aware response-rule example that demonstrates the already-shipped `require_advisory_public_internet_exposure` predicate
- update the sample YAML so operators can copy a conservative public-exposure rule without widening Vigil's current trust boundary
- keep the change documentation-only and leave advisory matching and response behavior unchanged

## Why this task

There were no open PRs, unresolved review threads, requested changes, failing CI signals, or open issues that needed scheduled follow-up in `YMRYMR/vigil`.

The next unfinished roadmap item remains **Phase 16 — Mitigation-aware response rules**. Within that open item, the smallest safe slice available from this environment was to improve operator-facing examples for the already-implemented public-exposure predicate, rather than inventing broader exposure inference or richer guidance attribution.

## Validation

- reviewed `ROADMAP.md` to confirm `Mitigation-aware response rules` is still the next unfinished roadmap item
- reviewed `docs/RESPONSE-RULES.md`, `response-rules.example.yaml`, and the repository's public advisory guidance in `README.md` / `docs/USER-GUIDE.md`
- limited the change to documentation and sample YAML for existing behavior only

## Notes

- I did not run local Rust tests in this scheduled environment because the repository checkout is not available in the workspace and direct GitHub cloning is blocked here
- this PR does not change advisory scoring, exposure inference, or active-response logic; it only documents an existing conservative predicate more concretely
