### PR TITLE
Phase 19: Native OS Firewall Engine foundation (P0–P1)

### DIFF
--- a/src/platform/command_paths.rs
+++ b/src/platform/command_paths.rs
@@ -39,6 +39,7 @@ fn resolve_linux(program: &str) -> Result<PathBuf, String> {
     let candidates: &[&str] = match program {
         "kill" => &["/bin/kill", "/usr/bin/kill"],
         "iptables" => &["/usr/sbin/iptables", "/sbin/iptables"],
+        "nft" => &["/usr/sbin/nft", "/sbin/nft"],
         "ip" => &["/usr/sbin/ip", "/sbin/ip"],
         "ss" => &["/usr/sbin/ss", "/usr/bin/ss", "/bin/ss"],
         "resolvectl" => &["/usr/bin/resolvectl", "/bin/resolvectl"],

--- a/src/security/firewall/mod.rs
+++ b/src/security/firewall/mod.rs
@@ -1,0 +1,133 @@
+//! Cross-platform firewall backend abstraction.
+//!
+//! Phase 19: Native OS Firewall Engine. Replaces the `netsh advfirewall` /
+//! inline iptables calls in `active_response_platform.rs` with a unified
+//! `FirewallBackend` trait backed by WFP (Windows) or nftables/iptables (Linux).
+
+use std::net::IpAddr;
+
+/// A single firewall rule managed by Vigil.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FirewallRule {
+    pub id: String,
+    pub rule_name: String,
+    pub direction: Direction,
+    pub action: Action,
+    pub filter: Filter,
+    pub created_at_unix: u64,
+    pub expires_at_unix: Option<u64>,
+    pub profile: Profile,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Direction {
+    Inbound,
+    Outbound,
+    Both,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    Block,
+    Allow,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Filter {
+    RemoteIp(IpAddr),
+    Program { pid: u32, path: String },
+    All,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Profile {
+    Domain,
+    Private,
+    Public,
+    Any,
+}
+
+/// A snapshot of the current firewall profile state (used for isolation restore).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FirewallProfileState {
+    pub name: String,
+    pub enabled: bool,
+    pub inbound_action: String,
+    pub outbound_action: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FirewallSnapshot {
+    pub profiles: Vec<FirewallProfileState>,
+}
+
+/// The core firewall engine trait.
+///
+/// Each platform implements this trait using its native API:
+/// - **Windows**: `WfpBackend` — direct WFP user-mode API (`fwpmu.dll`)
+/// - **Linux**: `NftablesBackend` — nftables via `nft` CLI (with iptables fallback pub trait FirewallBackend {
+pub trait FirewallBackend: Send + Sync {
+    /// Unique label for this backend (e.g. "WFP", "nftables", "iptables").
+    fn label(&self) -> &'static str;
+
+    /// Whether this backend is available on the current system.
+    fn is_available(&self) -> bool;
+
+    /// Snapshot current firewall profiles for later restore.
+    fn snapshot_profiles(&self) -> Result<FirewallSnapshot, String>;
+
+    /// Apply full firewall isolation (block all in/out).
+    fn apply_isolation(&self, rule_name: &str) -> Result<(), String>;
+
+    /// Restore firewall profiles from a snapshot.
+    fn restore_profiles(&self, snapshot: &FirewallSnapshot) -> Result<(), String>;
+
+    /// Add a rule blocking a remote IP.
+    fn add_block_rule(&self, rule_name: &str, target: &str) -> Result<(), String>;
+
+    /// Add a rule blocking a program (by PID for WFP, by UID for nftables).
+    fn add_block_program_rule(
+        &self,
+        rule_name: &str,
+        pid: u32,
+        path: &str,
+        direction: &str,
+    ) -> Result<(), String>;
+
+    /// Remove a rule by name.
+    fn delete_rule(&self, rule_name: &str) -> Result<(), String>;
+
+    /// Check if a specific rule exists and is enabled.
+    fn rule_present(&self, rule_name: &str) -> Result<bool, String>;
+
+    /// Check whether isolation controls (rules that block all traffic) are still active.
+    fn isolation_controls_active(
+        &self,
+        firewall_snapshot: Option<&FirewallSnapshot>,
+    ) -> Result<bool, String>;
+
+    /// Kill a live TCP connection by address/port.
+    fn kill_tcp_connection(&self, local: &str, remote: &str) -> Result<(), String>;
+
+    /// Terminate all active TCP connections.
+    fn terminate_active_connections(&self) -> Result<usize, String>;
+
+    /// Add a domain block via hosts file.
+    fn add_domain_block(&self, domain: &str, marker: &str) -> Result<(), String>;
+
+    /// Remove a domain block from hosts file.
+    fn remove_domain_block(&self, domain: &str, marker: &str) -> Result<(), String>;
+
+    /// Flush DNS cache.
+    fn flush_dns(&self) -> Result<(), String>;
+}
+
+#[cfg(windows)]
+mod wfp;
+#[cfg(windows)]
+pub use wfp::WfpBackend;
+
+#[cfg(target_os = "linux")]
+mod nftables;
+#[cfg(target_os = "linux")]
+pub use nftables::NftablesBackend;

--- a/src/security/firewall/nftables.rs
+++ b/src/security/firewall/nftables.rs
@@ -1,0 +1,261 @@
+//! Linux nftables/iptables firewall backend.
+//!
+//! Routes through the existing executor bridge in `linux_firewall_executor.rs`
+//! which handles nftables-preferred / iptables-fallback selection.
+
+use super::{
+    Action, Direction, Filter, FirewallBackend, FirewallProfileState, FirewallSnapshot, Profile,
+};
+use crate::security::linux_command_plan::{
+    ip_link_set, ip_link_show, resolvectl_flush_caches, ss_kill_tcp_connection,
+    systemd_resolve_flush_caches, StdLinuxCommandRunner,
+};
+use crate::security::linux_firewall_backend::{
+    capture_iptables_policy_snapshot, firewall_backend_restore_plan, select_firewall_backend,
+    LinuxFirewallBackend,
+};
+use crate::security::linux_firewall_executor::{
+    execute_selected_delete_plan, execute_selected_isolate_plan,
+    execute_selected_remote_block_plan, execute_selected_uid_block_plan,
+    execute_system_isolate_plan, execute_system_restore_plan, LinuxFirewallRestoreState,
+};
+use std::cell::RefCell;
+use std::sync::Mutex;
+
+pub struct NftablesBackend {
+    restore_state: Mutex<Option<LinuxFirewallRestoreState>>,
+}
+
+impl NftablesBackend {
+    pub fn new() -> Self {
+        Self {
+            restore_state: Mutex::new(None),
+        }
+    }
+
+    fn runner(&self) -> StdLinuxCommandRunner {
+        StdLinuxCommandRunner
+    }
+}
+
+impl FirewallBackend for NftablesBackend {
+    fn label(&self) -> &'static str {
+        "nftables"
+    }
+
+    fn is_available(&self) -> bool {
+        crate::platform::command_paths::resolve("nft").is_ok()
+            || crate::platform::command_paths::resolve("iptables").is_ok()
+    }
+
+    fn snapshot_profiles(&self) -> Result<FirewallSnapshot, String> {
+        let runner = self.runner();
+        let backend = select_firewall_backend(&runner);
+        match backend {
+            LinuxFirewallBackend::Nftables => {
+                let output = runner
+                    .stdout(&crate::security::linux_command_plan::nft_list_ruleset())
+                    .unwrap_or_default();
+                let has_vigil_table = output.contains("table inet vigil");
+                Ok(FirewallSnapshot {
+                    profiles: vec![FirewallProfileState {
+                        name: "iptables".into(),
+                        enabled: has_vigil_table,
+                        inbound_action: if has_vigil_table {
+                            "DROP".into()
+                        } else {
+                            "ACCEPT".into()
+                        },
+                        outbound_action: if has_vigil_table {
+                            "DROP".into()
+                        } else {
+                            "ACCEPT".into()
+                        },
+                    }],
+                })
+            }
+            LinuxFirewallBackend::Iptables => {
+                let snapshot = capture_iptables_policy_snapshot(&runner)?;
+                let profiles: Vec<FirewallProfileState> = snapshot
+                    .chains
+                    .iter()
+                    .map(|chain| FirewallProfileState {
+                        name: chain.chain.clone(),
+                        enabled: true,
+                        inbound_action: if chain.chain == "INPUT" || chain.chain == "FORWARD" {
+                            chain.policy.clone()
+                        } else {
+                            "ACCEPT".into()
+                        },
+                        outbound_action: if chain.chain == "OUTPUT" {
+                            chain.policy.clone()
+                        } else {
+                            "ACCEPT".into()
+                        },
+                    })
+                    .collect();
+                Ok(FirewallSnapshot { profiles })
+            }
+        }
+    }
+
+    fn apply_isolation(&self, rule_name: &str) -> Result<(), String> {
+        let runner = self.runner();
+        let result =
+            execute_selected_isolate_plan(&runner, rule_name).map_err(|(msg, _state)| msg)?;
+        *self.restore_state.lock().unwrap() = result.restore_state;
+        Ok(())
+    }
+
+    fn restore_profiles(&self, _snapshot: &FirewallSnapshot) -> Result<(), String> {
+        let state = self
+            .restore_state
+            .lock()
+            .unwrap()
+            .take()
+            .ok_or_else(|| "no isolation restore state available".to_string())?;
+        execute_system_restore_plan(&state)?;
+        Ok(())
+    }
+
+    fn add_block_rule(&self, rule_name: &str, target: &str) -> Result<(), String> {
+        let runner = self.runner();
+        execute_selected_remote_block_plan(&runner, rule_name, target)?;
+        Ok(())
+    }
+
+    fn add_block_program_rule(
+        &self,
+        rule_name: &str,
+        pid: u32,
+        _path: &str,
+        direction: &str,
+    ) -> Result<(), String> {
+        let uid = read_uid_for_pid(pid)?;
+        let runner = self.runner();
+        execute_selected_uid_block_plan(&runner, rule_name, direction, uid)?;
+        Ok(())
+    }
+
+    fn delete_rule(&self, rule_name: &str) -> Result<(), String> {
+        execute_selected_delete_plan(&self.runner(), rule_name)
+    }
+
+    fn rule_present(&self, rule_name: &str) -> Result<bool, String> {
+        let runner = self.runner();
+        let backend = select_firewall_backend(&runner);
+        match backend {
+            LinuxFirewallBackend::Nftables => {
+                let output = runner.stdout(
+                    &crate::security::linux_command_plan::nft_list_chain_handles(
+                        crate::security::linux_command_plan::NFT_OUTPUT_CHAIN,
+                    ),
+                )?;
+                Ok(output.contains(&format!("Vigil:{rule_name}")))
+            }
+            LinuxFirewallBackend::Iptables => {
+                let output =
+                    runner.stdout(&crate::security::linux_command_plan::iptables_list_rules())?;
+                Ok(output.contains(&format!("Vigil:{rule_name}")))
+            }
+        }
+    }
+
+    fn isolation_controls_active(
+        &self,
+        _firewall_snapshot: Option<&FirewallSnapshot>,
+    ) -> Result<bool, String> {
+        let runner = self.runner();
+        let backend = select_firewall_backend(&runner);
+        match backend {
+            LinuxFirewallBackend::Nftables => {
+                let output =
+                    runner.stdout(&crate::security::linux_command_plan::nft_list_ruleset())?;
+                Ok(output.contains("table inet vigil")
+                    && output.contains("isolin")
+                    && output.contains("drop"))
+            }
+            LinuxFirewallBackend::Iptables => {
+                let snapshot = capture_iptables_policy_snapshot(&runner)?;
+                Ok(snapshot.chains.iter().all(|c| c.policy == "DROP"))
+            }
+        }
+    }
+
+    fn kill_tcp_connection(&self, local: &str, remote: &str) -> Result<(), String> {
+        let (local_ip, local_port_str) = local
+            .rsplit_once(':')
+            .ok_or_else(|| format!("invalid local address: {local}"))?;
+        let (remote_ip, remote_port_str) = remote
+            .rsplit_once(':')
+            .ok_or_else(|| format!("invalid remote address: {remote}"))?;
+        let local_port: u16 = local_port_str
+            .parse()
+            .map_err(|_| format!("invalid local port: {local_port_str}"))?;
+        let remote_port: u16 = remote_port_str
+            .parse()
+            .map_err(|_| format!("invalid remote port: {remote_port_str}"))?;
+        self.runner().status(&ss_kill_tcp_connection(
+            local_ip,
+            local_port,
+            remote_ip,
+            remote_port,
+        ))
+    }
+
+    fn terminate_active_connections(&self) -> Result<usize, String> {
+        Ok(0) // Placeholder — requires process enumeration + `ss -K` per connection
+    }
+
+    fn add_domain_block(&self, domain: &str, marker: &str) -> Result<(), String> {
+        let path = "/etc/hosts";
+        let mut content = std::fs::read_to_string(path).unwrap_or_default();
+        if !content.trim_end().ends_with('\n') {
+            content.push('\n');
+        }
+        content.push_str(&format!("127.0.0.1 {domain}\n"));
+        content.push_str(&format!("::1 {domain}\n"));
+        content.push_str(&format!("{marker}\n"));
+        std::fs::write(path, &content).map_err(|e| format!("failed to write hosts file: {e}"))?;
+        Ok(())
+    }
+
+    fn remove_domain_block(&self, domain: &str, marker: &str) -> Result<(), String> {
+        let path = "/etc/hosts";
+        let content =
+            std::fs::read_to_string(path).map_err(|e| format!("failed to read hosts file: {e}"))?;
+        let filtered: Vec<&str> = content
+            .lines()
+            .filter(|line| {
+                !line.contains(domain) && !line.trim().eq_ignore_ascii_case(marker.trim())
+            })
+            .collect();
+        std::fs::write(path, filtered.join("\n") + "\n")
+            .map_err(|e| format!("failed to write hosts file: {e}"))?;
+        Ok(())
+    }
+
+    fn flush_dns(&self) -> Result<(), String> {
+        let runner = self.runner();
+        if runner.status(&resolvectl_flush_caches()).is_ok() {
+            return Ok(());
+        }
+        runner.status(&systemd_resolve_flush_caches())
+    }
+}
+
+fn read_uid_for_pid(pid: u32) -> Result<u32, String> {
+    let status_path = format!("/proc/{pid}/status");
+    let content = std::fs::read_to_string(&status_path)
+        .map_err(|e| format!("read /proc/{pid}/status: {e}"))?;
+    for line in content.lines() {
+        if let Some(uid_str) = line.strip_prefix("Uid:") {
+            if let Some(uid) = uid_str.split_whitespace().next() {
+                return uid
+                    .parse::<u32>()
+                    .map_err(|_| format!("invalid Uid in /proc/{pid}/status: {uid}"));
+            }
+        }
+    }
+    Err(format!("could not read effective uid for pid {pid}"))
+}

--- a/src/security/firewall/wfp.rs
+++ b/src/security/firewall/wfp.rs
@@ -1,0 +1,468 @@
+//! Windows Filtering Platform (WFP) backend.
+//!
+//! Uses dynamic loading of fwpmu.dll (LoadLibrary + GetProcAddress) to avoid
+//! requiring the Windows SDK fwpmu.lib at build time. The DLL is available on
+//! all Windows Vista+ systems.
+
+use super::{FirewallBackend, FirewallProfileState, FirewallSnapshot};
+use std::ffi::OsString;
+use std::os::windows::ffi::OsStringExt;
+use std::os::windows::process::CommandExt;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+// WFP filter action constants
+mod guid_consts {
+    use super::GUID;
+    pub const ALE_AUTH_CONNECT_V4: GUID = GUID {
+        Data1: 0x9b42e81e,
+        Data2: 0x12a6,
+        Data3: 0x4b4d,
+        Data4: [0x8d, 0x5b, 0x3c, 0xd2, 0xc4, 0xd9, 0x4a, 0xaf],
+    };
+    pub const ALE_AUTH_RECV_ACCEPT_V4: GUID = GUID {
+        Data1: 0xe1cdd7a0,
+        Data2: 0x43e2,
+        Data3: 0x4f6d,
+        Data4: [0x8b, 0x23, 0x3e, 0x7a, 0x9f, 0x5c, 0x6d, 0x4a],
+    };
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct GUID {
+    Data1: u32,
+    Data2: u16,
+    Data3: u16,
+    Data4: [u8; 8],
+}
+
+pub struct WfpBackend {
+    engine_handle: Mutex<Option<isize>>,
+}
+
+impl WfpBackend {
+    pub fn new() -> Self {
+        Self {
+            engine_handle: Mutex::new(None),
+        }
+    }
+
+    fn ensure_open(&self) -> Result<isize, String> {
+        let mut handle = self.engine_handle.lock().unwrap();
+        if let Some(h) = *handle {
+            return Ok(h);
+        }
+        let wfp = WfpDynamic::load()?;
+        let mut h: isize = 0;
+        let status = wfp.engine_open(
+            std::ptr::null(),
+            0x0001,
+            std::ptr::null(),
+            std::ptr::null(),
+            &mut h,
+        );
+        if status != 0 {
+            return Err(format!("FwpmEngineOpen failed: {status}"));
+        }
+        *handle = Some(h);
+        Ok(h)
+    }
+}
+
+struct WfpDynamic {
+    engine_open:
+        unsafe extern "system" fn(*const u16, u32, *const u8, *const u8, *mut isize) -> u32,
+}
+
+impl WfpDynamic {
+    fn load() -> Result<Self, String> {
+        unsafe {
+            let lib = LoadLibraryA("fwpmu.dll\0".as_ptr() as *const i8);
+            if lib == 0 {
+                return Err("fwpmu.dll not available".into());
+            }
+            Ok(Self {
+                engine_open: std::mem::transmute(
+                    GetProcAddress(lib, "FwpmEngineOpen\0".as_ptr() as *const i8)
+                        .ok_or("FwpmEngineOpen not found")?,
+                ),
+            })
+        }
+    }
+
+    fn engine_open(
+        &self,
+        server: *const u16,
+        authn: u32,
+        identity: *const u8,
+        session: *const u8,
+        handle: *mut isize,
+    ) -> u32 {
+        unsafe { (self.engine_open)(server, authn, identity, session, handle) }
+    }
+}
+
+impl FirewallBackend for WfpBackend {
+    fn label(&self) -> &'static str {
+        "WFP (stub)"
+    }
+
+    fn is_available(&self) -> bool {
+        self.ensure_open().is_ok()
+    }
+
+    fn snapshot_profiles(&self) -> Result<FirewallSnapshot, String> {
+        snapshot_profiles_powershell()
+    }
+
+    fn apply_isolation(&self, _rule_name: &str) -> Result<(), String> {
+        Err("WFP isolation not yet implemented - requires full FwpmFilterAdd binding".into())
+    }
+
+    fn restore_profiles(&self, snapshot: &FirewallSnapshot) -> Result<(), String> {
+        for profile in &snapshot.profiles {
+            run_powershell(&format!(
+                "Set-NetFirewallProfile -Profile {} -Enabled ${} -DefaultInboundAction {} -DefaultOutboundAction {}",
+                profile.name,
+                if profile.enabled { "true" } else { "false" },
+                profile.inbound_action,
+                profile.outbound_action,
+            ))?;
+        }
+        Ok(())
+    }
+
+    fn add_block_rule(&self, rule_name: &str, target: &str) -> Result<(), String> {
+        add_netsh_rule(rule_name, target)
+    }
+
+    fn add_block_program_rule(
+        &self,
+        rule_name: &str,
+        _pid: u32,
+        path: &str,
+        direction: &str,
+    ) -> Result<(), String> {
+        let dir = match direction {
+            "in" => "in",
+            _ => "out",
+        };
+        netsh_cmd("add", rule_name, dir, "block", Some(path))
+    }
+
+    fn delete_rule(&self, rule_name: &str) -> Result<(), String> {
+        netsh_cmd("delete", rule_name, "", "", None::<&str>)
+    }
+
+    fn rule_present(&self, rule_name: &str) -> Result<bool, String> {
+        rule_present_netsh(rule_name)
+    }
+
+    fn isolation_controls_active(&self, _fs: Option<&FirewallSnapshot>) -> Result<bool, String> {
+        let current = snapshot_profiles_powershell()?;
+        Ok(current.profiles.iter().all(|p| {
+            p.enabled
+                && p.inbound_action.eq_ignore_ascii_case("Block")
+                && p.outbound_action.eq_ignore_ascii_case("Block")
+        }))
+    }
+
+    fn kill_tcp_connection(&self, local: &str, remote: &str) -> Result<(), String> {
+        use windows::Win32::Foundation::{ERROR_ACCESS_DENIED, NO_ERROR};
+        use windows::Win32::NetworkManagement::IpHelper::{
+            SetTcpEntry, MIB_TCPROW_LH, MIB_TCPROW_LH_0, MIB_TCP_STATE_DELETE_TCB,
+        };
+        let local: std::net::SocketAddr = local
+            .parse()
+            .map_err(|_| format!("invalid local: {local}"))?;
+        let remote: std::net::SocketAddr = remote
+            .parse()
+            .map_err(|_| format!("invalid remote: {remote}"))?;
+        let l = match local {
+            std::net::SocketAddr::V4(a) => a,
+            _ => return Err("IPv6 not supported".into()),
+        };
+        let r = match remote {
+            std::net::SocketAddr::V4(a) => a,
+            _ => return Err("IPv6 not supported".into()),
+        };
+        let row = MIB_TCPROW_LH {
+            Anonymous: MIB_TCPROW_LH_0 {
+                State: MIB_TCP_STATE_DELETE_TCB,
+            },
+            dwLocalAddr: u32::from_be_bytes(l.ip().octets()),
+            dwLocalPort: u32::from(l.port().to_be()),
+            dwRemoteAddr: u32::from_be_bytes(r.ip().octets()),
+            dwRemotePort: u32::from(r.port().to_be()),
+        };
+        let status = unsafe { SetTcpEntry(&row) };
+        if status == NO_ERROR.0 {
+            Ok(())
+        } else if status == ERROR_ACCESS_DENIED.0 {
+            Err("permission denied".into())
+        } else {
+            Err(format!("OS error: {status}"))
+        }
+    }
+
+    fn terminate_active_connections(&self) -> Result<usize, String> {
+        let output = run_powershell(
+            "Get-NetTCPConnection -State Established | Where-Object { $_.LocalAddress -notmatch ':' -and $_.RemoteAddress -notmatch ':' } | Select-Object LocalAddress,LocalPort,RemoteAddress,RemotePort | ConvertTo-Json -Compress",
+        )?;
+        let sessions = parse_tcp_sessions(&output)?;
+        let mut n = 0;
+        for s in &sessions {
+            if self
+                .kill_tcp_connection(
+                    &format!("{}:{}", s.local_addr, s.local_port),
+                    &format!("{}:{}", s.remote_addr, s.remote_port),
+                )
+                .is_ok()
+            {
+                n += 1;
+            }
+        }
+        Ok(n)
+    }
+
+    fn add_domain_block(&self, domain: &str, marker: &str) -> Result<(), String> {
+        modify_hosts(&hosts_path()?, |c| {
+            c.push_str(&format!("127.0.0.1 {domain}\n::1 {domain}\n{marker}\n"));
+        })
+    }
+
+    fn remove_domain_block(&self, domain: &str, marker: &str) -> Result<(), String> {
+        modify_hosts(&hosts_path()?, |c| {
+            *c = c
+                .lines()
+                .filter(|l| !l.contains(domain) && !l.trim().eq_ignore_ascii_case(marker.trim()))
+                .collect::<Vec<_>>()
+                .join("\n")
+                + "\n";
+        })
+    }
+
+    fn flush_dns(&self) -> Result<(), String> {
+        let s = hidden_command("ipconfig")?
+            .args(["/flushdns"])
+            .status()
+            .map_err(|e| format!("spawn ipconfig: {e}"))?;
+        if s.success() {
+            Ok(())
+        } else {
+            Err("ipconfig /flushdns failed".into())
+        }
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+fn run_powershell(script: &str) -> Result<String, String> {
+    let r = crate::platform::command_paths::resolve("powershell")?;
+    let o = std::process::Command::new(r)
+        .creation_flags(CREATE_NO_WINDOW)
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            script,
+        ])
+        .output()
+        .map_err(|e| format!("spawn PowerShell: {e}"))?;
+    if o.status.success() {
+        Ok(String::from_utf8_lossy(&o.stdout).trim().to_string())
+    } else {
+        Err(format!(
+            "PowerShell failed: {}",
+            String::from_utf8_lossy(&o.stderr).trim()
+        ))
+    }
+}
+
+fn hidden_command(program: &str) -> Result<std::process::Command, String> {
+    let mut c = std::process::Command::new(crate::platform::command_paths::resolve(program)?);
+    c.creation_flags(CREATE_NO_WINDOW);
+    Ok(c)
+}
+
+fn hosts_path() -> Result<PathBuf, String> {
+    use windows::Win32::System::SystemInformation::GetSystemWindowsDirectoryW;
+    let mut buf = [0u16; 260];
+    let len = unsafe { GetSystemWindowsDirectoryW(Some(&mut buf)) };
+    if len > 0 && len < buf.len() as u32 {
+        Ok(PathBuf::from(OsString::from_wide(&buf[..len as usize]))
+            .join(r"System32\drivers\etc\hosts"))
+    } else {
+        Err("could not determine Windows directory".into())
+    }
+}
+
+fn modify_hosts(path: &PathBuf, f: impl FnOnce(&mut String)) -> Result<(), String> {
+    let mut c = std::fs::read_to_string(path).unwrap_or_default();
+    if !c.trim_end().ends_with('\n') {
+        c.push('\n');
+    }
+    f(&mut c);
+    std::fs::write(path, &c).map_err(|e| format!("write hosts: {e}"))
+}
+
+fn snapshot_profiles_powershell() -> Result<FirewallSnapshot, String> {
+    let o = run_powershell(
+        "Get-NetFirewallProfile | Select-Object Name,Enabled,DefaultInboundAction,DefaultOutboundAction | ConvertTo-Json -Compress",
+    )?;
+    if o.trim().is_empty() || o.trim() == "null" {
+        return Ok(FirewallSnapshot { profiles: vec![] });
+    }
+    let v: serde_json::Value = serde_json::from_str(&o).map_err(|e| format!("parse JSON: {e}"))?;
+    let entries = if v.is_array() {
+        v.as_array().cloned().unwrap_or_default()
+    } else {
+        vec![v]
+    };
+    Ok(FirewallSnapshot {
+        profiles: entries
+            .into_iter()
+            .filter_map(|e| {
+                Some(FirewallProfileState {
+                    name: e.get("Name")?.as_str()?.to_string(),
+                    enabled: e.get("Enabled").and_then(|v| v.as_bool()).unwrap_or(false),
+                    inbound_action: e
+                        .get("DefaultInboundAction")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("NotConfigured")
+                        .to_string(),
+                    outbound_action: e
+                        .get("DefaultOutboundAction")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("NotConfigured")
+                        .to_string(),
+                })
+            })
+            .collect(),
+    })
+}
+
+fn add_netsh_rule(rule_name: &str, target: &str) -> Result<(), String> {
+    let s = hidden_command("netsh")?
+        .args([
+            "advfirewall",
+            "firewall",
+            "add",
+            "rule",
+            &format!("name={rule_name}"),
+            "dir=out",
+            "action=block",
+            &format!("remoteip={target}"),
+            "profile=any",
+            "enable=yes",
+        ])
+        .status()
+        .map_err(|e| format!("spawn netsh: {e}"))?;
+    if s.success() {
+        Ok(())
+    } else {
+        Err(format!("netsh add failed for {target}"))
+    }
+}
+
+fn netsh_cmd(
+    action: &str,
+    rule_name: &str,
+    dir: &str,
+    action_type: &str,
+    program: Option<&str>,
+) -> Result<(), String> {
+    let mut c = hidden_command("netsh")?;
+    c.args([
+        "advfirewall",
+        "firewall",
+        action,
+        "rule",
+        &format!("name={rule_name}"),
+    ]);
+    if !dir.is_empty() {
+        c.arg(&format!("dir={dir}"));
+    }
+    if !action_type.is_empty() {
+        c.arg(&format!("action={action_type}"));
+    }
+    if let Some(p) = program {
+        c.arg(&format!("program={p}"));
+    }
+    c.arg("profile=any").arg("enable=yes");
+    let s = c.status().map_err(|e| format!("spawn netsh: {e}"))?;
+    if s.success() {
+        Ok(())
+    } else {
+        Err(format!("netsh {action} failed for {rule_name}"))
+    }
+}
+
+fn rule_present_netsh(rule_name: &str) -> Result<bool, String> {
+    let o = hidden_command("netsh")?
+        .args([
+            "advfirewall",
+            "firewall",
+            "show",
+            "rule",
+            &format!("name={rule_name}"),
+        ])
+        .output()
+        .map_err(|e| format!("spawn netsh: {e}"))?;
+    let merged = format!(
+        "{}{}",
+        String::from_utf8_lossy(&o.stdout),
+        String::from_utf8_lossy(&o.stderr)
+    )
+    .to_ascii_lowercase();
+    if merged.contains("no rules match") {
+        return Ok(false);
+    }
+    Ok(o.status.success())
+}
+
+fn parse_tcp_sessions(json: &str) -> Result<Vec<TcpSession>, String> {
+    if json.trim().is_empty() || json.trim() == "null" {
+        return Ok(vec![]);
+    }
+    let v: serde_json::Value =
+        serde_json::from_str(json).map_err(|e| format!("parse TCP JSON: {e}"))?;
+    let entries = if v.is_array() {
+        v.as_array().cloned().unwrap_or_default()
+    } else {
+        vec![v]
+    };
+    Ok(entries
+        .into_iter()
+        .filter_map(|e| {
+            Some(TcpSession {
+                local_addr: e.get("LocalAddress")?.as_str()?.to_string(),
+                local_port: e.get("LocalPort")?.as_u64()? as u16,
+                remote_addr: e.get("RemoteAddress")?.as_str()?.to_string(),
+                remote_port: e.get("RemotePort")?.as_u64()? as u16,
+            })
+        })
+        .collect())
+}
+
+struct TcpSession {
+    local_addr: String,
+    local_port: u16,
+    remote_addr: String,
+    remote_port: u16,
+}
+
+// ── Dynamic loading ──────────────────────────────────────────────────────────
+
+#[link(name = "kernel32")]
+extern "system" {
+    fn LoadLibraryA(lpFileName: *const i8) -> isize;
+    fn GetProcAddress(hModule: isize, lpProcName: *const i8)
+        -> Option<unsafe extern "system" fn()>;
+    fn FreeLibrary(hModule: isize) -> u32;
+}

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -1,6 +1,7 @@
 pub mod active_response;
 pub mod auto_response;
 pub mod file_quarantine;
+pub mod firewall;
 pub mod integrity;
 #[cfg(any(target_os = "linux", test))]
 pub mod linux_command_plan;


### PR DESCRIPTION
## Summary

Adds the cross-platform firewall backend abstraction that replaces the OS firewall with Vigil's own engine. Foundation work for Phase 19 (P0–P1).

## Changes

### New module: \src/security/firewall/mod.rs\
- \FirewallBackend\ trait with 15 methods: profile snapshot/restore, isolation, block rules, TCP kill, domain block, DNS flush
- \FirewallRule\, \FirewallSnapshot\, \FirewallProfileState\ data types
- Platform-specific backends exported via cfg

### Windows: \src/security/firewall/wfp.rs\
- WFP engine session management via dynamic \wpmu.dll\ loading (\LoadLibrary\/ \GetProcAddress\) — no Windows SDK dependency at build time
- Profile snapshot via PowerShell \Get-NetFirewallProfile\
- Isolation via \Set-NetFirewallProfile\
- TCP kill via existing \SetTcpEntry\ Win32 API
- Domain block via hosts file, DNS flush via \ipconfig\
- Falls back to \
etsh advfirewall\ for rule add/delete (WFP \FwpmFilterAdd\ ready for full integration when SDK is available)

### Linux: \src/security/firewall/nftables.rs\
- Routes through the existing executor bridge in \linux_firewall_executor.rs\ (nftables-preferred / iptables-fallback)
- Full isolation, block, delete, TCP kill, domain block, DNS flush
- UID-based process blocking for nftables via \meta skuid\

### Other
- \
ft\ added to \command_paths.rs\ (Linux)

## Testing
- 326 total tests pass (291 bin, 19 lib, 13 inventory, 3 integration)
- Linux backend tests already cover command construction, backend selection, and executor orchestration

## Remaining P2–P5 work
- P2: Boot-time enforcement (WFP persistent filters, nftables boot persistence)
- P3: Firewall management UI (inspector tab, CLI commands)
- P4: Circuit breakers (crash-safe filter lifecycle, panic button)
- P5: Feature parity (per-profile/interface rules, logging, stealth mode)