### PR TITLE
Remove legacy JSON paths + migrate change history — full DB-backed storage

### DIFF
--- a/src/advisory.rs
+++ b/src/advisory.rs
@@ -22,8 +22,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
-const CACHE_FILE: &str = "vigil-advisory-cache.json";
-const CACHE_SCHEMA_VERSION: u32 = 1;
+const DB_SCHEMA_VERSION: u32 = 1;
 const DEFAULT_SOURCE_TTL_SECS: u64 = 24 * 60 * 60;
 const NVD_SOURCE_KEY: &str = "nvd-cve";
 const NVD_SOURCE_KIND: &str = "nvd";
@@ -452,35 +451,8 @@ fn load_cache_summary() -> Result<Option<CacheSummary>, String> {
 }
 
 fn load_cache() -> Result<Option<AdvisoryCache>, String> {
-    // Try SQLite DB first (faster, supports multi-source).
-    if let Ok(db) = crate::storage::db::StorageDb::open() {
-        if let Some(cache) = db.load_advisory_cache()? {
-            return Ok(Some(cache));
-        }
-    }
-    // Fall back to legacy JSON cache.
-    let path = cache_path();
-    if !path.exists() {
-        return Ok(None);
-    }
-    let loaded: Option<AdvisoryCache> = crate::security::policy::load_struct_with_integrity(&path)
-        .map_err(|e| {
-            format!(
-                "failed to load protected advisory cache {}: {e}",
-                path.display()
-            )
-        })?;
-    let Some(cache) = loaded else {
-        return Ok(None);
-    };
-    if cache.schema_version != CACHE_SCHEMA_VERSION {
-        return Err(format!(
-            "protected advisory cache {} used unsupported schema version {}",
-            path.display(),
-            cache.schema_version
-        ));
-    }
-    Ok(Some(cache))
+    let db = crate::storage::db::StorageDb::open()?;
+    db.load_advisory_cache()
 }
 
 fn load_cache_for_import() -> Result<Option<AdvisoryCache>, String> {
@@ -495,38 +467,21 @@ fn load_cache_for_import() -> Result<Option<AdvisoryCache>, String> {
 }
 
 fn save_cache(cache: &AdvisoryCache) -> Result<(), String> {
-    let path = cache_path();
-    crate::security::policy::save_struct_with_integrity(&path, cache).map_err(|e| {
-        format!(
-            "failed to save protected advisory cache {}: {e}",
-            path.display()
-        )
-    })?;
-    // Mirror to SQLite DB (best-effort, non-fatal on failure).
-    if let Ok(db) = crate::storage::db::StorageDb::open() {
-        let _ = db.replace_advisory_sources(&cache.sources);
-        for source in &cache.sources {
-            let source_records: Vec<_> = cache
-                .records
-                .iter()
-                .filter(|r| r.provenance.source_key == source.source_key)
-                .cloned()
-                .collect();
-            if !source_records.is_empty() {
-                let _ = db.replace_advisory_records(
-                    &source_records,
-                    &source.source_key,
-                    &source.source_kind,
-                );
-            }
+    let db = crate::storage::db::StorageDb::open()?;
+    db.replace_advisory_sources(&cache.sources)?;
+    for source in &cache.sources {
+        let source_records: Vec<_> = cache
+            .records
+            .iter()
+            .filter(|r| r.provenance.source_key == source.source_key)
+            .cloned()
+            .collect();
+        if !source_records.is_empty() {
+            db.replace_advisory_records(&source_records, &source.source_key, &source.source_kind)?;
         }
-        let _ = db.checkpoint();
     }
+    db.checkpoint()?;
     Ok(())
-}
-
-fn cache_path() -> PathBuf {
-    crate::config::data_dir().join(CACHE_FILE)
 }
 
 fn load_nvd_snapshot_batch(paths: &[PathBuf]) -> Result<AdvisoryCache, String> {
@@ -606,7 +561,7 @@ fn sync_nvd_with_fetcher(
 
 fn empty_cache(now: u64) -> AdvisoryCache {
     AdvisoryCache {
-        schema_version: CACHE_SCHEMA_VERSION,
+        schema_version: DB_SCHEMA_VERSION,
         generated_unix: now,
         sources: vec![],
         records: vec![],
@@ -803,7 +758,7 @@ fn parse_nvd_snapshot(bytes: &[u8], imported_from: Option<&Path>) -> Result<Advi
         .collect::<Vec<_>>();
 
     Ok(AdvisoryCache {
-        schema_version: CACHE_SCHEMA_VERSION,
+        schema_version: DB_SCHEMA_VERSION,
         generated_unix: fetched_unix,
         sources: vec![source],
         records,
@@ -812,7 +767,7 @@ fn parse_nvd_snapshot(bytes: &[u8], imported_from: Option<&Path>) -> Result<Advi
 
 fn merge_cache(existing: Option<AdvisoryCache>, incoming: AdvisoryCache) -> AdvisoryCache {
     let mut merged = existing.unwrap_or_else(|| AdvisoryCache {
-        schema_version: CACHE_SCHEMA_VERSION,
+        schema_version: DB_SCHEMA_VERSION,
         generated_unix: incoming.generated_unix,
         sources: vec![],
         records: vec![],
@@ -834,7 +789,7 @@ fn merge_cache(existing: Option<AdvisoryCache>, incoming: AdvisoryCache) -> Advi
         merge_record_indexed(&mut merged.records, &mut record_index, record);
     }
     merged.generated_unix = unix_now();
-    merged.schema_version = CACHE_SCHEMA_VERSION;
+    merged.schema_version = DB_SCHEMA_VERSION;
     merged
 }
 
@@ -1333,7 +1288,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(cache.schema_version, CACHE_SCHEMA_VERSION);
+        assert_eq!(cache.schema_version, DB_SCHEMA_VERSION);
         assert_eq!(cache.records.len(), 1);
         assert_eq!(cache.sources[0].source_key, "nvd-cve");
         assert_eq!(cache.sources[0].total_results, 1);
@@ -1395,46 +1350,14 @@ mod tests {
         assert_eq!(deduped[1].match_criteria_id, secondary.match_criteria_id);
     }
 
-    #[test]
-    fn protected_cache_round_trip_preserves_records() {
-        let dir = temp_dir();
-        let path = dir.join(CACHE_FILE);
-        let cache = AdvisoryCache {
-            schema_version: CACHE_SCHEMA_VERSION,
-            generated_unix: 42,
-            sources: vec![AdvisorySourceCache {
-                source_key: "nvd-cve".into(),
-                source_kind: "nvd".into(),
-                source_url: "https://services.nvd.nist.gov/rest/json/cves/2.0".into(),
-                imported_from: Some("/tmp/nvd.json".into()),
-                imported_from_batch: vec!["/tmp/nvd.json".into()],
-                fetched_unix: 42,
-                expires_unix: 84,
-                snapshot_sha256: "abc".into(),
-                total_results: 1,
-                status: SourceHealth::Fresh,
-                last_attempt_unix: 0,
-                last_error: None,
-            }],
-            records: vec![VulnerabilityRecord {
-                primary_id: "CVE-2026-9999".into(),
-                summary: "Test record".into(),
-                ..VulnerabilityRecord::default()
-            }],
-        };
-
-        crate::security::policy::save_struct_with_integrity(&path, &cache).unwrap();
-        let loaded: AdvisoryCache = crate::security::policy::load_struct_with_integrity(&path)
-            .unwrap()
-            .unwrap();
-        assert_eq!(loaded.records.len(), 1);
-        assert_eq!(loaded.records[0].primary_id, "CVE-2026-9999");
-    }
+    // The old protected_cache_round_trip_preserves_records test used the
+    // legacy JSON path which has been removed. DB round-trip is covered
+    // by storage::db::tests::checkpoint_and_verify_round_trip.
 
     #[test]
     fn merge_cache_keeps_other_sources_and_updates_matching_nvd_records() {
         let existing = AdvisoryCache {
-            schema_version: CACHE_SCHEMA_VERSION,
+            schema_version: DB_SCHEMA_VERSION,
             generated_unix: 100,
             sources: vec![
                 AdvisorySourceCache {
@@ -1493,7 +1416,7 @@ mod tests {
             ],
         };
         let imported = AdvisoryCache {
-            schema_version: CACHE_SCHEMA_VERSION,
+            schema_version: DB_SCHEMA_VERSION,
             generated_unix: 110,
             sources: vec![AdvisorySourceCache {
                 source_key: "nvd-cve".into(),
@@ -1599,13 +1522,13 @@ mod tests {
 
         let merged = merge_cache(
             Some(AdvisoryCache {
-                schema_version: CACHE_SCHEMA_VERSION,
+                schema_version: DB_SCHEMA_VERSION,
                 generated_unix: 120,
                 sources: vec![],
                 records: vec![existing_record],
             }),
             AdvisoryCache {
-                schema_version: CACHE_SCHEMA_VERSION,
+                schema_version: DB_SCHEMA_VERSION,
                 generated_unix: 110,
                 sources: vec![],
                 records: vec![imported_record],
@@ -1716,7 +1639,7 @@ mod tests {
     #[test]
     fn nvd_sync_windows_split_long_offline_gaps() {
         let existing = AdvisoryCache {
-            schema_version: CACHE_SCHEMA_VERSION,
+            schema_version: DB_SCHEMA_VERSION,
             generated_unix: 0,
             sources: vec![],
             records: vec![VulnerabilityRecord {

--- a/src/advisory_match_status.rs
+++ b/src/advisory_match_status.rs
@@ -4,7 +4,7 @@ use crate::advisory_match::{
     MatchBasis, MatchConfidence, VersionMatchStatus,
 };
 use crate::software_inventory::{InstalledSoftware, InventorySource};
-use crate::storage::{InventoryStore, ProtectedJsonInventoryStore};
+use crate::storage::{DbInventoryStore, InventoryStore};
 use crate::version_compare::VersionSource;
 use std::path::PathBuf;
 
@@ -36,7 +36,7 @@ struct RecordAdvisoryMatch {
 }
 
 pub fn run_cli() -> Result<(), String> {
-    let inventory = ProtectedJsonInventoryStore::new_default().load_inventory()?;
+    let inventory = DbInventoryStore::new().load_inventory()?;
     if inventory.is_empty() {
         println!(
             "Advisory match status: unavailable (no protected software inventory snapshot found)."

--- a/src/advisory_runtime_score.rs
+++ b/src/advisory_runtime_score.rs
@@ -10,7 +10,7 @@ use crate::software_inventory::{
     correlate_runtime_inventory, InstalledSoftware, InventorySource, RuntimeCorrelationConfidence,
     RuntimeInventoryTarget,
 };
-use crate::storage::{InventoryStore, ProtectedJsonInventoryStore};
+use crate::storage::{DbInventoryStore, InventoryStore};
 use crate::version_compare::VersionSource;
 use std::sync::{OnceLock, RwLock};
 use std::time::{Duration, Instant};
@@ -100,7 +100,7 @@ pub fn advisory_score_for_runtime_target(
 fn load_advisory_score_for_runtime_target(
     target: &RuntimeInventoryTarget<'_>,
 ) -> AdvisoryScoreOutcome {
-    let inventory = match ProtectedJsonInventoryStore::new_default().load_inventory() {
+    let inventory = match DbInventoryStore::new().load_inventory() {
         Ok(inventory) => inventory,
         Err(_) => return AdvisoryScoreOutcome::default(),
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,7 +185,7 @@ fn spawn_bootstrap(
                         software_count,
                         "startup-safe software inventory snapshot collected"
                     );
-                    let inventory_store = storage::ProtectedJsonInventoryStore::new_default();
+                    let inventory_store = storage::DbInventoryStore::new();
                     if let Err(err) =
                         storage::InventoryStore::replace_inventory(&inventory_store, &inventory)
                     {

--- a/src/security/linux_firewall_executor.rs
+++ b/src/security/linux_firewall_executor.rs
@@ -10,7 +10,7 @@ use super::linux_command_plan::{
     iptables_delete_rule, nft_delete_rule_by_handle, nft_flush_chain, nft_list_chain_handles,
     nft_list_ruleset, nft_parse_handle_by_comment, LinuxCommand, LinuxCommandRunner,
     NFT_FORWARD_CHAIN, NFT_INPUT_CHAIN, NFT_ISOL_FORWARD_CHAIN, NFT_ISOL_IN_CHAIN,
-    NFT_ISOL_OUT_CHAIN, NFT_OUTPUT_CHAIN, NFT_TABLE,
+    NFT_ISOL_OUT_CHAIN, NFT_OUTPUT_CHAIN,
 };
 use super::linux_firewall_backend::{
     capture_iptables_policy_snapshot, firewall_backend_block_remote_plan,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,119 +1,41 @@
 pub mod db;
 
 use crate::software_inventory::InstalledSoftware;
-use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
-
-const SOFTWARE_INVENTORY_FILE: &str = "vigil-software-inventory.json";
-const SOFTWARE_INVENTORY_SCHEMA_VERSION: u32 = 1;
-
 pub trait InventoryStore {
     fn replace_inventory(&self, entries: &[InstalledSoftware]) -> Result<(), String>;
-    #[cfg_attr(not(test), allow(dead_code))]
     fn load_inventory(&self) -> Result<Vec<InstalledSoftware>, String>;
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct SoftwareInventoryState {
-    schema_version: u32,
-    generated_unix: u64,
-    entries: Vec<InstalledSoftware>,
-}
+pub struct DbInventoryStore;
 
-pub struct ProtectedJsonInventoryStore {
-    path: PathBuf,
-}
-
-impl ProtectedJsonInventoryStore {
-    pub fn new_default() -> Self {
-        Self::from_path(crate::config::data_dir().join(SOFTWARE_INVENTORY_FILE))
-    }
-
-    pub fn from_path(path: impl Into<PathBuf>) -> Self {
-        Self { path: path.into() }
-    }
-
-    pub fn path(&self) -> &Path {
-        &self.path
+impl DbInventoryStore {
+    pub fn new() -> Self {
+        Self
     }
 }
 
-impl InventoryStore for ProtectedJsonInventoryStore {
+impl InventoryStore for DbInventoryStore {
     fn replace_inventory(&self, entries: &[InstalledSoftware]) -> Result<(), String> {
-        let state = SoftwareInventoryState {
-            schema_version: SOFTWARE_INVENTORY_SCHEMA_VERSION,
-            generated_unix: chrono::Utc::now().timestamp().max(0) as u64,
-            entries: entries.to_vec(),
-        };
-        crate::security::policy::save_struct_with_integrity(self.path(), &state).map_err(|e| {
-            format!(
-                "failed to persist protected software inventory {}: {e}",
-                self.path().display()
-            )
-        })?;
-        // Mirror to SQLite DB (best-effort, non-fatal on failure).
-        if let Ok(db) = crate::storage::db::StorageDb::open() {
-            let _ = db.replace_software_inventory(entries);
-            let _ = db.checkpoint();
-        }
+        let db = crate::storage::db::StorageDb::open()?;
+        db.replace_software_inventory(entries)?;
+        db.checkpoint()?;
         Ok(())
     }
 
     fn load_inventory(&self) -> Result<Vec<InstalledSoftware>, String> {
-        // Try SQLite DB first.
-        if let Ok(db) = crate::storage::db::StorageDb::open() {
-            if let Ok(entries) = db.load_software_inventory() {
-                if !entries.is_empty() {
-                    return Ok(entries);
-                }
-            }
-        }
-        // Fall back to legacy JSON cache.
-        let loaded: Option<SoftwareInventoryState> =
-            crate::security::policy::load_struct_with_integrity(self.path()).map_err(|e| {
-                format!(
-                    "failed to load protected software inventory {}: {e}",
-                    self.path().display()
-                )
-            })?;
-        let Some(state) = loaded else {
-            return Ok(Vec::new());
-        };
-        if state.schema_version != SOFTWARE_INVENTORY_SCHEMA_VERSION {
-            return Err(format!(
-                "unsupported software inventory schema {} in {}",
-                state.schema_version,
-                self.path().display()
-            ));
-        }
-        Ok(state.entries)
+        let db = crate::storage::db::StorageDb::open()?;
+        db.load_software_inventory()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn test_inventory_store() -> (ProtectedJsonInventoryStore, PathBuf) {
-        let unique = format!(
-            "vigil-storage-test-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos()
-        );
-        let dir = std::env::temp_dir().join(unique);
-        std::fs::create_dir_all(&dir).unwrap();
-        (
-            ProtectedJsonInventoryStore::from_path(dir.join(SOFTWARE_INVENTORY_FILE)),
-            dir,
-        )
-    }
+    use crate::software_inventory::{InstalledSoftware, InventorySource};
 
     #[test]
     fn protected_store_round_trip() {
-        let (store, dir) = test_inventory_store();
+        let store = DbInventoryStore::new();
         let rows = vec![InstalledSoftware {
             product_key: "curl".into(),
             display_name: "curl".into(),
@@ -122,7 +44,7 @@ mod tests {
             version_hint: Some("8.8.0".into()),
             product_aliases: vec!["curl".into()],
             vendor_key: Some("curl-project".into()),
-            source: crate::software_inventory::InventorySource::RunningProcess,
+            source: InventorySource::RunningProcess,
         }];
         store.replace_inventory(&rows).unwrap();
         let loaded = store.load_inventory().unwrap();
@@ -131,6 +53,5 @@ mod tests {
         assert_eq!(loaded[0].version_hint.as_deref(), Some("8.8.0"));
         assert_eq!(loaded[0].product_aliases, vec!["curl".to_string()]);
         assert_eq!(loaded[0].vendor_key.as_deref(), Some("curl-project"));
-        std::fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/src/ui/inspector.rs
+++ b/src/ui/inspector.rs
@@ -17,7 +17,7 @@ use crate::{
         RuntimeCorrelationConfidence, RuntimeCorrelationReason, RuntimeInventoryMatch,
         RuntimeInventoryTarget,
     },
-    storage::{InventoryStore, ProtectedJsonInventoryStore},
+    storage::{DbInventoryStore, InventoryStore},
     ui::{has_known_location, is_ghost_process_name, theme, ProcessSelection},
     version_compare::VersionSource,
 };
@@ -701,7 +701,7 @@ fn advisory_lookup_key(sel: &ProcessSelection) -> AdvisoryLookupKey {
 }
 
 fn load_advisory_snapshot_for_selection(sel: &ProcessSelection) -> AdvisoryInspectorSnapshot {
-    let inventory = match ProtectedJsonInventoryStore::new_default().load_inventory() {
+    let inventory = match DbInventoryStore::new().load_inventory() {
         Ok(inventory) => inventory,
         Err(_) => {
             return AdvisoryInspectorSnapshot {


### PR DESCRIPTION
## Summary

Remove all legacy HMAC-protected JSON cache code paths and migrate change history to the SQLite database. Full DB-backed storage for advisory caches, change history, and software inventory with incremental UPSERTs and WAL maintenance.

## Changes

### Advisory cache + software inventory (from PR #286)
- save_cache() / load_cache() — DB-only, JSON removed
- ProtectedJsonInventoryStore → DbInventoryStore — all callers updated

### Change history (new)
- save_cache() / load_cache() — DB-only, JSON removed
- un_status_cli() — reads from DB instead of JSON
- Removed CACHE_FILE, cache_path(), CACHE_SCHEMA_VERSION

### Performance
- eplace_advisory_records() uses INSERT ... ON CONFLICT DO UPDATE (UPSERT) instead of delete-then-insert for incremental sync
- checkpoint() runs PRAGMA wal_checkpoint(TRUNCATE) before computing digest to keep WAL bounded
- wal_checkpoint() exposed as public method

## Validation
- cargo test: 284 tests pass
- cargo build: clean
- cargo fmt --check: clean