### PR TITLE
Phase 16: clarify public exposure trust boundary in user guide

### DIFF
--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -108,6 +108,7 @@ By default, Vigil also requires an extra typed confirmation before turning on di
 The Trusted Processes section now includes a short onboarding tutorial. It explains how to keep the shipped baseline, learn from Activity and the Inspector, and add only stable apps you already recognize.
 
 Response rules can also match high-confidence advisory context conservatively, including known-exploited status, mitigation-guidance availability, explicitly vendor-tagged guidance references, missing fixed-version bounds, affected-product text, and obvious public-internet exposure for a globally routable listening socket. See [Response rules](RESPONSE-RULES.md) and `response-rules.example.yaml` for the exact YAML fields and example patterns.
+That public-exposure predicate is intentionally strict: only a current `LISTEN` socket bound to an obviously globally routable local IP matches today. Wildcard binds such as `0.0.0.0`, loopback listeners, RFC1918 or CGNAT IPv4 ranges, unique-local IPv6 addresses, and reachability that depends on NAT or reverse proxies still stay unmatched.
 
 ### Help
 


### PR DESCRIPTION
## Summary

- clarify in `docs/USER-GUIDE.md` that the shipped `require_advisory_public_internet_exposure` predicate only matches a current `LISTEN` socket bound to an obviously globally routable local IP
- spell out that wildcard binds, loopback listeners, RFC1918/CGNAT IPv4 space, unique-local IPv6, and reachability inferred through NAT or reverse proxies do not count today
- keep the change documentation-only so the current Phase 16 trust boundary stays unchanged

## Why this task

There were no open pull requests, unresolved review threads, requested changes, failing CI signals, or open issues that needed scheduled follow-up in `YMRYMR/vigil`.

The next unfinished roadmap item remains **Phase 16 — Mitigation-aware response rules**. Within that still-open item, this was the smallest safe slice that was concrete from the current repository state: tighten operator-facing guidance for the already-shipped public-exposure predicate without widening advisory matching or exposure inference.

## Validation

- reviewed `ROADMAP.md` to confirm the next unfinished item remains the open Phase 16 mitigation-aware response-rule work
- reviewed `docs/RESPONSE-RULES.md`, `docs/USER-GUIDE.md`, `response-rules.example.yaml`, and `src/security/response_rules.rs` to align the new guidance with the actual shipped predicate behavior
- confirmed the branch diff is limited to a single-line clarification in `docs/USER-GUIDE.md`

## Notes

- I did not run local Rust tests in this scheduled environment because the repository checkout is not available in the workspace and this branch changes documentation only
- this PR does not change response-rule matching, advisory scoring, or exposure inference behavior; it only clarifies the current conservative boundary for operators
