### PR TITLE
Phase 19: add trusted nft command resolution

### DIFF
--- a/src/platform/command_paths.rs
+++ b/src/platform/command_paths.rs
@@ -36,9 +36,15 @@ fn resolve_windows(program: &str) -> Result<PathBuf, String> {
 
 #[cfg(target_os = "linux")]
 fn resolve_linux(program: &str) -> Result<PathBuf, String> {
-    let candidates: &[&str] = match program {
+    resolve_from_candidates(program, linux_candidates(program))
+}
+
+#[cfg(target_os = "linux")]
+fn linux_candidates(program: &str) -> &'static [&'static str] {
+    match program {
         "kill" => &["/bin/kill", "/usr/bin/kill"],
         "iptables" => &["/usr/sbin/iptables", "/sbin/iptables"],
+        "nft" => &["/usr/sbin/nft", "/sbin/nft", "/usr/bin/nft", "/bin/nft"],
         "ip" => &["/usr/sbin/ip", "/sbin/ip"],
         "ss" => &["/usr/sbin/ss", "/usr/bin/ss", "/bin/ss"],
         "resolvectl" => &["/usr/bin/resolvectl", "/bin/resolvectl"],
@@ -46,8 +52,7 @@ fn resolve_linux(program: &str) -> Result<PathBuf, String> {
         "systemctl" => &["/bin/systemctl", "/usr/bin/systemctl"],
         "crontab" => &["/usr/bin/crontab", "/bin/crontab"],
         _ => &[],
-    };
-    resolve_from_candidates(program, candidates)
+    }
 }
 
 fn resolve_from_candidates(program: &str, candidates: &[&str]) -> Result<PathBuf, String> {
@@ -57,4 +62,17 @@ fn resolve_from_candidates(program: &str, candidates: &[&str]) -> Result<PathBuf
         .map(PathBuf::from)
         .find(|path| Path::new(path).exists())
         .ok_or_else(|| format!("required trusted binary for {program} not found"))
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::linux_candidates;
+
+    #[test]
+    fn linux_trusted_candidates_include_nft() {
+        assert_eq!(
+            linux_candidates("nft"),
+            &["/usr/sbin/nft", "/sbin/nft", "/usr/bin/nft", "/bin/nft"]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- add `nft` to the Linux trusted command resolver used by `StdLinuxCommandRunner`
- factor Linux candidate selection into a small helper so the nft path whitelist is testable
- add a focused Linux-only unit test that locks in the trusted `nft` candidate list

## Why this task

There were no open PRs, unresolved review threads, requested changes, or failing CI signals that needed scheduled follow-up in `YMRYMR/vigil`.

`ROADMAP.md` shows Phase 19 as the next unfinished phase. The first listed Windows WFP item is too broad for a safe scheduled pass, so I took the smallest explicit slice from the same Phase 19 foundation work: the Linux nftables backend activation path already uses `StdLinuxCommandRunner`, but `src/platform/command_paths.rs` did not trust-resolve `nft` at all. That makes the already-merged nftables executor path fail before it can invoke the backend.

## Validation

- reviewed `ROADMAP.md` to confirm Phase 19 is the next explicit unfinished phase
- reviewed `src/security/linux_command_plan.rs` and confirmed `StdLinuxCommandRunner` resolves command paths through `src/platform/command_paths.rs`
- added a focused Linux-only unit test covering the new `nft` candidate list

## Notes

- I could not run local Rust checks in this scheduled environment because the repository is not available here as a buildable local checkout and direct clone access is blocked
- this change does not complete the broader Phase 19 Linux activation work yet; it removes one concrete blocker in the trusted-command path so the existing nft executor bridge can run on supported Linux systems