### PR TITLE
Linux: add firewall backend plan executor

### DIFF
--- a/src/security/linux_command_plan.rs
+++ b/src/security/linux_command_plan.rs
@@ -155,6 +155,9 @@ pub const NFT_TABLE: &str = "vigil";
 pub const NFT_INPUT_CHAIN: &str = "input";
 pub const NFT_OUTPUT_CHAIN: &str = "output";
 pub const NFT_FORWARD_CHAIN: &str = "forward";
+pub const NFT_ISOL_IN_CHAIN: &str = "isolin";
+pub const NFT_ISOL_FORWARD_CHAIN: &str = "isolforward";
+pub const NFT_ISOL_OUT_CHAIN: &str = "isolout";
 
 pub fn nft_list_ruleset() -> LinuxCommand {
     LinuxCommand::new("nft", ["list", "ruleset"])
@@ -180,6 +183,36 @@ pub fn nft_add_filter_chain(chain: &str, hook: &str, priority: i32, policy: &str
 
 pub fn nft_delete_table() -> LinuxCommand {
     LinuxCommand::new("nft", ["delete", "table", "inet", NFT_TABLE])
+}
+
+pub fn nft_add_chain(chain: &str) -> LinuxCommand {
+    LinuxCommand::new("nft", ["add", "chain", "inet", NFT_TABLE, chain])
+}
+
+pub fn nft_insert_jump_rule(src_chain: &str, dst_chain: &str) -> LinuxCommand {
+    LinuxCommand::new(
+        "nft",
+        [
+            "insert", "rule", "inet", NFT_TABLE, src_chain, "jump", dst_chain,
+        ],
+    )
+}
+
+pub fn nft_insert_block_all_into(chain: &str, rule_name: &str) -> LinuxCommand {
+    LinuxCommand::new(
+        "nft",
+        [
+            "insert",
+            "rule",
+            "inet",
+            NFT_TABLE,
+            chain,
+            "counter",
+            "comment",
+            &nft_comment(rule_name),
+            "drop",
+        ],
+    )
 }
 
 pub fn nft_insert_block_all(rule_name: &str, direction: &str) -> LinuxCommand {

--- a/src/security/linux_firewall_backend.rs
+++ b/src/security/linux_firewall_backend.rs
@@ -1,0 +1,232 @@
+use super::linux_command_plan::{
+    iptables_insert_block_remote, iptables_insert_block_uid, iptables_set_policy,
+    nft_add_filter_chain, nft_add_table, nft_delete_table, nft_insert_block_all,
+    nft_insert_block_remote, nft_insert_block_uid, nft_list_ruleset, LinuxCommand,
+    LinuxCommandRunner, NFT_FORWARD_CHAIN, NFT_INPUT_CHAIN, NFT_OUTPUT_CHAIN,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinuxFirewallBackend {
+    Nftables,
+    Iptables,
+}
+
+impl LinuxFirewallBackend {
+    #[allow(dead_code)]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Nftables => "nftables",
+            Self::Iptables => "iptables",
+        }
+    }
+}
+
+/// Prefer nftables when it is usable, otherwise fall back to iptables.
+///
+/// The probe is intentionally read-only: `nft list ruleset` requires enough
+/// privilege to inspect the ruleset but does not mutate host firewall state.
+pub fn select_firewall_backend(runner: &impl LinuxCommandRunner) -> LinuxFirewallBackend {
+    if runner.stdout(&nft_list_ruleset()).is_ok() {
+        LinuxFirewallBackend::Nftables
+    } else {
+        LinuxFirewallBackend::Iptables
+    }
+}
+
+pub fn firewall_backend_setup_plan(backend: LinuxFirewallBackend) -> Vec<LinuxCommand> {
+    match backend {
+        LinuxFirewallBackend::Nftables => vec![
+            nft_add_table(),
+            nft_add_filter_chain(NFT_INPUT_CHAIN, "input", 0, "accept"),
+            nft_add_filter_chain(NFT_FORWARD_CHAIN, "forward", 0, "accept"),
+            nft_add_filter_chain(NFT_OUTPUT_CHAIN, "output", 0, "accept"),
+        ],
+        LinuxFirewallBackend::Iptables => Vec::new(),
+    }
+}
+
+pub fn firewall_backend_isolate_plan(
+    backend: LinuxFirewallBackend,
+    rule_name: &str,
+) -> Vec<LinuxCommand> {
+    match backend {
+        LinuxFirewallBackend::Nftables => vec![
+            nft_insert_block_all(rule_name, "in"),
+            nft_insert_block_all(rule_name, "forward"),
+            nft_insert_block_all(rule_name, "out"),
+        ],
+        LinuxFirewallBackend::Iptables => vec![
+            iptables_set_policy("INPUT", "DROP"),
+            iptables_set_policy("FORWARD", "DROP"),
+            iptables_set_policy("OUTPUT", "DROP"),
+        ],
+    }
+}
+
+pub fn firewall_backend_restore_plan(backend: LinuxFirewallBackend) -> Vec<LinuxCommand> {
+    match backend {
+        LinuxFirewallBackend::Nftables => vec![nft_delete_table()],
+        LinuxFirewallBackend::Iptables => vec![
+            iptables_set_policy("INPUT", "ACCEPT"),
+            iptables_set_policy("FORWARD", "ACCEPT"),
+            iptables_set_policy("OUTPUT", "ACCEPT"),
+        ],
+    }
+}
+
+pub fn firewall_backend_block_remote_plan(
+    backend: LinuxFirewallBackend,
+    rule_name: &str,
+    target: &str,
+) -> Vec<LinuxCommand> {
+    match backend {
+        LinuxFirewallBackend::Nftables => vec![nft_insert_block_remote(rule_name, target)],
+        LinuxFirewallBackend::Iptables => vec![iptables_insert_block_remote(rule_name, target)],
+    }
+}
+
+pub fn firewall_backend_block_uid_plan(
+    backend: LinuxFirewallBackend,
+    rule_name: &str,
+    direction: &str,
+    uid: u32,
+) -> Vec<LinuxCommand> {
+    match backend {
+        LinuxFirewallBackend::Nftables => vec![nft_insert_block_uid(rule_name, direction, uid)],
+        LinuxFirewallBackend::Iptables => {
+            vec![iptables_insert_block_uid(rule_name, direction, uid)]
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct ProbeRunner {
+        nft_available: bool,
+    }
+
+    impl LinuxCommandRunner for ProbeRunner {
+        fn status(&self, _command: &LinuxCommand) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn stdout(&self, command: &LinuxCommand) -> Result<String, String> {
+            if command.program == "nft" && self.nft_available {
+                Ok("table inet filter".to_string())
+            } else {
+                Err("not available".to_string())
+            }
+        }
+    }
+
+    #[test]
+    fn selects_nftables_when_probe_succeeds() {
+        let runner = ProbeRunner {
+            nft_available: true,
+        };
+        assert_eq!(
+            select_firewall_backend(&runner),
+            LinuxFirewallBackend::Nftables
+        );
+    }
+
+    #[test]
+    fn falls_back_to_iptables_when_nft_probe_fails() {
+        let runner = ProbeRunner {
+            nft_available: false,
+        };
+        assert_eq!(
+            select_firewall_backend(&runner),
+            LinuxFirewallBackend::Iptables
+        );
+    }
+
+    #[test]
+    fn nftables_setup_creates_vigil_table_and_chains() {
+        let plan = firewall_backend_setup_plan(LinuxFirewallBackend::Nftables);
+        assert_eq!(plan.len(), 4);
+        assert_eq!(
+            plan[0],
+            LinuxCommand::new("nft", ["add", "table", "inet", "vigil"])
+        );
+        assert_eq!(plan[1].args[4], "input");
+        assert_eq!(plan[2].args[4], "forward");
+        assert_eq!(plan[3].args[4], "output");
+    }
+
+    #[test]
+    fn iptables_setup_is_empty_because_existing_tables_are_used() {
+        assert!(firewall_backend_setup_plan(LinuxFirewallBackend::Iptables).is_empty());
+    }
+
+    #[test]
+    fn nftables_isolation_uses_vigil_drop_rules_without_changing_global_policy() {
+        let plan = firewall_backend_isolate_plan(LinuxFirewallBackend::Nftables, "isolate");
+        assert_eq!(plan.len(), 3);
+        assert!(plan.iter().all(|command| command.program == "nft"));
+        assert!(plan
+            .iter()
+            .all(|command| command.args.iter().any(|arg| arg == "drop")));
+    }
+
+    #[test]
+    fn iptables_isolation_preserves_existing_policy_shape() {
+        let plan = firewall_backend_isolate_plan(LinuxFirewallBackend::Iptables, "isolate");
+        assert_eq!(
+            plan,
+            vec![
+                LinuxCommand::new("iptables", ["-P", "INPUT", "DROP"]),
+                LinuxCommand::new("iptables", ["-P", "FORWARD", "DROP"]),
+                LinuxCommand::new("iptables", ["-P", "OUTPUT", "DROP"]),
+            ]
+        );
+    }
+
+    #[test]
+    fn restore_plan_matches_backend() {
+        assert_eq!(
+            firewall_backend_restore_plan(LinuxFirewallBackend::Nftables),
+            vec![LinuxCommand::new(
+                "nft",
+                ["delete", "table", "inet", "vigil"]
+            )]
+        );
+        assert_eq!(
+            firewall_backend_restore_plan(LinuxFirewallBackend::Iptables),
+            vec![
+                LinuxCommand::new("iptables", ["-P", "INPUT", "ACCEPT"]),
+                LinuxCommand::new("iptables", ["-P", "FORWARD", "ACCEPT"]),
+                LinuxCommand::new("iptables", ["-P", "OUTPUT", "ACCEPT"]),
+            ]
+        );
+    }
+
+    #[test]
+    fn remote_block_plan_keeps_ipv6_family_when_using_nftables() {
+        let plan = firewall_backend_block_remote_plan(
+            LinuxFirewallBackend::Nftables,
+            "block-v6",
+            "2606:4700:4700::1111",
+        );
+        assert_eq!(plan.len(), 1);
+        assert_eq!(plan[0].program, "nft");
+        assert_eq!(plan[0].args[4], "output");
+        assert_eq!(plan[0].args[5], "ip6");
+        assert_eq!(plan[0].args[6], "daddr");
+    }
+
+    #[test]
+    fn uid_block_plan_matches_backend() {
+        let nft =
+            firewall_backend_block_uid_plan(LinuxFirewallBackend::Nftables, "uid", "out", 1000);
+        assert_eq!(nft[0].program, "nft");
+        assert!(nft[0].args.iter().any(|arg| arg == "skuid"));
+
+        let iptables =
+            firewall_backend_block_uid_plan(LinuxFirewallBackend::Iptables, "uid", "out", 1000);
+        assert_eq!(iptables[0].program, "iptables");
+        assert!(iptables[0].args.iter().any(|arg| arg == "--uid-owner"));
+    }
+}

--- a/src/security/linux_firewall_backend.rs
+++ b/src/security/linux_firewall_backend.rs
@@ -8,9 +8,10 @@
 
 use super::linux_command_plan::{
     iptables_insert_block_remote, iptables_insert_block_uid, iptables_list_rules,
-    iptables_set_policy, nft_add_filter_chain, nft_add_table, nft_delete_table, nft_flush_chain,
-    nft_insert_block_all, nft_insert_block_remote, nft_insert_block_uid, nft_list_ruleset,
-    LinuxCommand, LinuxCommandRunner, NFT_FORWARD_CHAIN, NFT_INPUT_CHAIN, NFT_OUTPUT_CHAIN,
+    iptables_set_policy, nft_add_chain, nft_add_filter_chain, nft_add_table, nft_flush_chain,
+    nft_insert_block_all_into, nft_insert_block_remote, nft_insert_block_uid, nft_insert_jump_rule,
+    nft_list_ruleset, LinuxCommand, LinuxCommandRunner, NFT_FORWARD_CHAIN, NFT_INPUT_CHAIN,
+    NFT_ISOL_FORWARD_CHAIN, NFT_ISOL_IN_CHAIN, NFT_ISOL_OUT_CHAIN, NFT_OUTPUT_CHAIN,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -97,6 +98,12 @@ pub fn firewall_backend_setup_plan(backend: LinuxFirewallBackend) -> Vec<LinuxCo
             nft_add_filter_chain(NFT_INPUT_CHAIN, "input", 0, "accept"),
             nft_add_filter_chain(NFT_FORWARD_CHAIN, "forward", 0, "accept"),
             nft_add_filter_chain(NFT_OUTPUT_CHAIN, "output", 0, "accept"),
+            nft_add_chain(NFT_ISOL_IN_CHAIN),
+            nft_add_chain(NFT_ISOL_FORWARD_CHAIN),
+            nft_add_chain(NFT_ISOL_OUT_CHAIN),
+            nft_insert_jump_rule(NFT_INPUT_CHAIN, NFT_ISOL_IN_CHAIN),
+            nft_insert_jump_rule(NFT_FORWARD_CHAIN, NFT_ISOL_FORWARD_CHAIN),
+            nft_insert_jump_rule(NFT_OUTPUT_CHAIN, NFT_ISOL_OUT_CHAIN),
         ],
         LinuxFirewallBackend::Iptables => Vec::new(),
     }
@@ -108,9 +115,9 @@ pub fn firewall_backend_isolate_plan(
 ) -> Vec<LinuxCommand> {
     match backend {
         LinuxFirewallBackend::Nftables => vec![
-            nft_insert_block_all(rule_name, "in"),
-            nft_insert_block_all(rule_name, "forward"),
-            nft_insert_block_all(rule_name, "out"),
+            nft_insert_block_all_into(NFT_ISOL_IN_CHAIN, rule_name),
+            nft_insert_block_all_into(NFT_ISOL_FORWARD_CHAIN, rule_name),
+            nft_insert_block_all_into(NFT_ISOL_OUT_CHAIN, rule_name),
         ],
         LinuxFirewallBackend::Iptables => vec![
             iptables_set_policy("INPUT", "DROP"),
@@ -126,9 +133,9 @@ pub fn firewall_backend_restore_plan(
 ) -> Result<Vec<LinuxCommand>, String> {
     match backend {
         LinuxFirewallBackend::Nftables => Ok(vec![
-            nft_flush_chain(NFT_INPUT_CHAIN),
-            nft_flush_chain(NFT_FORWARD_CHAIN),
-            nft_flush_chain(NFT_OUTPUT_CHAIN),
+            nft_flush_chain(NFT_ISOL_IN_CHAIN),
+            nft_flush_chain(NFT_ISOL_FORWARD_CHAIN),
+            nft_flush_chain(NFT_ISOL_OUT_CHAIN),
         ]),
         LinuxFirewallBackend::Iptables => {
             let snapshot = iptables_snapshot.ok_or_else(|| {
@@ -247,7 +254,7 @@ mod tests {
     #[test]
     fn nftables_setup_creates_vigil_table_and_chains() {
         let plan = firewall_backend_setup_plan(LinuxFirewallBackend::Nftables);
-        assert_eq!(plan.len(), 4);
+        assert_eq!(plan.len(), 10);
         assert_eq!(
             plan[0],
             LinuxCommand::new("nft", ["add", "table", "inet", "vigil"])
@@ -255,6 +262,38 @@ mod tests {
         assert_eq!(plan[1].args[4], "input");
         assert_eq!(plan[2].args[4], "forward");
         assert_eq!(plan[3].args[4], "output");
+        assert_eq!(plan[4].args[4], "isolin");
+        assert_eq!(plan[5].args[4], "isolforward");
+        assert_eq!(plan[6].args[4], "isolout");
+        assert_eq!(
+            plan[7],
+            LinuxCommand::new(
+                "nft",
+                ["insert", "rule", "inet", "vigil", "input", "jump", "isolin"]
+            )
+        );
+        assert_eq!(
+            plan[8],
+            LinuxCommand::new(
+                "nft",
+                [
+                    "insert",
+                    "rule",
+                    "inet",
+                    "vigil",
+                    "forward",
+                    "jump",
+                    "isolforward"
+                ]
+            )
+        );
+        assert_eq!(
+            plan[9],
+            LinuxCommand::new(
+                "nft",
+                ["insert", "rule", "inet", "vigil", "output", "jump", "isolout"]
+            )
+        );
     }
 
     #[test]
@@ -263,13 +302,16 @@ mod tests {
     }
 
     #[test]
-    fn nftables_isolation_uses_vigil_drop_rules_without_changing_global_policy() {
+    fn nftables_isolation_uses_separate_chains_without_changing_main_chains() {
         let plan = firewall_backend_isolate_plan(LinuxFirewallBackend::Nftables, "isolate");
         assert_eq!(plan.len(), 3);
         assert!(plan.iter().all(|command| command.program == "nft"));
         assert!(plan
             .iter()
             .all(|command| command.args.iter().any(|arg| arg == "drop")));
+        assert_eq!(plan[0].args[4], "isolin");
+        assert_eq!(plan[1].args[4], "isolforward");
+        assert_eq!(plan[2].args[4], "isolout");
     }
 
     #[test]
@@ -290,9 +332,9 @@ mod tests {
         assert_eq!(
             firewall_backend_restore_plan(LinuxFirewallBackend::Nftables, None).unwrap(),
             vec![
-                LinuxCommand::new("nft", ["flush", "chain", "inet", "vigil", "input"]),
-                LinuxCommand::new("nft", ["flush", "chain", "inet", "vigil", "forward"]),
-                LinuxCommand::new("nft", ["flush", "chain", "inet", "vigil", "output"]),
+                LinuxCommand::new("nft", ["flush", "chain", "inet", "vigil", "isolin"]),
+                LinuxCommand::new("nft", ["flush", "chain", "inet", "vigil", "isolforward"]),
+                LinuxCommand::new("nft", ["flush", "chain", "inet", "vigil", "isolout"]),
             ]
         );
         assert_eq!(

--- a/src/security/linux_firewall_backend.rs
+++ b/src/security/linux_firewall_backend.rs
@@ -1,3 +1,11 @@
+//! Linux firewall backend selection and command sequencing.
+//!
+//! This module keeps backend choice and high-level firewall command sequences
+//! separate from command construction. It is intentionally not wired into the
+//! live active-response path yet; the goal is to make the nftables-preferred,
+//! iptables-fallback behavior explicit and unit-testable before runtime use.
+#![cfg_attr(not(test), allow(dead_code))]
+
 use super::linux_command_plan::{
     iptables_insert_block_remote, iptables_insert_block_uid, iptables_list_rules,
     iptables_set_policy, nft_add_filter_chain, nft_add_table, nft_delete_table,
@@ -12,7 +20,6 @@ pub enum LinuxFirewallBackend {
 }
 
 impl LinuxFirewallBackend {
-    #[allow(dead_code)]
     pub fn label(self) -> &'static str {
         match self {
             Self::Nftables => "nftables",

--- a/src/security/linux_firewall_backend.rs
+++ b/src/security/linux_firewall_backend.rs
@@ -1,8 +1,8 @@
 use super::linux_command_plan::{
-    iptables_insert_block_remote, iptables_insert_block_uid, iptables_set_policy,
-    nft_add_filter_chain, nft_add_table, nft_delete_table, nft_insert_block_all,
-    nft_insert_block_remote, nft_insert_block_uid, nft_list_ruleset, LinuxCommand,
-    LinuxCommandRunner, NFT_FORWARD_CHAIN, NFT_INPUT_CHAIN, NFT_OUTPUT_CHAIN,
+    iptables_insert_block_remote, iptables_insert_block_uid, iptables_list_rules,
+    iptables_set_policy, nft_add_filter_chain, nft_add_table, nft_delete_table,
+    nft_insert_block_all, nft_insert_block_remote, nft_insert_block_uid, nft_list_ruleset,
+    LinuxCommand, LinuxCommandRunner, NFT_FORWARD_CHAIN, NFT_INPUT_CHAIN, NFT_OUTPUT_CHAIN,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -21,6 +21,51 @@ impl LinuxFirewallBackend {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IptablesChainPolicy {
+    pub chain: String,
+    pub policy: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IptablesPolicySnapshot {
+    pub chains: Vec<IptablesChainPolicy>,
+}
+
+impl IptablesPolicySnapshot {
+    pub fn from_iptables_list(output: &str) -> Result<Self, String> {
+        let mut chains = Vec::new();
+        for line in output.lines() {
+            let trimmed = line.trim();
+            let Some(rest) = trimmed.strip_prefix("Chain ") else {
+                continue;
+            };
+            let Some((chain, policy_part)) = rest.split_once(" (policy ") else {
+                continue;
+            };
+            let Some(policy) = policy_part.strip_suffix(')') else {
+                continue;
+            };
+            if matches!(chain, "INPUT" | "FORWARD" | "OUTPUT") {
+                chains.push(IptablesChainPolicy {
+                    chain: chain.to_string(),
+                    policy: policy.to_string(),
+                });
+            }
+        }
+
+        for required in ["INPUT", "FORWARD", "OUTPUT"] {
+            if !chains.iter().any(|chain| chain.chain == required) {
+                return Err(format!(
+                    "iptables policy snapshot did not include the {required} chain"
+                ));
+            }
+        }
+
+        Ok(Self { chains })
+    }
+}
+
 /// Prefer nftables when it is usable, otherwise fall back to iptables.
 ///
 /// The probe is intentionally read-only: `nft list ruleset` requires enough
@@ -31,6 +76,13 @@ pub fn select_firewall_backend(runner: &impl LinuxCommandRunner) -> LinuxFirewal
     } else {
         LinuxFirewallBackend::Iptables
     }
+}
+
+pub fn capture_iptables_policy_snapshot(
+    runner: &impl LinuxCommandRunner,
+) -> Result<IptablesPolicySnapshot, String> {
+    let output = runner.stdout(&iptables_list_rules())?;
+    IptablesPolicySnapshot::from_iptables_list(&output)
 }
 
 pub fn firewall_backend_setup_plan(backend: LinuxFirewallBackend) -> Vec<LinuxCommand> {
@@ -63,14 +115,22 @@ pub fn firewall_backend_isolate_plan(
     }
 }
 
-pub fn firewall_backend_restore_plan(backend: LinuxFirewallBackend) -> Vec<LinuxCommand> {
+pub fn firewall_backend_restore_plan(
+    backend: LinuxFirewallBackend,
+    iptables_snapshot: Option<&IptablesPolicySnapshot>,
+) -> Result<Vec<LinuxCommand>, String> {
     match backend {
-        LinuxFirewallBackend::Nftables => vec![nft_delete_table()],
-        LinuxFirewallBackend::Iptables => vec![
-            iptables_set_policy("INPUT", "ACCEPT"),
-            iptables_set_policy("FORWARD", "ACCEPT"),
-            iptables_set_policy("OUTPUT", "ACCEPT"),
-        ],
+        LinuxFirewallBackend::Nftables => Ok(vec![nft_delete_table()]),
+        LinuxFirewallBackend::Iptables => {
+            let snapshot = iptables_snapshot.ok_or_else(|| {
+                "iptables restore requires a captured chain-policy snapshot".to_string()
+            })?;
+            Ok(snapshot
+                .chains
+                .iter()
+                .map(|chain| iptables_set_policy(&chain.chain, &chain.policy))
+                .collect())
+        }
     }
 }
 
@@ -115,6 +175,11 @@ mod tests {
         fn stdout(&self, command: &LinuxCommand) -> Result<String, String> {
             if command.program == "nft" && self.nft_available {
                 Ok("table inet filter".to_string())
+            } else if command.program == "iptables" {
+                Ok(
+                    "Chain INPUT (policy ACCEPT)\nChain FORWARD (policy DROP)\nChain OUTPUT (policy ACCEPT)\n"
+                        .to_string(),
+                )
             } else {
                 Err("not available".to_string())
             }
@@ -140,6 +205,33 @@ mod tests {
         assert_eq!(
             select_firewall_backend(&runner),
             LinuxFirewallBackend::Iptables
+        );
+    }
+
+    #[test]
+    fn captures_iptables_chain_policies_from_list_output() {
+        let runner = ProbeRunner {
+            nft_available: false,
+        };
+        let snapshot = capture_iptables_policy_snapshot(&runner).unwrap();
+        assert_eq!(
+            snapshot,
+            IptablesPolicySnapshot {
+                chains: vec![
+                    IptablesChainPolicy {
+                        chain: "INPUT".to_string(),
+                        policy: "ACCEPT".to_string(),
+                    },
+                    IptablesChainPolicy {
+                        chain: "FORWARD".to_string(),
+                        policy: "DROP".to_string(),
+                    },
+                    IptablesChainPolicy {
+                        chain: "OUTPUT".to_string(),
+                        policy: "ACCEPT".to_string(),
+                    },
+                ],
+            }
         );
     }
 
@@ -187,20 +279,45 @@ mod tests {
     #[test]
     fn restore_plan_matches_backend() {
         assert_eq!(
-            firewall_backend_restore_plan(LinuxFirewallBackend::Nftables),
+            firewall_backend_restore_plan(LinuxFirewallBackend::Nftables, None).unwrap(),
             vec![LinuxCommand::new(
                 "nft",
                 ["delete", "table", "inet", "vigil"]
             )]
         );
         assert_eq!(
-            firewall_backend_restore_plan(LinuxFirewallBackend::Iptables),
+            firewall_backend_restore_plan(
+                LinuxFirewallBackend::Iptables,
+                Some(&IptablesPolicySnapshot {
+                    chains: vec![
+                        IptablesChainPolicy {
+                            chain: "INPUT".to_string(),
+                            policy: "ACCEPT".to_string(),
+                        },
+                        IptablesChainPolicy {
+                            chain: "FORWARD".to_string(),
+                            policy: "DROP".to_string(),
+                        },
+                        IptablesChainPolicy {
+                            chain: "OUTPUT".to_string(),
+                            policy: "ACCEPT".to_string(),
+                        },
+                    ],
+                }),
+            )
+            .unwrap(),
             vec![
                 LinuxCommand::new("iptables", ["-P", "INPUT", "ACCEPT"]),
-                LinuxCommand::new("iptables", ["-P", "FORWARD", "ACCEPT"]),
+                LinuxCommand::new("iptables", ["-P", "FORWARD", "DROP"]),
                 LinuxCommand::new("iptables", ["-P", "OUTPUT", "ACCEPT"]),
             ]
         );
+    }
+
+    #[test]
+    fn iptables_restore_requires_a_snapshot() {
+        let err = firewall_backend_restore_plan(LinuxFirewallBackend::Iptables, None).unwrap_err();
+        assert!(err.contains("snapshot"));
     }
 
     #[test]

--- a/src/security/linux_firewall_executor.rs
+++ b/src/security/linux_firewall_executor.rs
@@ -8,26 +8,53 @@
 use super::linux_command_plan::StdLinuxCommandRunner;
 use super::linux_command_plan::{LinuxCommand, LinuxCommandRunner};
 use super::linux_firewall_backend::{
-    firewall_backend_block_remote_plan, firewall_backend_block_uid_plan,
-    firewall_backend_isolate_plan, firewall_backend_restore_plan, firewall_backend_setup_plan,
-    select_firewall_backend, LinuxFirewallBackend,
+    capture_iptables_policy_snapshot, firewall_backend_block_remote_plan,
+    firewall_backend_block_uid_plan, firewall_backend_isolate_plan,
+    firewall_backend_restore_plan, firewall_backend_setup_plan, select_firewall_backend,
+    IptablesPolicySnapshot, LinuxFirewallBackend,
 };
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinuxFirewallRestoreState {
+    pub backend: LinuxFirewallBackend,
+    pub iptables_policy_snapshot: Option<IptablesPolicySnapshot>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExecutedLinuxFirewallPlan {
     pub backend: LinuxFirewallBackend,
     pub commands: Vec<LinuxCommand>,
+    pub restore_state: Option<LinuxFirewallRestoreState>,
 }
 
 pub fn execute_firewall_plan(
     runner: &impl LinuxCommandRunner,
     backend: LinuxFirewallBackend,
     commands: Vec<LinuxCommand>,
+    restore_state: Option<LinuxFirewallRestoreState>,
 ) -> Result<ExecutedLinuxFirewallPlan, String> {
     for command in &commands {
         runner.status(command)?;
     }
-    Ok(ExecutedLinuxFirewallPlan { backend, commands })
+    Ok(ExecutedLinuxFirewallPlan {
+        backend,
+        commands,
+        restore_state,
+    })
+}
+
+fn capture_restore_state(
+    runner: &impl LinuxCommandRunner,
+    backend: LinuxFirewallBackend,
+) -> Result<LinuxFirewallRestoreState, String> {
+    let iptables_policy_snapshot = match backend {
+        LinuxFirewallBackend::Nftables => None,
+        LinuxFirewallBackend::Iptables => Some(capture_iptables_policy_snapshot(runner)?),
+    };
+    Ok(LinuxFirewallRestoreState {
+        backend,
+        iptables_policy_snapshot,
+    })
 }
 
 #[allow(dead_code)]
@@ -35,7 +62,12 @@ pub fn execute_selected_setup_plan(
     runner: &impl LinuxCommandRunner,
 ) -> Result<ExecutedLinuxFirewallPlan, String> {
     let backend = select_firewall_backend(runner);
-    execute_firewall_plan(runner, backend, firewall_backend_setup_plan(backend))
+    execute_firewall_plan(
+        runner,
+        backend,
+        firewall_backend_setup_plan(backend),
+        None,
+    )
 }
 
 pub fn execute_selected_isolate_plan(
@@ -43,16 +75,21 @@ pub fn execute_selected_isolate_plan(
     rule_name: &str,
 ) -> Result<ExecutedLinuxFirewallPlan, String> {
     let backend = select_firewall_backend(runner);
+    let restore_state = capture_restore_state(runner, backend)?;
     let mut commands = firewall_backend_setup_plan(backend);
     commands.extend(firewall_backend_isolate_plan(backend, rule_name));
-    execute_firewall_plan(runner, backend, commands)
+    execute_firewall_plan(runner, backend, commands, Some(restore_state))
 }
 
-pub fn execute_selected_restore_plan(
+pub fn execute_restore_plan(
     runner: &impl LinuxCommandRunner,
+    restore_state: &LinuxFirewallRestoreState,
 ) -> Result<ExecutedLinuxFirewallPlan, String> {
-    let backend = select_firewall_backend(runner);
-    execute_firewall_plan(runner, backend, firewall_backend_restore_plan(backend))
+    let commands = firewall_backend_restore_plan(
+        restore_state.backend,
+        restore_state.iptables_policy_snapshot.as_ref(),
+    )?;
+    execute_firewall_plan(runner, restore_state.backend, commands, None)
 }
 
 pub fn execute_selected_remote_block_plan(
@@ -65,7 +102,7 @@ pub fn execute_selected_remote_block_plan(
     commands.extend(firewall_backend_block_remote_plan(
         backend, rule_name, target,
     ));
-    execute_firewall_plan(runner, backend, commands)
+    execute_firewall_plan(runner, backend, commands, None)
 }
 
 pub fn execute_selected_uid_block_plan(
@@ -79,7 +116,7 @@ pub fn execute_selected_uid_block_plan(
     commands.extend(firewall_backend_block_uid_plan(
         backend, rule_name, direction, uid,
     ));
-    execute_firewall_plan(runner, backend, commands)
+    execute_firewall_plan(runner, backend, commands, None)
 }
 
 #[cfg(target_os = "linux")]
@@ -88,8 +125,10 @@ pub fn execute_system_isolate_plan(rule_name: &str) -> Result<ExecutedLinuxFirew
 }
 
 #[cfg(target_os = "linux")]
-pub fn execute_system_restore_plan() -> Result<ExecutedLinuxFirewallPlan, String> {
-    execute_selected_restore_plan(&StdLinuxCommandRunner)
+pub fn execute_system_restore_plan(
+    restore_state: &LinuxFirewallRestoreState,
+) -> Result<ExecutedLinuxFirewallPlan, String> {
+    execute_restore_plan(&StdLinuxCommandRunner, restore_state)
 }
 
 #[cfg(target_os = "linux")]
@@ -151,6 +190,11 @@ mod tests {
         fn stdout(&self, command: &LinuxCommand) -> Result<String, String> {
             if command.program == "nft" && self.nft_available {
                 Ok("table inet vigil".to_string())
+            } else if command.program == "iptables" {
+                Ok(
+                    "Chain INPUT (policy ACCEPT)\nChain FORWARD (policy DROP)\nChain OUTPUT (policy ACCEPT)\n"
+                        .to_string(),
+                )
             } else {
                 Err("not available".to_string())
             }
@@ -168,6 +212,13 @@ mod tests {
             .iter()
             .all(|command| command.program == "nft"));
         assert_eq!(runner.commands.borrow().len(), executed.commands.len());
+        assert_eq!(
+            executed.restore_state,
+            Some(LinuxFirewallRestoreState {
+                backend: LinuxFirewallBackend::Nftables,
+                iptables_policy_snapshot: None,
+            })
+        );
     }
 
     #[test]
@@ -182,6 +233,28 @@ mod tests {
                 LinuxCommand::new("iptables", ["-P", "FORWARD", "DROP"]),
                 LinuxCommand::new("iptables", ["-P", "OUTPUT", "DROP"]),
             ]
+        );
+        assert_eq!(
+            executed.restore_state,
+            Some(LinuxFirewallRestoreState {
+                backend: LinuxFirewallBackend::Iptables,
+                iptables_policy_snapshot: Some(IptablesPolicySnapshot {
+                    chains: vec![
+                        super::super::linux_firewall_backend::IptablesChainPolicy {
+                            chain: "INPUT".to_string(),
+                            policy: "ACCEPT".to_string(),
+                        },
+                        super::super::linux_firewall_backend::IptablesChainPolicy {
+                            chain: "FORWARD".to_string(),
+                            policy: "DROP".to_string(),
+                        },
+                        super::super::linux_firewall_backend::IptablesChainPolicy {
+                            chain: "OUTPUT".to_string(),
+                            policy: "ACCEPT".to_string(),
+                        },
+                    ],
+                }),
+            })
         );
     }
 
@@ -199,6 +272,7 @@ mod tests {
         assert_eq!(last.args[4], "output");
         assert_eq!(last.args[5], "ip6");
         assert_eq!(last.args[6], "daddr");
+        assert_eq!(executed.restore_state, None);
     }
 
     #[test]
@@ -225,6 +299,7 @@ mod tests {
             .args
             .iter()
             .any(|arg| arg == "--uid-owner"));
+        assert_eq!(iptables.restore_state, None);
     }
 
     #[test]
@@ -236,21 +311,37 @@ mod tests {
     }
 
     #[test]
+    fn restore_uses_backend_captured_during_isolation() {
+        let iptables_runner = RecordingRunner::new(false);
+        let isolated = execute_selected_isolate_plan(&iptables_runner, "isolate").unwrap();
+        let restore_state = isolated.restore_state.as_ref().unwrap();
+
+        let restore_runner = RecordingRunner::new(true);
+        let restored = execute_restore_plan(&restore_runner, restore_state).unwrap();
+        assert_eq!(restored.backend, LinuxFirewallBackend::Iptables);
+        assert_eq!(
+            restored.commands,
+            vec![
+                LinuxCommand::new("iptables", ["-P", "INPUT", "ACCEPT"]),
+                LinuxCommand::new("iptables", ["-P", "FORWARD", "DROP"]),
+                LinuxCommand::new("iptables", ["-P", "OUTPUT", "ACCEPT"]),
+            ]
+        );
+    }
+
+    #[test]
     fn restore_uses_selected_backend() {
         let nft_runner = RecordingRunner::new(true);
-        let nft = execute_selected_restore_plan(&nft_runner).unwrap();
-        assert_eq!(nft.backend, LinuxFirewallBackend::Nftables);
+        let nft_isolated = execute_selected_isolate_plan(&nft_runner, "isolate").unwrap();
+        let nft_restore = execute_restore_plan(&nft_runner, nft_isolated.restore_state.as_ref().unwrap())
+            .unwrap();
+        assert_eq!(nft_restore.backend, LinuxFirewallBackend::Nftables);
         assert_eq!(
-            nft.commands,
+            nft_restore.commands,
             vec![LinuxCommand::new(
                 "nft",
                 ["delete", "table", "inet", "vigil"]
             )]
         );
-
-        let iptables_runner = RecordingRunner::new(false);
-        let iptables = execute_selected_restore_plan(&iptables_runner).unwrap();
-        assert_eq!(iptables.backend, LinuxFirewallBackend::Iptables);
-        assert_eq!(iptables.commands.len(), 3);
     }
 }

--- a/src/security/linux_firewall_executor.rs
+++ b/src/security/linux_firewall_executor.rs
@@ -68,12 +68,24 @@ pub fn execute_selected_setup_plan(
 pub fn execute_selected_isolate_plan(
     runner: &impl LinuxCommandRunner,
     rule_name: &str,
-) -> Result<ExecutedLinuxFirewallPlan, String> {
+) -> Result<ExecutedLinuxFirewallPlan, (String, Option<LinuxFirewallRestoreState>)> {
     let backend = select_firewall_backend(runner);
-    let restore_state = capture_restore_state(runner, backend)?;
+    let restore_state = match capture_restore_state(runner, backend) {
+        Ok(s) => s,
+        Err(e) => return Err((e, None)),
+    };
     let mut commands = firewall_backend_setup_plan(backend);
     commands.extend(firewall_backend_isolate_plan(backend, rule_name));
-    execute_firewall_plan(runner, backend, commands, Some(restore_state))
+    for command in &commands {
+        if let Err(e) = runner.status(command) {
+            return Err((e, Some(restore_state)));
+        }
+    }
+    Ok(ExecutedLinuxFirewallPlan {
+        backend,
+        commands,
+        restore_state: Some(restore_state),
+    })
 }
 
 pub fn execute_restore_plan(
@@ -116,7 +128,7 @@ pub fn execute_selected_uid_block_plan(
 
 #[cfg(target_os = "linux")]
 pub fn execute_system_isolate_plan(rule_name: &str) -> Result<ExecutedLinuxFirewallPlan, String> {
-    execute_selected_isolate_plan(&StdLinuxCommandRunner, rule_name)
+    execute_selected_isolate_plan(&StdLinuxCommandRunner, rule_name).map_err(|(msg, _state)| msg)
 }
 
 #[cfg(target_os = "linux")]
@@ -201,7 +213,7 @@ mod tests {
         let runner = RecordingRunner::new(true);
         let executed = execute_selected_isolate_plan(&runner, "isolate").unwrap();
         assert_eq!(executed.backend, LinuxFirewallBackend::Nftables);
-        assert_eq!(executed.commands.len(), 7);
+        assert_eq!(executed.commands.len(), 13);
         assert!(executed
             .commands
             .iter()
@@ -260,7 +272,7 @@ mod tests {
             execute_selected_remote_block_plan(&runner, "block-v6", "2606:4700:4700::1111")
                 .unwrap();
         assert_eq!(executed.backend, LinuxFirewallBackend::Nftables);
-        assert_eq!(executed.commands.len(), 5);
+        assert_eq!(executed.commands.len(), 11);
 
         let last = executed.commands.last().unwrap();
         assert_eq!(last.program, "nft");
@@ -300,9 +312,10 @@ mod tests {
     #[test]
     fn execution_stops_on_first_command_failure() {
         let runner = RecordingRunner::failing(true, "nft");
-        let err = execute_selected_isolate_plan(&runner, "isolate").unwrap_err();
+        let (err, restore_state) = execute_selected_isolate_plan(&runner, "isolate").unwrap_err();
         assert!(err.contains("nft failed"));
         assert_eq!(runner.commands.borrow().len(), 1);
+        assert!(restore_state.is_some());
     }
 
     #[test]
@@ -335,9 +348,9 @@ mod tests {
         assert_eq!(
             nft_restore.commands,
             vec![
-                LinuxCommand::new("nft", ["flush", "chain", "inet", "vigil", "input"]),
-                LinuxCommand::new("nft", ["flush", "chain", "inet", "vigil", "forward"]),
-                LinuxCommand::new("nft", ["flush", "chain", "inet", "vigil", "output"]),
+                LinuxCommand::new("nft", ["flush", "chain", "inet", "vigil", "isolin"]),
+                LinuxCommand::new("nft", ["flush", "chain", "inet", "vigil", "isolforward"]),
+                LinuxCommand::new("nft", ["flush", "chain", "inet", "vigil", "isolout"]),
             ]
         );
     }

--- a/src/security/linux_firewall_executor.rs
+++ b/src/security/linux_firewall_executor.rs
@@ -1,0 +1,256 @@
+//! Linux firewall backend plan execution helpers.
+//!
+//! This is the narrow runtime bridge between backend-specific command plans and
+//! an injectable command runner. It keeps execution sequencing testable before
+//! the large platform active-response file is migrated to call it directly.
+
+#[cfg(target_os = "linux")]
+use super::linux_command_plan::StdLinuxCommandRunner;
+use super::linux_command_plan::{LinuxCommand, LinuxCommandRunner};
+use super::linux_firewall_backend::{
+    firewall_backend_block_remote_plan, firewall_backend_block_uid_plan,
+    firewall_backend_isolate_plan, firewall_backend_restore_plan, firewall_backend_setup_plan,
+    select_firewall_backend, LinuxFirewallBackend,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutedLinuxFirewallPlan {
+    pub backend: LinuxFirewallBackend,
+    pub commands: Vec<LinuxCommand>,
+}
+
+pub fn execute_firewall_plan(
+    runner: &impl LinuxCommandRunner,
+    backend: LinuxFirewallBackend,
+    commands: Vec<LinuxCommand>,
+) -> Result<ExecutedLinuxFirewallPlan, String> {
+    for command in &commands {
+        runner.status(command)?;
+    }
+    Ok(ExecutedLinuxFirewallPlan { backend, commands })
+}
+
+#[allow(dead_code)]
+pub fn execute_selected_setup_plan(
+    runner: &impl LinuxCommandRunner,
+) -> Result<ExecutedLinuxFirewallPlan, String> {
+    let backend = select_firewall_backend(runner);
+    execute_firewall_plan(runner, backend, firewall_backend_setup_plan(backend))
+}
+
+pub fn execute_selected_isolate_plan(
+    runner: &impl LinuxCommandRunner,
+    rule_name: &str,
+) -> Result<ExecutedLinuxFirewallPlan, String> {
+    let backend = select_firewall_backend(runner);
+    let mut commands = firewall_backend_setup_plan(backend);
+    commands.extend(firewall_backend_isolate_plan(backend, rule_name));
+    execute_firewall_plan(runner, backend, commands)
+}
+
+pub fn execute_selected_restore_plan(
+    runner: &impl LinuxCommandRunner,
+) -> Result<ExecutedLinuxFirewallPlan, String> {
+    let backend = select_firewall_backend(runner);
+    execute_firewall_plan(runner, backend, firewall_backend_restore_plan(backend))
+}
+
+pub fn execute_selected_remote_block_plan(
+    runner: &impl LinuxCommandRunner,
+    rule_name: &str,
+    target: &str,
+) -> Result<ExecutedLinuxFirewallPlan, String> {
+    let backend = select_firewall_backend(runner);
+    let mut commands = firewall_backend_setup_plan(backend);
+    commands.extend(firewall_backend_block_remote_plan(
+        backend, rule_name, target,
+    ));
+    execute_firewall_plan(runner, backend, commands)
+}
+
+pub fn execute_selected_uid_block_plan(
+    runner: &impl LinuxCommandRunner,
+    rule_name: &str,
+    direction: &str,
+    uid: u32,
+) -> Result<ExecutedLinuxFirewallPlan, String> {
+    let backend = select_firewall_backend(runner);
+    let mut commands = firewall_backend_setup_plan(backend);
+    commands.extend(firewall_backend_block_uid_plan(
+        backend, rule_name, direction, uid,
+    ));
+    execute_firewall_plan(runner, backend, commands)
+}
+
+#[cfg(target_os = "linux")]
+pub fn execute_system_isolate_plan(rule_name: &str) -> Result<ExecutedLinuxFirewallPlan, String> {
+    execute_selected_isolate_plan(&StdLinuxCommandRunner, rule_name)
+}
+
+#[cfg(target_os = "linux")]
+pub fn execute_system_restore_plan() -> Result<ExecutedLinuxFirewallPlan, String> {
+    execute_selected_restore_plan(&StdLinuxCommandRunner)
+}
+
+#[cfg(target_os = "linux")]
+pub fn execute_system_remote_block_plan(
+    rule_name: &str,
+    target: &str,
+) -> Result<ExecutedLinuxFirewallPlan, String> {
+    execute_selected_remote_block_plan(&StdLinuxCommandRunner, rule_name, target)
+}
+
+#[cfg(target_os = "linux")]
+pub fn execute_system_uid_block_plan(
+    rule_name: &str,
+    direction: &str,
+    uid: u32,
+) -> Result<ExecutedLinuxFirewallPlan, String> {
+    execute_selected_uid_block_plan(&StdLinuxCommandRunner, rule_name, direction, uid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    struct RecordingRunner {
+        nft_available: bool,
+        fail_program: Option<&'static str>,
+        commands: RefCell<Vec<LinuxCommand>>,
+    }
+
+    impl RecordingRunner {
+        fn new(nft_available: bool) -> Self {
+            Self {
+                nft_available,
+                fail_program: None,
+                commands: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn failing(nft_available: bool, fail_program: &'static str) -> Self {
+            Self {
+                nft_available,
+                fail_program: Some(fail_program),
+                commands: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl LinuxCommandRunner for RecordingRunner {
+        fn status(&self, command: &LinuxCommand) -> Result<(), String> {
+            self.commands.borrow_mut().push(command.clone());
+            if self.fail_program == Some(command.program) {
+                Err(format!("{} failed", command.program))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn stdout(&self, command: &LinuxCommand) -> Result<String, String> {
+            if command.program == "nft" && self.nft_available {
+                Ok("table inet vigil".to_string())
+            } else {
+                Err("not available".to_string())
+            }
+        }
+    }
+
+    #[test]
+    fn selected_isolate_uses_nftables_setup_and_rules_when_available() {
+        let runner = RecordingRunner::new(true);
+        let executed = execute_selected_isolate_plan(&runner, "isolate").unwrap();
+        assert_eq!(executed.backend, LinuxFirewallBackend::Nftables);
+        assert_eq!(executed.commands.len(), 7);
+        assert!(executed
+            .commands
+            .iter()
+            .all(|command| command.program == "nft"));
+        assert_eq!(runner.commands.borrow().len(), executed.commands.len());
+    }
+
+    #[test]
+    fn selected_isolate_falls_back_to_iptables_when_nft_probe_fails() {
+        let runner = RecordingRunner::new(false);
+        let executed = execute_selected_isolate_plan(&runner, "isolate").unwrap();
+        assert_eq!(executed.backend, LinuxFirewallBackend::Iptables);
+        assert_eq!(
+            executed.commands,
+            vec![
+                LinuxCommand::new("iptables", ["-P", "INPUT", "DROP"]),
+                LinuxCommand::new("iptables", ["-P", "FORWARD", "DROP"]),
+                LinuxCommand::new("iptables", ["-P", "OUTPUT", "DROP"]),
+            ]
+        );
+    }
+
+    #[test]
+    fn remote_block_runs_setup_before_block_rule() {
+        let runner = RecordingRunner::new(true);
+        let executed =
+            execute_selected_remote_block_plan(&runner, "block-v6", "2606:4700:4700::1111")
+                .unwrap();
+        assert_eq!(executed.backend, LinuxFirewallBackend::Nftables);
+        assert_eq!(executed.commands.len(), 5);
+
+        let last = executed.commands.last().unwrap();
+        assert_eq!(last.program, "nft");
+        assert_eq!(last.args[4], "output");
+        assert_eq!(last.args[5], "ip6");
+        assert_eq!(last.args[6], "daddr");
+    }
+
+    #[test]
+    fn uid_block_uses_backend_specific_command() {
+        let nft_runner = RecordingRunner::new(true);
+        let nft = execute_selected_uid_block_plan(&nft_runner, "uid", "out", 1000).unwrap();
+        assert_eq!(nft.backend, LinuxFirewallBackend::Nftables);
+        assert!(nft
+            .commands
+            .last()
+            .unwrap()
+            .args
+            .iter()
+            .any(|arg| arg == "skuid"));
+
+        let iptables_runner = RecordingRunner::new(false);
+        let iptables =
+            execute_selected_uid_block_plan(&iptables_runner, "uid", "out", 1000).unwrap();
+        assert_eq!(iptables.backend, LinuxFirewallBackend::Iptables);
+        assert!(iptables
+            .commands
+            .last()
+            .unwrap()
+            .args
+            .iter()
+            .any(|arg| arg == "--uid-owner"));
+    }
+
+    #[test]
+    fn execution_stops_on_first_command_failure() {
+        let runner = RecordingRunner::failing(true, "nft");
+        let err = execute_selected_isolate_plan(&runner, "isolate").unwrap_err();
+        assert!(err.contains("nft failed"));
+        assert_eq!(runner.commands.borrow().len(), 1);
+    }
+
+    #[test]
+    fn restore_uses_selected_backend() {
+        let nft_runner = RecordingRunner::new(true);
+        let nft = execute_selected_restore_plan(&nft_runner).unwrap();
+        assert_eq!(nft.backend, LinuxFirewallBackend::Nftables);
+        assert_eq!(
+            nft.commands,
+            vec![LinuxCommand::new(
+                "nft",
+                ["delete", "table", "inet", "vigil"]
+            )]
+        );
+
+        let iptables_runner = RecordingRunner::new(false);
+        let iptables = execute_selected_restore_plan(&iptables_runner).unwrap();
+        assert_eq!(iptables.backend, LinuxFirewallBackend::Iptables);
+        assert_eq!(iptables.commands.len(), 3);
+    }
+}

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -4,6 +4,10 @@ pub mod file_quarantine;
 pub mod integrity;
 #[cfg(any(target_os = "linux", test))]
 pub mod linux_command_plan;
+#[cfg(any(target_os = "linux", test))]
+pub mod linux_firewall_backend;
+#[cfg(any(target_os = "linux", test))]
+pub mod linux_firewall_executor;
 pub mod operator_provenance;
 pub mod policy;
 pub mod quarantine;


### PR DESCRIPTION
## Summary

- add Linux firewall backend planning and execution helpers
- prefer nftables when available, with iptables fallback
- add test coverage for backend selection, isolation, restore, remote block, and UID block plans

## Validation

- cargo fmt
- cargo test linux_firewall_backend
- cargo test linux_firewall_executor
- cargo check