### PR TITLE
PR 3+4: SQLite-backed advisory cache and software inventory (DB-first reads)

### DIFF
--- a/src/advisory.rs
+++ b/src/advisory.rs
@@ -452,6 +452,13 @@ fn load_cache_summary() -> Result<Option<CacheSummary>, String> {
 }
 
 fn load_cache() -> Result<Option<AdvisoryCache>, String> {
+    // Try SQLite DB first (faster, supports multi-source).
+    if let Ok(db) = crate::storage::db::StorageDb::open() {
+        if let Some(cache) = db.load_advisory_cache()? {
+            return Ok(Some(cache));
+        }
+    }
+    // Fall back to legacy JSON cache.
     let path = cache_path();
     if !path.exists() {
         return Ok(None);

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -118,7 +118,8 @@ impl StorageDb {
                 publisher_hint   TEXT NOT NULL DEFAULT '',
                 version_hint     TEXT NOT NULL DEFAULT '',
                 source           TEXT NOT NULL DEFAULT '',
-                updated_unix     INTEGER NOT NULL DEFAULT 0
+                updated_unix     INTEGER NOT NULL DEFAULT 0,
+                payload_json     TEXT NOT NULL DEFAULT '{}'
             );
 
             CREATE INDEX IF NOT EXISTS idx_inventory_path
@@ -141,6 +142,11 @@ impl StorageDb {
             )
             .map_err(|e| format!("set schema version: {e}"))?;
         }
+
+        // Migration: add payload_json column to software_inventory if missing.
+        let _ = conn.execute_batch(
+            "ALTER TABLE software_inventory ADD COLUMN payload_json TEXT NOT NULL DEFAULT '{}';",
+        );
         Ok(())
     }
 
@@ -343,6 +349,68 @@ impl StorageDb {
             sources,
             records,
         }))
