### PR TITLE
Phase 16: clarify README response-rule trust boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ Use [`docs/RESPONSE-RULES.md`](docs/RESPONSE-RULES.md) together with
 turn those high-confidence advisory matches into conservative operator-managed
 response rules.
 
+Those advisory-aware predicates stay intentionally narrow today. Mitigation
+guidance counts only when the protected advisory cache preserves non-empty
+mitigation text or an explicit remediation-tagged reference such as `Fix`,
+`Patch`, `Update`, `Upgrade`, `Workaround`, `Guidance`, or `Solution`. Vendor
+guidance counts only when that same tagged reference is also marked as
+vendor-authored material such as `Vendor Advisory`, `Vendor Bulletin`, or
+`Vendor Notice`. Public-internet exposure counts only for a current `LISTEN`
+socket bound to an obviously globally routable local IP. Fixed-version-only
+tokens do not count as operator guidance.
+
 Use `--sync-nvd --force` only when you need to override the normal 2-hour
 minimum interval. Provide an API key via `VIGIL_NVD_API_KEY` if the deployment
 needs higher NVD API headroom.


### PR DESCRIPTION
## Summary

- clarify in `README.md` that the shipped Phase 16 advisory-aware response-rule slice still uses a narrow trust boundary
- spell out that mitigation guidance only counts from preserved mitigation text or explicit remediation-tagged references such as `Fix`, `Patch`, `Update`, `Upgrade`, `Workaround`, `Guidance`, and `Solution`
- note that vendor guidance only counts when the same tagged reference is also marked as vendor-authored material such as `Vendor Advisory`, `Vendor Bulletin`, or `Vendor Notice`
- document that public-internet exposure still only counts for a current `LISTEN` socket bound to an obviously globally routable local IP, and that fixed-version-only tokens do not count as operator guidance

## Why this task

There were no open pull requests in `YMRYMR/vigil` created by the authenticated agent login `YMRYMR`, so there was no active PR follow-up or CI blocker to address.

The next unfinished roadmap item remains **Phase 16 — Mitigation-aware response rules**. The smallest safe in-scope slice was to bring the top-level README into line with the stricter trust boundary already documented in `docs/RESPONSE-RULES.md` and `docs/USER-GUIDE.md`, without widening any advisory matching or active-response behavior.

## Validation

- reviewed `ROADMAP.md` to confirm the next unfinished roadmap item remains Phase 16 mitigation-aware response rules
- reviewed `README.md`, `docs/RESPONSE-RULES.md`, `docs/USER-GUIDE.md`, and `src/advisory_runtime_score.rs` to keep the new wording aligned with the currently shipped explicit-tag and public-exposure behavior
- confirmed the branch diff is limited to a single paragraph in `README.md`

## Notes

- I did not run local Rust tests in this scheduled environment because the repository checkout is not available as a buildable local workspace here and the change is documentation-only
- this PR does not change advisory scoring, response-rule parsing, or exposure inference; it only makes the README more precise for operators