### PR TITLE
Phase 16: preserve vendor alias output follow-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ metadata without touching Vigil's startup path:
 vigil_inventory
 ```
 
+Its JSON output includes normalized product and vendor hints such as
+`product_key`, `product_aliases`, `vendor_key`, and `vendor_aliases` so later
+matching stays explainable and conservative.
+
 ---
 
 ## Installation

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -190,6 +190,13 @@ The standalone `vigil_inventory` helper prints local Windows/Linux software inve
 vigil_inventory
 ```
 
+Each row includes conservative normalized identity hints so later matching can stay explainable:
+
+- `product_key` for the primary normalized product identity
+- `product_aliases` for alternate normalized product forms derived from names and executable stems
+- `vendor_key` for the primary normalized publisher or vendor identity
+- `vendor_aliases` for alternate normalized vendor forms, including suffix-stripped aliases
+
 Current inventory sources:
 
 - Windows uninstall registry

--- a/src/bin/vigil_inventory.rs
+++ b/src/bin/vigil_inventory.rs
@@ -52,6 +52,8 @@ struct InventoryEntry {
     product_aliases: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     vendor_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    vendor_aliases: Vec<String>,
     source: &'static str,
 }
 
@@ -90,6 +92,11 @@ fn enrich_inventory_identity(entry: &mut InventoryEntry) {
         .publisher_hint
         .as_deref()
         .and_then(normalize_vendor_key);
+    entry.vendor_aliases = entry
+        .publisher_hint
+        .as_deref()
+        .map(collect_vendor_aliases)
+        .unwrap_or_default();
 }
 
 fn primary_product_key(display_name: &str, executable_path: Option<&str>) -> Option<String> {
@@ -113,6 +120,18 @@ fn collect_product_aliases(display_name: &str, executable_path: Option<&str>) ->
                 aliases.insert(alias);
             }
         }
+    }
+    aliases.into_iter().collect()
+}
+
+fn collect_vendor_aliases(publisher: &str) -> Vec<String> {
+    let publisher = publisher.split('<').next().unwrap_or(publisher).trim();
+    let mut aliases = BTreeSet::new();
+    if let Some(alias) = normalize_vendor_key(publisher) {
+        aliases.insert(alias);
+    }
+    if let Some(alias) = normalize_identity(publisher) {
+        aliases.insert(alias);
     }
     aliases.into_iter().collect()
 }
@@ -230,6 +249,7 @@ fn inventory_entry_from_uninstall_key(key: &winreg::RegKey) -> Option<InventoryE
         product_key: None,
         product_aliases: Vec::new(),
         vendor_key: None,
+        vendor_aliases: Vec::new(),
         source: "windows-uninstall-registry",
     })
 }
@@ -302,6 +322,7 @@ fn inventory_entry_from_dpkg_fields(fields: &BTreeMap<String, String>) -> Option
         product_key: None,
         product_aliases: Vec::new(),
         vendor_key: None,
+        vendor_aliases: Vec::new(),
         source: "linux-dpkg-status",
     })
 }
@@ -351,6 +372,7 @@ fn inventory_entry_from_rpm_line(line: &str) -> Option<InventoryEntry> {
         product_key: None,
         product_aliases: Vec::new(),
         vendor_key: None,
+        vendor_aliases: Vec::new(),
         source: "linux-rpm-database",
     })
 }
@@ -358,7 +380,7 @@ fn inventory_entry_from_rpm_line(line: &str) -> Option<InventoryEntry> {
 fn collect_apk_entries() -> Vec<InventoryEntry> {
     let Ok(installed) = std::fs::read_to_string("/lib/apk/db/installed") else {
         return Vec::new();
-    };
+    }
     parse_apk_installed(&installed)
 }
 
@@ -401,6 +423,7 @@ fn inventory_entry_from_apk_fields(fields: &BTreeMap<char, String>) -> Option<In
         product_key: None,
         product_aliases: Vec::new(),
         vendor_key: None,
+        vendor_aliases: Vec::new(),
         source: "linux-apk-installed",
     })
 }
@@ -558,6 +581,18 @@ mod tests {
     }
 
     #[test]
+    fn collect_vendor_aliases_keeps_full_and_suffix_stripped_forms() {
+        assert_eq!(
+            collect_vendor_aliases("Example Corporation <sec@example.com>"),
+            vec!["example".to_string(), "example-corporation".to_string()]
+        );
+        assert_eq!(
+            collect_vendor_aliases("Microsoft Corporation"),
+            vec!["microsoft".to_string(), "microsoft-corporation".to_string()]
+        );
+    }
+
+    #[test]
     fn collect_product_aliases_uses_display_name_and_executable_stem() {
         let aliases = collect_product_aliases(
             "Google Chrome",
@@ -579,6 +614,7 @@ mod tests {
             product_key: None,
             product_aliases: Vec::new(),
             vendor_key: None,
+            vendor_aliases: Vec::new(),
             source: "windows-uninstall-registry",
         };
 
@@ -589,6 +625,10 @@ mod tests {
         assert_eq!(
             entry.product_aliases,
             vec!["agent".to_string(), "example-agent".to_string()]
+        );
+        assert_eq!(
+            entry.vendor_aliases,
+            vec!["example".to_string(), "example-corp".to_string()]
         );
     }
 }

--- a/src/bin/vigil_inventory.rs
+++ b/src/bin/vigil_inventory.rs
@@ -380,7 +380,7 @@ fn inventory_entry_from_rpm_line(line: &str) -> Option<InventoryEntry> {
 fn collect_apk_entries() -> Vec<InventoryEntry> {
     let Ok(installed) = std::fs::read_to_string("/lib/apk/db/installed") else {
         return Vec::new();
-    }
+    };
     parse_apk_installed(&installed)
 }
 


### PR DESCRIPTION
Superseded by #275, which reapplies the same focused vendor-alias work on a clean branch based on current `master` to avoid the stale/diverged branch state.

Original preservation notes:

## Summary
- preserve the current unmerged work on `codex/phase16-vendor-aliases-current` in a reviewable PR
- add `vendor_aliases` to the standalone `vigil_inventory` JSON output alongside the existing normalized product and vendor hints
- document those emitted identity-hint fields in the README and user guide

## Why
There were no open pull requests in `YMRYMR/vigil`, but this branch still contains a focused diff across `README.md`, `docs/USER-GUIDE.md`, and `src/bin/vigil_inventory.rs`.

Opening a fresh draft PR keeps that work visible, reviewable, and eligible for normal CI instead of leaving it stranded on a branch with no review path.

## Validation
- compared `codex/phase16-vendor-aliases-current` against `master`
- confirmed the branch still carries a small focused diff across three files
- did not run local Rust checks in this scheduled environment because the repository checkout was not available as a local buildable workspace here

## Notes
- this PR is intentionally draft so maintainers can review the diff and CI before deciding whether to refresh or merge it
- the branch has diverged from `master`, so reviewers should treat this as preservation of remaining work rather than as a claim that it is immediately merge-ready