+    }
+
+    // ── Software inventory helpers ──────────────────────────────────────
+
+    pub fn replace_software_inventory(
+        &self,
+        entries: &[crate::software_inventory::InstalledSoftware],
+    ) -> Result<(), String> {
+        let conn = self.conn()?;
+        conn.execute("DELETE FROM software_inventory", [])
+            .map_err(|e| format!("clear inventory: {e}"))?;
+        let mut stmt = conn
+            .prepare(
+                "INSERT INTO software_inventory
+                 (product_key, display_name, executable_path, publisher_hint,
+                  version_hint, source, updated_unix, payload_json)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            )
+            .map_err(|e| format!("prepare inventory insert: {e}"))?;
+        for entry in entries {
+            let payload = serde_json::to_string(entry).unwrap_or_default();
+            stmt.execute(rusqlite::params![
+                entry.product_key,
+                entry.display_name,
+                entry.executable_path,
+                entry.publisher_hint.as_deref().unwrap_or(""),
+                entry.version_hint.as_deref().unwrap_or(""),
+                format!("{:?}", entry.source),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+                payload,
+            ])
+            .map_err(|e| format!("insert inventory {}: {e}", entry.product_key))?;
+        }
+        Ok(())
+    }
+
+    pub fn load_software_inventory(
+        &self,
+    ) -> Result<Vec<crate::software_inventory::InstalledSoftware>, String> {
+        let conn = self.conn()?;
+        let mut stmt = conn
+            .prepare("SELECT payload_json FROM software_inventory ORDER BY product_key")
+            .map_err(|e| format!("prepare inventory select: {e}"))?;
+        let rows = stmt
+            .query_map([], |row| {
+                let payload: String = row.get(0)?;
+                Ok(payload)
+            })
+            .map_err(|e| format!("query inventory: {e}"))?;
+        let mut result = Vec::new();
+        for row in rows {
+            let payload = row.map_err(|e| format!("read inventory row: {e}"))?;
+            if let Ok(entry) =
+                serde_json::from_str::<crate::software_inventory::InstalledSoftware>(&payload)
+            {
+                result.push(entry);
+            }
+        }
+        Ok(result)
     }
 
     pub fn verify(&self) -> Result<bool, String> {

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -305,6 +305,46 @@ impl StorageDb {
         Ok(count as usize)
     }
 
+    pub fn load_advisory_cache(&self) -> Result<Option<crate::advisory::AdvisoryCache>, String> {
+        let sources = self.load_advisory_sources()?;
+        if sources.is_empty() {
+            return Ok(None);
+        }
+        let conn = self.conn()?;
+        let mut records = Vec::new();
+        for src in &sources {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT payload_json FROM advisory_record
+                     WHERE source_key = ?1 AND source_kind = ?2",
+                )
+                .map_err(|e| format!("prepare record select: {e}"))?;
+            let rows = stmt
+                .query_map(rusqlite::params![src.source_key, src.source_kind], |row| {
+                    let payload: String = row.get(0)?;
+                    Ok(payload)
+                })
+                .map_err(|e| format!("query records for {}: {e}", src.source_key))?;
+            for row in rows {
+                let payload = row.map_err(|e| format!("read record: {e}"))?;
+                if let Ok(rec) =
+                    serde_json::from_str::<crate::advisory::VulnerabilityRecord>(&payload)
+                {
+                    records.push(rec);
+                }
+            }
+        }
+        Ok(Some(crate::advisory::AdvisoryCache {
+            schema_version: 1,
+            generated_unix: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+            sources,
+            records,
+        }))
+    }
+
     pub fn verify(&self) -> Result<bool, String> {
         let stored: Option<StorageManifest> =
             crate::security::policy::load_struct_with_integrity(&self.manifest_path)

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -50,10 +50,25 @@ impl InventoryStore for ProtectedJsonInventoryStore {
                 "failed to persist protected software inventory {}: {e}",
                 self.path().display()
             )
-        })
+        })?;
+        // Mirror to SQLite DB (best-effort, non-fatal on failure).
+        if let Ok(db) = crate::storage::db::StorageDb::open() {
+            let _ = db.replace_software_inventory(entries);
+            let _ = db.checkpoint();
+        }
+        Ok(())
     }
 
     fn load_inventory(&self) -> Result<Vec<InstalledSoftware>, String> {
+        // Try SQLite DB first.
+        if let Ok(db) = crate::storage::db::StorageDb::open() {
+            if let Ok(entries) = db.load_software_inventory() {
+                if !entries.is_empty() {
+                    return Ok(entries);
+                }
+            }
+        }
+        // Fall back to legacy JSON cache.
         let loaded: Option<SoftwareInventoryState> =
             crate::security::policy::load_struct_with_integrity(self.path()).map_err(|e| {
                 format!(


### PR DESCRIPTION
## Summary

Migrate application data storage from HMAC-protected JSON files to a single SQLite database with integrity manifests, covering advisory caches and software inventory. Reads try the DB first with automatic JSON fallback.

## Changes

### Advisory cache (PR 3)
- **load_cache()** now tries SQLite DB first, falls back to JSON
- **save_cache()** mirrors writes to DB (already in PR 2)

### Software inventory (PR 4)
- **eplace_inventory()** mirrors writes to DB via StorageDb::replace_software_inventory()
- **load_inventory()** reads from DB first, falls back to JSON
- Full InstalledSoftware struct serialized as payload_json
- ALTER TABLE migration adds payload_json to existing DBs

## Schema
- dvisory_record now uses composite PRIMARY KEY (primary_id, source_key) so multi-source CVEs coexist
- software_inventory includes payload_json for full struct fidelity

## Integrity
- compute_digest hashes schema SQL (sqlite_master.sql) + all row values (all column types) + PRAGMA table_info columns
- Manifest verified on startup via existing HMAC policy layer

## Validation
- cargo test: 285 tests pass
- cargo build: clean
- cargo fmt --check: clean