### PR TITLE
Document Linux hardening and add systemd unit baseline

### DIFF
--- a/docs/LINUX-HARDENING.md
+++ b/docs/LINUX-HARDENING.md
@@ -1,0 +1,54 @@
+# Linux hardening notes
+
+This document records Linux-specific service and active-response expectations so
+Linux behaviour can be reviewed at the same level of detail as Windows behaviour.
+
+## Boot-time service hardening
+
+The Linux boot-time service should run with the smallest practical systemd
+sandbox that still allows Vigil to monitor host network/process activity and
+restore connectivity after containment.
+
+The installed unit should:
+
+- keep the service headless by passing `--service-mode`;
+- use the shared data directory passed through `--data-dir`;
+- avoid gaining new privileges after startup;
+- bound capabilities to the networking, BPF, performance-monitoring, and process
+  control capabilities Vigil needs for Linux monitoring and response;
+- make the filesystem read-only except for the configured Vigil data directory
+  and the host locations that containment/recovery intentionally manages;
+- keep a sane restart policy so repeated failures do not trap the machine in an
+  unusable state together with the pre-login fail-open guard.
+
+## Linux capability expectations
+
+The preferred long-term shape is per-action capability reporting in the UI:
+
+| Area | Typical Linux requirement | Notes |
+| --- | --- | --- |
+| Network/process polling | regular user for reduced visibility; root/capabilities for full visibility | The UI should say when Linux has fallen back to reduced visibility. |
+| eBPF realtime monitoring | `CAP_BPF` and usually `CAP_PERFMON`; older kernels may require broader privileges | Diagnostics should distinguish missing capability, missing BTF, and verifier errors. |
+| Firewall isolation/rules | `CAP_NET_ADMIN` or root | Prefer nftables when available, with iptables fallback. |
+| TCP connection kill | root or relevant networking capability plus `ss -K` support | Failure should degrade cleanly, not leave partial state. |
+| Process suspend/resume | same UID or `CAP_KILL`/root depending target | The UI should explain when a PID cannot be controlled. |
+| Adapter isolation | `CAP_NET_ADMIN` or root | Always preserve enough state for restore and break-glass recovery. |
+| Hosts-file domain block | root or write access to `/etc/hosts` | Restore must only remove Vigil-owned marker blocks. |
+| systemd service install/uninstall | root | Installer should never self-elevate unexpectedly. |
+
+## Active-response parity TODOs
+
+These are the next Linux refinements after service hardening:
+
+1. Add a Linux active-response backend trait and a mocked command runner so
+   iptables/ip/ss/hosts-file behaviour can be unit-tested without root.
+2. Add nftables as the preferred firewall backend and keep iptables as fallback.
+3. Improve executable-path blocking. The current UID-based Linux fallback can
+   overblock unrelated processes that share the same effective UID; the UI and
+   backend should either use a more precise isolation primitive or label the
+   action as broader than Windows path blocking.
+4. Add explicit privilege diagnostics to Settings/Inspector so Linux operators
+   know whether realtime monitoring, response actions, and recovery are fully
+   available.
+5. Exercise break-glass recovery for both firewall-policy isolation and adapter
+   cutoff on Linux VMs before widening release claims.

--- a/docs/SUPPORTED-PLATFORMS.md
+++ b/docs/SUPPORTED-PLATFORMS.md
@@ -27,6 +27,7 @@ Current Linux-specific priorities:
 - Package inventory through dpkg, RPM, and Alpine apk sources.
 - Reversible active-response actions through Linux-native controls.
 - Clear privilege UX around root and Linux capabilities.
+- Service and active-response hardening tracked in [`LINUX-HARDENING.md`](LINUX-HARDENING.md).
 
 ## Out of active scope
 

--- a/packaging/linux/vigil.service.example
+++ b/packaging/linux/vigil.service.example
@@ -1,0 +1,46 @@
+[Unit]
+Description=Vigil network monitor
+Documentation=https://github.com/YMRYMR/vigil
+After=network.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Replace both placeholders before installing this example manually.
+ExecStart=/opt/vigil/vigil --service-mode --data-dir /var/lib/vigil
+Restart=on-failure
+RestartSec=5s
+StartLimitIntervalSec=300
+StartLimitBurst=3
+StandardOutput=journal
+StandardError=journal
+
+# Vigil needs host network/process visibility and controlled response actions.
+# These bounds keep the service from gaining unrelated privileges while still
+# allowing Linux monitoring, firewall response, process response, and recovery.
+NoNewPrivileges=yes
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_BPF CAP_PERFMON CAP_SYS_PTRACE CAP_KILL CAP_DAC_READ_SEARCH CAP_CHOWN CAP_FOWNER
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_BPF CAP_PERFMON CAP_SYS_PTRACE CAP_KILL CAP_DAC_READ_SEARCH
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+PrivateTmp=yes
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/var/lib/vigil /etc/hosts /etc/systemd/system
+
+# Keep network address families broad enough for endpoint monitoring and local
+# response helpers. Do not enable private networking; Vigil must observe host
+# networking rather than an isolated namespace.
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK AF_PACKET
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/linux/vigil.service.example
+++ b/packaging/linux/vigil.service.example
@@ -3,6 +3,8 @@ Description=Vigil network monitor
 Documentation=https://github.com/YMRYMR/vigil
 After=network.target
 Wants=network-online.target
+StartLimitIntervalSec=300
+StartLimitBurst=3
 
 [Service]
 Type=simple
@@ -10,8 +12,6 @@ Type=simple
 ExecStart=/opt/vigil/vigil --service-mode --data-dir /var/lib/vigil
 Restart=on-failure
 RestartSec=5s
-StartLimitIntervalSec=300
-StartLimitBurst=3
 StandardOutput=journal
 StandardError=journal
 
@@ -35,7 +35,7 @@ ProtectKernelModules=yes
 ProtectKernelTunables=yes
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths=/var/lib/vigil /etc/hosts /etc/systemd/system
+ReadWritePaths=/var/lib/vigil /etc/hosts
 
 # Keep network address families broad enough for endpoint monitoring and local
 # response helpers. Do not enable private networking; Vigil must observe host


### PR DESCRIPTION
## Summary

- add `docs/LINUX-HARDENING.md` with Linux service, capability, and active-response parity expectations
- add `packaging/linux/vigil.service.example` as a hardened systemd unit baseline for review
- link the Linux hardening contract from `docs/SUPPORTED-PLATFORMS.md`

## Notes

This is intentionally a conservative first step toward Linux/Windows parity. It avoids touching the large Linux active-response implementation in this PR and instead establishes an auditable target for service hardening, privilege expectations, nftables/iptables follow-up work, and break-glass validation.

## Testing

Not run here. Changes are documentation and packaging-template only.