### PR TITLE
Mitigation-aware rules + NVD retry scheduling + IOC wiring

### DIFF
--- a/src/advisory.rs
+++ b/src/advisory.rs
@@ -60,6 +60,8 @@ pub struct AdvisorySourceCache {
     pub last_attempt_unix: u64,
     #[serde(default)]
     pub last_error: Option<String>,
+    #[serde(default)]
+    pub retry_after_unix: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -609,6 +611,7 @@ fn nvd_refresh_due() -> bool {
             })
             .is_none_or(|source| {
                 source.expires_unix <= now
+                    || (source.retry_after_unix > 0 && source.retry_after_unix <= now)
                     || matches!(source.status, SourceHealth::Error | SourceHealth::Stale)
             }),
         Ok(None) => true,
@@ -690,6 +693,7 @@ fn stamp_nvd_sync_success(cache: &mut AdvisoryCache, requested_pages: usize, now
         source.expires_unix = now.saturating_add(DEFAULT_SOURCE_TTL_SECS);
         source.status = SourceHealth::Fresh;
         source.last_error = None;
+        source.retry_after_unix = 0;
         if requested_pages > 1 {
             source.imported_from = None;
         }
@@ -707,6 +711,7 @@ fn stamp_nvd_sync_success(cache: &mut AdvisoryCache, requested_pages: usize, now
             status: SourceHealth::Fresh,
             last_attempt_unix: now,
             last_error: None,
+            retry_after_unix: 0,
         });
     }
 }
@@ -724,6 +729,15 @@ fn stamp_nvd_sync_failure(mut cache: AdvisoryCache, err: &str, now: u64) -> Advi
             SourceHealth::Error
         };
         source.last_error = Some(err.to_string());
+        let prev_delay = source
+            .retry_after_unix
+            .saturating_sub(source.last_attempt_unix);
+        let next_delay = if prev_delay == 0 || prev_delay > 86400 {
+            300
+        } else {
+            (prev_delay * 2).min(86400)
+        };
+        source.retry_after_unix = now.saturating_add(next_delay);
     } else {
         cache.sources.push(AdvisorySourceCache {
             source_key: NVD_SOURCE_KEY.into(),
@@ -738,6 +752,7 @@ fn stamp_nvd_sync_failure(mut cache: AdvisoryCache, err: &str, now: u64) -> Advi
             status: SourceHealth::Stale,
             last_attempt_unix: now,
             last_error: Some(err.to_string()),
+            retry_after_unix: 0,
         });
     }
     cache
@@ -772,6 +787,7 @@ fn parse_nvd_snapshot(bytes: &[u8], imported_from: Option<&Path>) -> Result<Advi
         status: SourceHealth::Fresh,
         last_attempt_unix: 0,
         last_error: None,
+        retry_after_unix: 0,
     };
 
     let imported_unix = fetched_unix;
@@ -1466,6 +1482,7 @@ mod tests {
                     status: SourceHealth::Fresh,
                     last_attempt_unix: 0,
                     last_error: None,
+                    retry_after_unix: 0,
                 },
                 AdvisorySourceCache {
                     source_key: "euvd".into(),
@@ -1480,6 +1497,7 @@ mod tests {
                     status: SourceHealth::Fresh,
                     last_attempt_unix: 0,
                     last_error: None,
+                    retry_after_unix: 0,
                 },
             ],
             records: vec![
@@ -1524,6 +1542,7 @@ mod tests {
                 status: SourceHealth::Fresh,
                 last_attempt_unix: 0,
                 last_error: None,
+                retry_after_unix: 0,
             }],
             records: vec![
                 VulnerabilityRecord {

--- a/src/advisory.rs
+++ b/src/advisory.rs
@@ -610,9 +610,13 @@ fn nvd_refresh_due() -> bool {
                 source.source_kind == NVD_SOURCE_KIND && source.source_key == NVD_SOURCE_KEY
             })
             .is_none_or(|source| {
+                let retry_due = source.retry_after_unix > 0 && source.retry_after_unix <= now;
+                let stale_or_error =
+                    matches!(source.status, SourceHealth::Error | SourceHealth::Stale);
                 source.expires_unix <= now
-                    || (source.retry_after_unix > 0 && source.retry_after_unix <= now)
-                    || matches!(source.status, SourceHealth::Error | SourceHealth::Stale)
+                    || retry_due
+                    || (stale_or_error
+                        && (source.retry_after_unix == 0 || source.retry_after_unix <= now))
             }),
         Ok(None) => true,
         Err(err) => {

--- a/src/advisory.rs
+++ b/src/advisory.rs
@@ -83,6 +83,9 @@ pub struct VulnerabilityRecord {
     pub affected_products: Vec<AffectedProduct>,
     pub references: Vec<VulnerabilityReference>,
     pub mitigations: Vec<String>,
+    pub fix_version: Option<String>,
+    pub workaround_instructions: Vec<String>,
+    pub upgrade_instructions: Vec<String>,
     pub provenance: VulnerabilityProvenance,
 }
 
@@ -491,7 +494,18 @@ fn save_cache(cache: &AdvisoryCache) -> Result<(), String> {
     match result {
         Ok(()) => {
             db.commit()?;
-            db.checkpoint().map(|_| ())
+            db.checkpoint()?;
+            // Extract IOCs from advisory records and feed into blocklist engine.
+            let iocs = crate::advisory_ioc::extract_iocs(&cache.records);
+            if !iocs.is_empty() {
+                crate::blocklist::add_advisory_iocs(
+                    "advisory",
+                    iocs.ips,
+                    iocs.domains,
+                    iocs.hashes,
+                );
+            }
+            Ok(())
         }
         Err(err) => {
             let _ = db.rollback();
@@ -959,6 +973,9 @@ fn parse_nvd_record(
         affected_products,
         references,
         mitigations,
+        fix_version: parse_fix_version(cve),
+        workaround_instructions: parse_workaround_instructions(cve),
+        upgrade_instructions: parse_upgrade_instructions(cve),
         provenance: VulnerabilityProvenance {
             source_kind: NVD_SOURCE_KIND.into(),
             source_key: NVD_SOURCE_KEY.into(),
@@ -1020,6 +1037,66 @@ fn parse_mitigations(cve: &Value) -> Vec<String> {
         }
     }
     mitigations
+}
+
+fn parse_fix_version(cve: &Value) -> Option<String> {
+    cve.get("references")
+        .and_then(Value::as_array)?
+        .iter()
+        .filter_map(|r| {
+            let url = r.get("url").and_then(Value::as_str)?;
+            let tags = r.get("tags")?.as_array()?;
+            let has_fix_tag = tags.iter().filter_map(Value::as_str).any(|tag| {
+                tag.eq_ignore_ascii_case("patch")
+                    || tag.eq_ignore_ascii_case("fix")
+                    || tag.eq_ignore_ascii_case("vendor fix")
+            });
+            if has_fix_tag {
+                Some(url.to_string())
+            } else {
+                None
+            }
+        })
+        .next()
+}
+
+fn parse_workaround_instructions(cve: &Value) -> Vec<String> {
+    extract_instructional_urls(cve, |tag| {
+        tag.eq_ignore_ascii_case("workaround") || tag.eq_ignore_ascii_case("mitigation")
+    })
+}
+
+fn parse_upgrade_instructions(cve: &Value) -> Vec<String> {
+    extract_instructional_urls(cve, |tag| {
+        tag.eq_ignore_ascii_case("upgrade")
+            || tag.eq_ignore_ascii_case("update")
+            || tag.eq_ignore_ascii_case("vendor upgrade")
+    })
+}
+
+fn extract_instructional_urls<F>(cve: &Value, matcher: F) -> Vec<String>
+where
+    F: Fn(&str) -> bool,
+{
+    let mut result = Vec::new();
+    if let Some(references) = cve.get("references").and_then(Value::as_array) {
+        for reference in references {
+            let Some(url) = reference.get("url").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(tags) = reference.get("tags").and_then(Value::as_array) else {
+                continue;
+            };
+            if tags
+                .iter()
+                .filter_map(Value::as_str)
+                .any(|tag| matcher(tag))
+            {
+                push_unique(&mut result, url.to_string());
+            }
+        }
+    }
+    result
 }
 
 fn parse_references(cve: &Value) -> Vec<VulnerabilityReference> {

--- a/src/advisory_history.rs
+++ b/src/advisory_history.rs
@@ -706,6 +706,7 @@ fn parse_snapshot(
         status: SourceHealth::Fresh,
         last_attempt_unix: 0,
         last_error: None,
+        retry_after_unix: 0,
     };
 
     let changes = payload
@@ -813,6 +814,7 @@ fn stamp_sync_success(cache: &mut ChangeHistoryCache, requested_pages: usize, no
             status: SourceHealth::Fresh,
             last_attempt_unix: now,
             last_error: None,
+            retry_after_unix: 0,
         }),
     }
     if requested_pages > 0 {
@@ -844,6 +846,7 @@ fn stamp_sync_failure(mut cache: ChangeHistoryCache, error: &str, now: u64) -> C
             status: SourceHealth::Error,
             last_attempt_unix: now,
             last_error: Some(error.to_string()),
+            retry_after_unix: 0,
         }),
     }
     cache
@@ -1163,6 +1166,7 @@ mod tests {
                 status: SourceHealth::Fresh,
                 last_attempt_unix: 0,
                 last_error: None,
+                retry_after_unix: 0,
             }],
             changes: vec![CveChangeEvent {
                 cve_id: "CVE-2026-9999".into(),
@@ -1344,6 +1348,7 @@ mod tests {
             status: SourceHealth::Error,
             last_attempt_unix: 10,
             last_error: Some("boom".into()),
+            retry_after_unix: 0,
         }];
 
         merge_source(
@@ -1361,6 +1366,7 @@ mod tests {
                 status: SourceHealth::Fresh,
                 last_attempt_unix: 30,
                 last_error: None,
+                retry_after_unix: 0,
             },
         );
 
@@ -1458,6 +1464,7 @@ mod tests {
                 status: SourceHealth::Error,
                 last_attempt_unix: 33,
                 last_error: Some("old error".into()),
+                retry_after_unix: 0,
             }],
             changes: vec![CveChangeEvent {
                 cve_id: "CVE-2026-12345".into(),

--- a/src/advisory_ncsc_bsi.rs
+++ b/src/advisory_ncsc_bsi.rs
@@ -350,6 +350,9 @@ fn parse_json_record(
         affected_products: products_from_value(value),
         references: references_from_value(value, source_kind.source_name(), &source_url),
         mitigations,
+        fix_version: None,
+        workaround_instructions: vec![],
+        upgrade_instructions: vec![],
         provenance: VulnerabilityProvenance {
             source_kind: source_kind.source_kind().into(),
             source_key: source_kind.source_key().into(),
@@ -417,6 +420,9 @@ fn parse_rss_item(
         affected_products: Vec::new(),
         references,
         mitigations: Vec::new(),
+        fix_version: None,
+        workaround_instructions: vec![],
+        upgrade_instructions: vec![],
         provenance: VulnerabilityProvenance {
             source_kind: source_kind.source_kind().into(),
             source_key: source_kind.source_key().into(),

--- a/src/advisory_ncsc_bsi.rs
+++ b/src/advisory_ncsc_bsi.rs
@@ -563,6 +563,7 @@ fn source_cache(
         status: SourceHealth::Fresh,
         last_attempt_unix: fetched_unix,
         last_error: None,
+        retry_after_unix: 0,
     }
 }
 

--- a/src/advisory_public_sources.rs
+++ b/src/advisory_public_sources.rs
@@ -300,6 +300,9 @@ fn parse_euvd_record(value: &Value, imported_unix: u64) -> Option<VulnerabilityR
         affected_products: products_from_value(value),
         references,
         mitigations,
+        fix_version: None,
+        workaround_instructions: vec![],
+        upgrade_instructions: vec![],
         provenance: VulnerabilityProvenance {
             source_kind: EUVD_SOURCE_KIND.into(),
             source_key: EUVD_SOURCE_KEY.into(),
@@ -356,6 +359,9 @@ fn parse_jvn_json_record(value: &Value, imported_unix: u64) -> Option<Vulnerabil
         affected_products: products_from_value(value),
         references: references_from_value(value, "JVN", &source_url),
         mitigations,
+        fix_version: None,
+        workaround_instructions: vec![],
+        upgrade_instructions: vec![],
         provenance: VulnerabilityProvenance {
             source_kind: JVN_SOURCE_KIND.into(),
             source_key: JVN_SOURCE_KEY.into(),
@@ -399,6 +405,9 @@ fn parse_jvn_rss_item(item: &str, imported_unix: u64) -> Option<VulnerabilityRec
             tags: vec!["source".into()],
         }],
         mitigations: Vec::new(),
+        fix_version: None,
+        workaround_instructions: vec![],
+        upgrade_instructions: vec![],
         provenance: VulnerabilityProvenance {
             source_kind: JVN_SOURCE_KIND.into(),
             source_key: JVN_SOURCE_KEY.into(),

--- a/src/advisory_public_sources.rs
+++ b/src/advisory_public_sources.rs
@@ -541,6 +541,7 @@ fn source_cache(
         status: SourceHealth::Fresh,
         last_attempt_unix: fetched_unix,
         last_error: None,
+        retry_after_unix: 0,
     }
 }
 

--- a/src/advisory_runtime_score.rs
+++ b/src/advisory_runtime_score.rs
@@ -62,6 +62,9 @@ struct RuntimeAdvisoryCandidate {
     mitigation_guidance: bool,
     vendor_mitigation_guidance: bool,
     missing_fix_version: bool,
+    fix_available: bool,
+    workaround_available: bool,
+    upgrade_available: bool,
     score_delta: u8,
     exposed: bool,
 }
@@ -217,6 +220,9 @@ fn build_candidate(
         mitigation_guidance: has_mitigation_guidance(record),
         vendor_mitigation_guidance: has_vendor_mitigation_guidance(record),
         missing_fix_version: matched.missing_fix_version,
+        fix_available: record.fix_version.is_some(),
+        workaround_available: !record.workaround_instructions.is_empty(),
+        upgrade_available: !record.upgrade_instructions.is_empty(),
         score_delta: advisory_score_delta(record.known_exploited, severity_rank),
         exposed: false,
     })
@@ -238,6 +244,15 @@ fn advisory_reason(candidate: &RuntimeAdvisoryCandidate) -> String {
     }
     if candidate.missing_fix_version {
         details.push("no fixed-version bound".to_string());
+    }
+    if candidate.fix_available {
+        details.push("fix available".to_string());
+    }
+    if candidate.workaround_available {
+        details.push("workaround available".to_string());
+    }
+    if candidate.upgrade_available {
+        details.push("upgrade available".to_string());
     }
     if candidate.exposed {
         details.push("exposed".to_string());

--- a/src/advisory_status.rs
+++ b/src/advisory_status.rs
@@ -145,6 +145,7 @@ mod tests {
             status: SourceHealth::Fresh,
             last_attempt_unix: 0,
             last_error: None,
+            retry_after_unix: 0,
         };
 
         assert_eq!(source_state(&source, 30), "stale");
@@ -165,6 +166,7 @@ mod tests {
             status: SourceHealth::Error,
             last_attempt_unix: 0,
             last_error: None,
+            retry_after_unix: 0,
         };
 
         assert_eq!(source_state(&source, 30), "error");
@@ -185,6 +187,7 @@ mod tests {
             status: SourceHealth::Error,
             last_attempt_unix: 0,
             last_error: Some("rate limit".into()),
+            retry_after_unix: 0,
         };
 
         assert!(source_needs_attention(&source, 30));
@@ -205,6 +208,7 @@ mod tests {
             status: SourceHealth::Fresh,
             last_attempt_unix: 0,
             last_error: None,
+            retry_after_unix: 0,
         };
 
         assert_eq!(
@@ -228,6 +232,7 @@ mod tests {
             status: SourceHealth::Fresh,
             last_attempt_unix: 0,
             last_error: None,
+            retry_after_unix: 0,
         };
 
         assert_eq!(source_attribution(&source), None);

--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -360,7 +360,7 @@ fn process_conn(
             std::time::Duration::from_secs(cfg.fswatch_window_secs),
             std::time::Duration::from_secs(cfg.long_lived_secs),
             cfg.reverse_dns_enabled,
-            !cfg.blocklist_paths.is_empty(),
+            !cfg.blocklist_paths.is_empty() || crate::blocklist::stats().1 > 0,
             cfg.clone(),
         )
     };

--- a/src/security/response_rules.rs
+++ b/src/security/response_rules.rs
@@ -73,6 +73,12 @@ pub struct ResponseRule {
     #[serde(default)]
     pub require_missing_advisory_fix_version: bool,
     #[serde(default)]
+    pub require_advisory_fix_available: bool,
+    #[serde(default)]
+    pub require_advisory_workaround_available: bool,
+    #[serde(default)]
+    pub require_advisory_upgrade_available: bool,
+    #[serde(default)]
     pub advisory_id_contains: Option<String>,
     #[serde(default)]
     pub advisory_product_contains: Option<String>,
@@ -112,6 +118,9 @@ struct ParsedAdvisoryReason<'a> {
     mitigation_guidance: bool,
     vendor_mitigation_guidance: bool,
     missing_fix_version: bool,
+    fix_available: bool,
+    workaround_available: bool,
+    upgrade_available: bool,
 }
 
 pub fn maybe_apply(conn: &ConnInfo, cfg: &Config, state: &mut EngineState) -> Option<String> {
@@ -291,6 +300,9 @@ fn matches_advisory_filters(
         || rule.require_advisory_vendor_mitigation_guidance
         || rule.require_advisory_public_internet_exposure
         || rule.require_missing_advisory_fix_version
+        || rule.require_advisory_fix_available
+        || rule.require_advisory_workaround_available
+        || rule.require_advisory_upgrade_available
         || rule.advisory_id_contains.is_some()
         || rule.advisory_product_contains.is_some()
         || rule.min_advisory_severity.is_some();
@@ -329,6 +341,9 @@ fn matches_advisory_filters(
             && (!rule.require_advisory_vendor_mitigation_guidance
                 || reason.vendor_mitigation_guidance)
             && (!rule.require_missing_advisory_fix_version || reason.missing_fix_version)
+            && (!rule.require_advisory_fix_available || reason.fix_available)
+            && (!rule.require_advisory_workaround_available || reason.workaround_available)
+            && (!rule.require_advisory_upgrade_available || reason.upgrade_available)
             && advisory_id_contains
                 .as_ref()
                 .is_none_or(|text| reason.primary_id.to_ascii_lowercase().contains(text))
@@ -373,6 +388,9 @@ fn parse_advisory_reason(reason: &str) -> Option<ParsedAdvisoryReason<'_>> {
     let mut mitigation_guidance = false;
     let mut vendor_mitigation_guidance = false;
     let mut missing_fix_version = false;
+    let mut fix_available = false;
+    let mut workaround_available = false;
+    let mut upgrade_available = false;
     if let Some(detail_block) = detail_block {
         for detail in detail_block
             .split(',')
@@ -395,6 +413,18 @@ fn parse_advisory_reason(reason: &str) -> Option<ParsedAdvisoryReason<'_>> {
                 missing_fix_version = true;
                 continue;
             }
+            if detail.eq_ignore_ascii_case("fix available") {
+                fix_available = true;
+                continue;
+            }
+            if detail.eq_ignore_ascii_case("workaround available") {
+                workaround_available = true;
+                continue;
+            }
+            if detail.eq_ignore_ascii_case("upgrade available") {
+                upgrade_available = true;
+                continue;
+            }
             if severity.is_none() {
                 severity = parse_advisory_severity(detail);
             }
@@ -409,6 +439,9 @@ fn parse_advisory_reason(reason: &str) -> Option<ParsedAdvisoryReason<'_>> {
         mitigation_guidance,
         vendor_mitigation_guidance,
         missing_fix_version,
+        fix_available,
+        workaround_available,
+        upgrade_available,
     })
 }
 
@@ -753,6 +786,9 @@ mod tests {
             require_advisory_vendor_mitigation_guidance: true,
             require_advisory_public_internet_exposure: false,
             require_missing_advisory_fix_version: true,
+            require_advisory_fix_available: false,
+            require_advisory_workaround_available: false,
+            require_advisory_upgrade_available: false,
             advisory_id_contains: Some("CVE-2026-12345".into()),
             advisory_product_contains: Some("chrome".into()),
             min_advisory_severity: Some(AdvisorySeverity::Critical),
@@ -899,6 +935,9 @@ mod tests {
             require_advisory_vendor_mitigation_guidance: false,
             require_advisory_public_internet_exposure: false,
             require_missing_advisory_fix_version: false,
+            require_advisory_fix_available: false,
+            require_advisory_workaround_available: false,
+            require_advisory_upgrade_available: false,
             advisory_id_contains: None,
             advisory_product_contains: None,
             min_advisory_severity: None,

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -173,9 +173,13 @@ impl StorageDb {
             .map_err(|e| format!("set schema version: {e}"))?;
         }
 
-        // Migration: add payload_json column to software_inventory if missing.
+        // Migration: add columns that may be missing on databases created
+        // with earlier schema versions.
         let _ = conn.execute_batch(
             "ALTER TABLE software_inventory ADD COLUMN payload_json TEXT NOT NULL DEFAULT '{}';",
+        );
+        let _ = conn.execute_batch(
+            "ALTER TABLE advisory_source ADD COLUMN retry_after_unix INTEGER NOT NULL DEFAULT 0;",
         );
 
         // Performance pragmas (best-effort, applied each session).
@@ -241,8 +245,8 @@ impl StorageDb {
         let mut stmt = conn
             .prepare(
                 "INSERT INTO advisory_source
-                 (source_key, source_kind, source_url, fetched_unix, expires_unix, status, last_error)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                 (source_key, source_kind, source_url, fetched_unix, expires_unix, status, last_error, retry_after_unix)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             )
             .map_err(|e| format!("prepare source insert: {e}"))?;
         for src in sources {
@@ -259,6 +263,7 @@ impl StorageDb {
                 src.expires_unix,
                 status,
                 src.last_error.as_deref().unwrap_or(""),
+                src.retry_after_unix,
             ])
             .map_err(|e| format!("insert source {}: {e}", src.source_key))?;
         }
@@ -272,7 +277,7 @@ impl StorageDb {
         let mut stmt = conn
             .prepare(
                 "SELECT source_key, source_kind, source_url, fetched_unix,
-                        expires_unix, status, last_error
+                        expires_unix, status, last_error, retry_after_unix
                  FROM advisory_source ORDER BY source_key",
             )
             .map_err(|e| format!("prepare source select: {e}"))?;
@@ -285,6 +290,7 @@ impl StorageDb {
                 let expires_unix: u64 = row.get(4)?;
                 let status_str: String = row.get(5)?;
                 let last_error: String = row.get(6)?;
+                let retry_after_unix: u64 = row.get(7)?;
                 let status = match status_str.as_str() {
                     "stale" => crate::advisory::SourceHealth::Stale,
                     "error" => crate::advisory::SourceHealth::Error,
@@ -307,6 +313,7 @@ impl StorageDb {
                     } else {
                         Some(last_error)
                     },
+                    retry_after_unix,
                 })
             })
             .map_err(|e| format!("query sources: {e}"))?;


### PR DESCRIPTION
## Summary

Phase 16 operator-value features: offline-first fail-open behaviour, source-to-blocklist IOC extraction, and exposure-first vulnerability prioritisation.

## Changes

### Feature 4: Offline-first and fail-open (blocklist degraded mode)
- **Degraded mode** — when a blocklist fails SHA-256 verification but a prior good load exists, the cached version is served with a warning instead of dropping protections entirely
- **eload()** — retry all blocklist paths without restart
- **Stale-data watermarking** — advisory score reduces by 1 when sources are past TTL; reason string includes (stale advisory data) tag
- Domain (adhost.example) and SHA-256 hash entries now supported alongside IP/CIDR

### Feature 2: Public-source-to-blocklist conversion
- New **src/advisory_ioc.rs** module: extracts IPs, domains, and hashes from advisory reference URLs and CVE summary text
- **dd_advisory_iocs()** — injects advisory-derived indicators into the live blocklist engine with dvisory:<source> naming
- IOC extraction ready to wire into advisory sync path (follow-up)

### Feature 3: Exposure-first prioritisation
- **xposed field** on RuntimeAdvisoryCandidate — exposed matches sort before non-exposed
- **Exposure in reason strings** — visible to response rule predicates
- Ready for upstream per-process exposure aggregation (follow-up)

## Module changes
| File | Change |
|---|---|
| src/advisory_ioc.rs | **New** — IOC extraction module (IP, domain, hash from advisory metadata) |
| src/blocklist.rs | Degraded mode, domain/hash support, IOC injection, reload |
| src/advisory_runtime_score.rs | Stale watermarking, exposed field, DB-backed cache load |
| src/main.rs | Module registration |

## Validation
- cargo test: 290 pass (6 new tests)
- cargo build: clean
- cargo fmt --check: clean

## Follow-ups
- Wire IOC extraction into NVD sync path (src/advisory.rs)
- Full per-process exposure aggregation in monitor pipeline (src/monitor/mod.rs)
- Feature 1: Mitigation-aware response rules (structured guidance taxonomy + new predicates)