### PR TITLE
Phase 19 P2: startup firewall rule reconciliation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,40 +82,62 @@ Windows and Linux are the active support targets. This phase is about making tho
 
 ---
 
-## Phase 19 — Native OS Firewall Engine 🚧 FOUNDATIONS IN PLACE
+## Phase 19 — Native OS Firewall Engine 🚧 IN PROGRESS
 
 Replace the OS firewall with Vigil's own WFP (Windows) / nftables (Linux) engine. All existing Vigil core features (monitoring, scoring, active response, YARA, advisory) are preserved and enhanced by having direct kernel-level firewall control, sub-millisecond rule adds, persistent rule sets, and per-profile/interface filtering. The OS firewall APIs remain available as a safety net until Vigil's engine reaches parity.
 
-Recent groundwork already landed on `master`: trusted `nft` command resolution, the cross-platform `FirewallBackend` abstraction, platform backend scaffolding for WFP and nftables/iptables, and `--firewall` status/list/panic CLI plumbing. The remaining checklist below tracks the still-open engine, persistence, UI, and safety work.
-
 ### Phase 0 — Foundation (2–3 weeks)
 
-- [ ] **Windows WFP user-mode API wrapper** — replace all `netsh advfirewall` calls with direct `Fwpm*` FFI bindings to `fwpmu.dll`. Sub-millisecond rule adds/removes. Filter-level operations (add, delete, enumerate) via `FwpmFilterAdd`, `FwpmFilterDeleteById`, `FwpmFilterEnum`. Provider registration (`FWPM_PROVIDER`) for Vigil rule ownership visibility. Sublayer registration at the correct weight relative to Windows Defender Firewall.
-- [ ] **Linux nftables backend activation** — route all Linux active-response firewall operations through the existing executor bridge in `linux_firewall_executor.rs` instead of inline iptables calls. Add `nft` to `command_paths.rs`. Wire `execute_selected_*` functions into `active_response_platform.rs`.
-- [ ] **Persistent rule store** — structured rule database (SQLite or integrity-protected JSON) with globally unique IDs, creation time, TTL, direction, action (block/allow/log), layer, interface filter, profile affinity, and scored/unscored flag for Vigil's dynamic response. Migrate current ad-hoc state tracking into this store.
-- [x] **Cross-platform `FirewallBackend` trait** — abstract WFP/nftables behind a unified trait. Current platform-split stays as the high-level API surface (`block_remote`, `block_process`, `isolate_machine`, etc.).
+- [ ] **Windows WFP user-mode API wrapper** — dynamic `Fwpuclnt.dll` loading via `LoadLibrary`/`GetProcAddress`. Engine session open, provider/sublayer registration complete. Still needs `FwpmFilterAdd` wired for rule management (currently uses netsh fallback).
+- [x] **Linux nftables backend activation** — `nft` added to `command_paths.rs`; full nftables-preferred / iptables-fallback executor bridge wired through `NftablesBackend`.
+- [ ] **Persistent rule store** — structured rule database (integrity-protected JSON or SQLite) with globally unique IDs, creation time, TTL, direction, action, layer, profile affinity. Migrate current ad-hoc state tracking into this store.
+- [x] **Cross-platform `FirewallBackend` trait** — unified trait with 15 methods, implemented for both WFP and nftables.
 
 ### Phase 1 — Core Firewall Engine (4–6 weeks)
 
-- [ ] **Windows WFP rule manager** — `FwpmEngineOpen` session management. `FwpmTransactionBegin/Commit` for atomic batch operations. `FWPM_LAYER_ALE_AUTH_CONNECT_V4/V6` and `FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4/V6` for outbound/inbound filtering. Filter conditions: local/remote IP (v4+v6), port, protocol, interface index, user/group SID (replaces current `add_block_program_rule` netsh approach). AE (Application Layer Enforcement) for PID/app-container-based filtering.
-- [ ] **Linux nftables rule manager** — create `vigil` nftables table with chains jumping from forward/input/output hooks. Rule management via existing `nft_insert_block_remote`, `nft_insert_block_uid`, etc. Rule lookup by handle via `nft_parse_handle_by_comment`. Boot persistence: `nft list ruleset` dump on shutdown, restore on startup.
-- [ ] **Dynamic vs. static rule separation** — Vigil's transient response rules (scored blocks with TTL) vs. operator-defined permanent allow/block rules. Same engine, different persistence lifetimes.
-- [ ] **Rule ordering and priority** — filter weight / chain priority that ensures Vigil's dynamic blocks override OS defaults, while operator permanent allows override Vigil dynamic blocks.
+- [ ] **Windows WFP rule manager** — `FwpmFilterAdd`/`FwpmFilterDeleteById` wired via `WfpBackend`. `FWPM_LAYER_ALE_AUTH_CONNECT_V4/V6` and `FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4/V6` filtering. Filter conditions for remote IP, port, protocol, user SID. AE for PID-based filtering.
+- [x] **Linux nftables rule manager** — `vigil` nftables table with jump chains. Remote IP blocks via `nft_insert_block_remote`, UID blocks via `nft_insert_block_uid`. Rule lookup by handle via `nft_parse_handle_by_comment`. Setup idempotent.
+- [ ] **Dynamic vs. static rule separation** — transient response rules (TTL-based) vs. operator-defined permanent allow/block rules.
+- [ ] **Rule ordering and priority** — filter weight / chain priority ensuring Vigil dynamic blocks override OS defaults.
 
 ### Phase 2 — Boot-Time Enforcement (2–3 weeks)
 
-- [ ] **Windows early-boot safe policy** — before Vigil userspace connects to WFP, the OS firewall's default profile applies (safe by default). On Vigil startup, load persistent rules from the rule store and apply them atomically. No kernel driver needed for user-space WFP management — `fwpmu.dll` filters persist in the kernel and survive process restarts.
-- [ ] **Windows ELAM readiness** — structure the WFP provider/sublayer registration so an Early Launch Anti-Malware (ELAM) driver could slot in at Phase 5 if cert signing (WHQL, ~3wk attestation) is justified. ELAM not required for Phase 2.
-- [ ] **Linux boot persistence** — nftables systemd service loads `/etc/nftables.conf` before `network.target`. Vigil writes its active ruleset to a Vigil-specific config fragment, included by the main nftables config. Systemd unit starts after `nftables.service`.
-- [ ] **Boot-time circuit breaker** — extend the existing pre-login guard and break-glass recovery to cover firewall rule state. If Vigil crashes during boot, the kernel keeps the last-applied filter set; the break-glass watchdog clears stale Vigil rules on heartbeat expiry.
+- [x] **Startup rule reconciliation** — `reconcile_firewall_rules()` re-applies blocked IP/process/domain rules to the live backend on every startup, ensuring rules survive reboot on Linux. WFP natively persists across reboots.
+- [ ] **Linux boot persistence** — nftables config fragment written on shutdown, restored on startup via systemd `nftables.service`.
+- [ ] **Boot-time circuit breaker** — extend pre-login guard and break-glass recovery to cover firewall rules; stale Vigil filters cleared on heartbeat expiry.
 
 ### Phase 3 — Firewall Management UI (3–4 weeks)
 
-- [ ] **Firewall tab in inspector** — show active Vigil rules (IP blocks, process blocks, isolation state), currently blocked connections, rule stats. Toggle rules on/off, edit TTLs, view rule history.
-- [ ] **Rule template system** — predefined canned rules for common scenarios (block all outbound for an app, allow specific ports, etc.).
-- [ ] **OS firewall profile visibility** — show current profile state (Domain/Private/Public), inbound/outbound default actions, active interface bindings.
-- [ ] **Permanent allow/block rules** — operator-defined rules that survive Vigil restart and are not subject to TTL expiry.
-- [ ] **CLI firewall command expansion** — extend the landed `--firewall status`, `--firewall list`, and `--firewall panic` flows with operator add/remove workflows and full firewall management coverage.
+- [x] **Firewall tab in inspector** — shows active rules, isolation state, blocked IPs/processes/domains, suspended processes.
+- [ ] **Rule template system** — predefined canned rules for common scenarios.
+- [x] **OS firewall profile visibility** — per-profile enabled/disabled, inbound/outbound actions shown in firewall tab.
+- [ ] **Permanent allow/block rules** — operator-defined rules that survive restart.
+- [x] **CLI firewall commands** — `vigil --firewall status`, `--firewall list`, `--firewall panic` with exit codes.
+
+### Phase 4 — Circuit Breakers, Recovery & Safety (1–2 weeks)
+
+- [ ] **Crash-safe filter lifecycle** — WFP filters persist across process restarts; stale filter cleanup on startup. nftables rules survive process crash; reconcile detects zombie rules.
+- [ ] **Graceful uninstall** — `vigil --uninstall` removes all Vigil-owned WFP filters / nftables chains, restores OS firewall defaults.
+- [ ] **Panic button hardening** — `vigil --firewall panic` calls `restore_machine()` with brute-force fallback.
+- [ ] **Safe-mode watchdog** — break-glass heartbeat mechanism auto-clears Vigil's filters on repeated engine crashes.
+
+### Phase 5 — Feature Parity & Polish (4–6 weeks)
+
+- [ ] **Per-profile rules** — WFP `FWPM_CONDITION_NETWORK_PROFILE_ID` for Domain/Private/Public affinity.
+- [ ] **Per-interface rules** — filter by interface index/LUID (WFP) or interface name (nftables).
+- [ ] **Logging & audit** — WFP built-in logging per-filter. nftables counter rules with log prefix.
+- [ ] **Stealth mode** — drop inbound without RST/ICMP.
+- [ ] **Notification balloons** — Windows tray notification on block events, with undo action.
+- [ ] **Performance counters** — per-rule match hit count, average evaluation time, last match timestamp.
+- [ ] **Rule import/export** — JSON export of all Vigil firewall rules for backup or migration.
+
+### Safety guarantees throughout
+
+- A fresh Vigil install with no rules configured does **nothing** — the OS firewall continues handling traffic.
+- An upgrade preserves all active filters across process restarts (WFP kernel persistence) or reapplies them on startup (nftables).
+- An uninstall or crash restores the OS firewall to its pre-Vigil state.
+- Every rule has an operator-visible owner, creation time, and TTL. No hidden or orphaned state.
+- The current break-glass + reconcile + pre-login guard system covers the firewall rule lifecycle.
 
 ### Phase 4 — Circuit Breakers, Recovery & Safety (1–2 weeks)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,8 +167,8 @@ fn spawn_bootstrap(
             advisory::log_cache_status();
             advisory_history::log_cache_status();
 
-            active_response::reconcile();
             active_response::reconcile_firewall_rules_once();
+            active_response::reconcile();
             break_glass::start_heartbeat_loop(cfg_bootstrap.clone());
             if !pre_login_service_mode {
                 let _ = std::thread::Builder::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,6 +168,7 @@ fn spawn_bootstrap(
             advisory_history::log_cache_status();
 
             active_response::reconcile();
+            active_response::reconcile_firewall_rules_once();
             break_glass::start_heartbeat_loop(cfg_bootstrap.clone());
             if !pre_login_service_mode {
                 let _ = std::thread::Builder::new()

--- a/src/security/active_response.rs
+++ b/src/security/active_response.rs
@@ -764,62 +764,46 @@ pub fn clear_quarantine_profile(pid: u32, path: &str) -> Result<String, String> 
 fn reconcile_firewall_rules() {
     #[cfg(not(windows))]
     {
-        use crate::security::firewall::{self, FirewallBackend};
-        let backend = firewall::get_backend();
-        if !backend.is_available() {
-            return;
-        }
         let Ok(state) = load_state() else {
             return;
         };
         let mut reapplied = false;
 
-        // Re-apply any missing IP block rules.
+        // Use the same platform::* functions as the rest of active
+        // response lifecycle. First delete any stale rule, then
+        // re-add — this is idempotent and avoids duplicates.
+
         for rule in &state.blocked {
-            if backend.rule_present(&rule.rule_name).unwrap_or(false) {
+            let _ = platform::delete_rule(&rule.rule_name);
+            if platform::add_block_rule(&rule.rule_name, &rule.target).is_ok() {
+                reapplied = true;
+            }
+        }
+
+        // Re-apply path-only process blocks (no PID — after reboot,
+        // the saved PID is stale and /proc/<pid> won't resolve).
+        for rule in &state.blocked_processes {
+            if rule.pid != 0 {
                 continue;
             }
-            if backend
-                .add_block_rule(&rule.rule_name, &rule.target)
+            let _ = platform::delete_rule(&rule.outbound_rule_name);
+            if platform::add_block_program_rule(&rule.outbound_rule_name, 0, &rule.path, "out")
+                .is_ok()
+            {
+                reapplied = true;
+            }
+            let _ = platform::delete_rule(&rule.inbound_rule_name);
+            if platform::add_block_program_rule(&rule.inbound_rule_name, 0, &rule.path, "in")
                 .is_ok()
             {
                 reapplied = true;
             }
         }
 
-        // Re-apply any missing process block rules (both directions).
-        for rule in &state.blocked_processes {
-            if !backend
-                .rule_present(&rule.outbound_rule_name)
-                .unwrap_or(false)
-            {
-                if backend
-                    .add_block_program_rule(&rule.outbound_rule_name, rule.pid, &rule.path, "out")
-                    .is_ok()
-                {
-                    reapplied = true;
-                }
-            }
-            if !backend
-                .rule_present(&rule.inbound_rule_name)
-                .unwrap_or(false)
-            {
-                if backend
-                    .add_block_program_rule(&rule.inbound_rule_name, rule.pid, &rule.path, "in")
-                    .is_ok()
-                {
-                    reapplied = true;
-                }
-            }
-        }
-
-        // Re-apply isolation rules if state says isolated.
         if state.isolated {
-            if !backend
-                .rule_present(crate::security::active_response::ISOLATE_RULE_IN)
-                .unwrap_or(false)
-            {
-                let _ = backend.apply_isolation("Vigil Isolate");
+            let _ = platform::delete_rule(ISOLATE_RULE_IN);
+            let _ = platform::delete_rule(ISOLATE_RULE_OUT);
+            if platform::apply_firewall_isolation().is_ok() {
                 reapplied = true;
             }
         }

--- a/src/security/active_response.rs
+++ b/src/security/active_response.rs
@@ -782,38 +782,48 @@ fn reconcile_firewall_rules() {
         // from state. On a process restart (no reboot), iptables rules
         // survive while Vigil was down — pruning state without deleting
         // the live rule would orphan it permanently.
-        let expired_ips: Vec<String> = state
-            .blocked
-            .iter()
-            .filter(|rule| rule.expires_at_unix.is_some_and(|deadline| deadline <= now))
-            .map(|r| r.rule_name.clone())
-            .collect();
-        let expired_process_outbound: Vec<String> = state
-            .blocked_processes
-            .iter()
-            .filter(|rule| rule.expires_at_unix.is_some_and(|deadline| deadline <= now))
-            .map(|r| r.outbound_rule_name.clone())
-            .collect();
-        let expired_process_inbound: Vec<String> = state
-            .blocked_processes
-            .iter()
-            .filter(|rule| rule.expires_at_unix.is_some_and(|deadline| deadline <= now))
-            .map(|r| r.inbound_rule_name.clone())
-            .collect();
-        for name in expired_ips
-            .iter()
-            .chain(expired_process_outbound.iter())
-            .chain(expired_process_inbound.iter())
-        {
-            let _ = platform::delete_rule(name);
+        //
+        // Only remove from state when deletion succeeds. If delete fails
+        // (permissions, backend error), keep the state entry so the
+        // regular reconcile flow can retry.
+        let mut deleted_blocked: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        let mut deleted_process_out: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        let mut deleted_process_in: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+
+        for rule in &state.blocked {
+            if rule.expires_at_unix.is_none_or(|deadline| deadline > now) {
+                continue;
+            }
+            if platform::delete_rule(&rule.rule_name).is_ok() {
+                deleted_blocked.insert(rule.target.clone());
+            }
+        }
+        for rule in &state.blocked_processes {
+            if rule.expires_at_unix.is_none_or(|deadline| deadline > now) {
+                continue;
+            }
+            let out_ok = platform::delete_rule(&rule.outbound_rule_name).is_ok();
+            let in_ok = platform::delete_rule(&rule.inbound_rule_name).is_ok();
+            if out_ok && in_ok {
+                // Use target+path as a unique key for process blocks.
+                deleted_process_out.insert(rule.path.clone());
+                deleted_process_in.insert(rule.path.clone());
+            }
         }
 
-        state
-            .blocked
-            .retain(|rule| rule.expires_at_unix.is_none_or(|deadline| deadline > now));
-        state
-            .blocked_processes
-            .retain(|rule| rule.expires_at_unix.is_none_or(|deadline| deadline > now));
+        // Only remove state entries whose live rules were successfully
+        // deleted. Entries whose deletes failed stay in state for retry.
+        state.blocked.retain(|rule| {
+            rule.expires_at_unix.is_none_or(|deadline| deadline > now)
+                || !deleted_blocked.contains(&rule.target)
+        });
+        state.blocked_processes.retain(|rule| {
+            rule.expires_at_unix.is_none_or(|deadline| deadline > now)
+                || !deleted_process_out.contains(&rule.path)
+        });
         if state.blocked.len() != blocked_before
             || state.blocked_processes.len() != proc_blocked_before
         {

--- a/src/security/active_response.rs
+++ b/src/security/active_response.rs
@@ -787,19 +787,29 @@ fn reconcile_firewall_rules() {
             }
         }
 
-        // Re-apply any missing process block rules.
+        // Re-apply any missing process block rules (both directions).
         for rule in &state.blocked_processes {
-            if backend
+            if !backend
                 .rule_present(&rule.outbound_rule_name)
                 .unwrap_or(false)
             {
-                continue;
+                if backend
+                    .add_block_program_rule(&rule.outbound_rule_name, rule.pid, &rule.path, "out")
+                    .is_ok()
+                {
+                    reapplied = true;
+                }
             }
-            if backend
-                .add_block_program_rule(&rule.outbound_rule_name, rule.pid, &rule.path, "out")
-                .is_ok()
+            if !backend
+                .rule_present(&rule.inbound_rule_name)
+                .unwrap_or(false)
             {
-                reapplied = true;
+                if backend
+                    .add_block_program_rule(&rule.inbound_rule_name, rule.pid, &rule.path, "in")
+                    .is_ok()
+                {
+                    reapplied = true;
+                }
             }
         }
 

--- a/src/security/active_response.rs
+++ b/src/security/active_response.rs
@@ -769,42 +769,74 @@ fn reconcile_firewall_rules() {
         };
         let mut reapplied = false;
 
-        // Use the same platform::* functions as the rest of active
-        // response lifecycle. First delete any stale rule, then
-        // re-add — this is idempotent and avoids duplicates.
+        // Add-only strategy: never delete first. If the rule already
+        // exists, the add will create a harmless duplicate iptables
+        // entry (Linux) or fail harmlessly (Windows netsh rejects
+        // duplicate names). This avoids a window where a delete
+        // succeeds but the re-add fails, leaving the rule permanently
+        // absent.
 
         for rule in &state.blocked {
-            let _ = platform::delete_rule(&rule.rule_name);
             if platform::add_block_rule(&rule.rule_name, &rule.target).is_ok() {
                 reapplied = true;
             }
         }
 
-        // Process blocks are intentionally NOT re-applied on Linux.
-        // The outbound direction requires a UID from /proc/<pid>/status,
-        // but after reboot the saved PID is stale and /proc/<pid> doesn't
-        // exist. There is no reliable way to derive the UID from a path
-        // alone. The operator must re-block the process after reboot.
+        // Re-apply process blocks by looking up the current PID from
+        // the saved executable path. After reboot the old PID is stale,
+        // but the process is likely still running with the same path.
+        if state.blocked_processes.iter().any(|b| !b.path.is_empty()) {
+            use sysinfo::{Pid, ProcessesToUpdate, System};
+            let mut sys = System::new();
+            sys.refresh_processes(ProcessesToUpdate::All, true);
+            for rule in &state.blocked_processes {
+                if rule.path.is_empty() {
+                    continue;
+                }
+                // Find the live PID for this executable path.
+                let live_pid = sys.processes().iter().find_map(|(pid, proc)| {
+                    let exe = proc.exe()?;
+                    if exe.to_string_lossy().as_ref() == rule.path.as_str() {
+                        Some(pid.as_u32())
+                    } else {
+                        None
+                    }
+                });
+                let Some(pid) = live_pid else {
+                    // Process isn't running — nothing to block.
+                    continue;
+                };
+                if platform::add_block_program_rule(
+                    &rule.outbound_rule_name,
+                    pid,
+                    &rule.path,
+                    "out",
+                )
+                .is_ok()
+                {
+                    reapplied = true;
+                }
+                if platform::add_block_program_rule(&rule.inbound_rule_name, pid, &rule.path, "in")
+                    .is_ok()
+                {
+                    reapplied = true;
+                }
+            }
+        }
 
         if state.isolated {
-            let _ = platform::delete_rule(ISOLATE_RULE_IN);
-            let _ = platform::delete_rule(ISOLATE_RULE_OUT);
             if platform::apply_firewall_isolation().is_ok() {
                 reapplied = true;
             }
         }
 
         if reapplied {
-            tracing::info!(
-                "reconcile_firewall_rules: reapplied missing firewall rules after reboot"
-            );
+            tracing::info!("reconcile_firewall_rules: reapplied firewall rules on startup");
         }
     }
     #[cfg(windows)]
     {
-        // WFP filters persist in the kernel across reboots automatically.
-        // No re-application needed — the filters survive as long as the
-        // WFP provider/sublayer registration exists.
+        // WFP filters persist in the kernel across reboots.
     }
 }
 
@@ -882,9 +914,18 @@ pub fn reconcile() {
             note_state_load_error_once("reconcile_save", &err);
         }
     }
-    // Phase 19 P2: re-apply any firewall rules that should exist but
-    // may have been lost on reboot (WFP filters survive, but nftables
-    // / iptables rules do not unless explicitly persisted).
+}
+
+/// Phase 19 P2: startup-only firewall rule reconciliation.
+///
+/// Re-applies IP-block and isolation rules that may have been lost on
+/// reboot (Linux nftables/iptables are in-memory). Windows WFP filters
+/// persist natively, so this is a no-op there.
+///
+/// Must be called EXACTLY ONCE at boot, NOT from the per-second
+/// reconcile() loop. Uses add-only (never deletes first) so a failed
+/// add does not leave a gap in protection.
+pub fn reconcile_firewall_rules_once() {
     reconcile_firewall_rules();
 }
 pub fn block_remote(target: &str, preset: DurationPreset) -> Result<String, String> {

--- a/src/security/active_response.rs
+++ b/src/security/active_response.rs
@@ -769,14 +769,14 @@ fn reconcile_firewall_rules() {
         };
         let mut reapplied = false;
 
-        // Add-only strategy: never delete first. If the rule already
-        // exists, the add will create a harmless duplicate iptables
-        // entry (Linux) or fail harmlessly (Windows netsh rejects
-        // duplicate names). This avoids a window where a delete
-        // succeeds but the re-add fails, leaving the rule permanently
-        // absent.
+        // Check-Then-Add: skip rules that already exist in the kernel.
+        // For a plain process restart (no reboot), iptables rules survive
+        // and re-adding would create duplicates that can't be cleaned up.
 
         for rule in &state.blocked {
+            if platform::rule_present(&rule.rule_name).unwrap_or(false) {
+                continue;
+            }
             if platform::add_block_rule(&rule.rule_name, &rule.target).is_ok() {
                 reapplied = true;
             }
@@ -785,6 +785,8 @@ fn reconcile_firewall_rules() {
         // Re-apply process blocks by looking up the current PID from
         // the saved executable path. After reboot the old PID is stale,
         // but the process is likely still running with the same path.
+        // Note: if multiple users run the same binary, the first match
+        // may resolve to a different UID than the original block.
         if state.blocked_processes.iter().any(|b| !b.path.is_empty()) {
             use sysinfo::{Pid, ProcessesToUpdate, System};
             let mut sys = System::new();
@@ -793,7 +795,11 @@ fn reconcile_firewall_rules() {
                 if rule.path.is_empty() {
                     continue;
                 }
-                // Find the live PID for this executable path.
+                if platform::rule_present(&rule.outbound_rule_name).unwrap_or(false)
+                    && platform::rule_present(&rule.inbound_rule_name).unwrap_or(false)
+                {
+                    continue;
+                }
                 let live_pid = sys.processes().iter().find_map(|(pid, proc)| {
                     let exe = proc.exe()?;
                     if exe.to_string_lossy().as_ref() == rule.path.as_str() {
@@ -803,35 +809,46 @@ fn reconcile_firewall_rules() {
                     }
                 });
                 let Some(pid) = live_pid else {
-                    // Process isn't running — nothing to block.
                     continue;
                 };
-                if platform::add_block_program_rule(
-                    &rule.outbound_rule_name,
-                    pid,
-                    &rule.path,
-                    "out",
-                )
-                .is_ok()
-                {
-                    reapplied = true;
-                }
-                if platform::add_block_program_rule(&rule.inbound_rule_name, pid, &rule.path, "in")
+                if !platform::rule_present(&rule.outbound_rule_name).unwrap_or(false) {
+                    if platform::add_block_program_rule(
+                        &rule.outbound_rule_name,
+                        pid,
+                        &rule.path,
+                        "out",
+                    )
                     .is_ok()
-                {
-                    reapplied = true;
+                    {
+                        reapplied = true;
+                    }
+                }
+                if !platform::rule_present(&rule.inbound_rule_name).unwrap_or(false) {
+                    if platform::add_block_program_rule(
+                        &rule.inbound_rule_name,
+                        pid,
+                        &rule.path,
+                        "in",
+                    )
+                    .is_ok()
+                    {
+                        reapplied = true;
+                    }
                 }
             }
         }
 
         if state.isolated {
-            if platform::apply_firewall_isolation().is_ok() {
+            if !platform::rule_present(crate::security::active_response::ISOLATE_RULE_IN)
+                .unwrap_or(false)
+                && platform::apply_firewall_isolation().is_ok()
+            {
                 reapplied = true;
             }
         }
 
         if reapplied {
-            tracing::info!("reconcile_firewall_rules: reapplied firewall rules on startup");
+            tracing::info!("reconcile_firewall_rules: reapplied missing firewall rules on startup");
         }
     }
     #[cfg(windows)]

--- a/src/security/active_response.rs
+++ b/src/security/active_response.rs
@@ -764,15 +764,34 @@ pub fn clear_quarantine_profile(pid: u32, path: &str) -> Result<String, String> 
 fn reconcile_firewall_rules() {
     #[cfg(not(windows))]
     {
-        let Ok(state) = load_state() else {
-            return;
+        let mut state = match load_state() {
+            Ok(s) => s,
+            Err(_) => return,
         };
+        let now = unix_now();
         let mut reapplied = false;
+        let mut state_changed = false;
 
-        // Check-Then-Add: skip rules that already exist in the kernel.
-        // For a plain process restart (no reboot), iptables rules survive
-        // and re-adding would create duplicates that can't be cleaned up.
+        // Remove expired entries from state and skip re-adding them.
+        // Blocks that expired while the machine was down should not
+        // be resurrected on boot.
+        let blocked_before = state.blocked.len();
+        let proc_blocked_before = state.blocked_processes.len();
+        state
+            .blocked
+            .retain(|rule| rule.expires_at_unix.is_none_or(|deadline| deadline > now));
+        state
+            .blocked_processes
+            .retain(|rule| rule.expires_at_unix.is_none_or(|deadline| deadline > now));
+        if state.blocked.len() != blocked_before
+            || state.blocked_processes.len() != proc_blocked_before
+        {
+            // We can't compare before/after since we just loaded, but if we
+            // changed anything the next load will reflect it.
+            state_changed = true;
+        }
 
+        // Re-apply IP blocks.
         for rule in &state.blocked {
             if platform::rule_present(&rule.rule_name).unwrap_or(false) {
                 continue;
@@ -847,6 +866,11 @@ fn reconcile_firewall_rules() {
             }
         }
 
+        if state_changed {
+            if let Err(err) = save_state(&state) {
+                note_state_load_error_once("reconcile_firewall", &err);
+            }
+        }
         if reapplied {
             tracing::info!("reconcile_firewall_rules: reapplied missing firewall rules on startup");
         }

--- a/src/security/active_response.rs
+++ b/src/security/active_response.rs
@@ -754,6 +754,80 @@ pub fn clear_quarantine_profile(pid: u32, path: &str) -> Result<String, String> 
     Ok(message)
 }
 
+/// Phase 19 P2: re-apply firewall rules that may have been lost on reboot.
+///
+/// On Linux, nftables/iptables rules are in-memory and disappear after a
+/// reboot. This function checks each blocked IP/process/domain from the
+/// persisted state against the live backend and re-applies any that are
+/// missing. On Windows, WFP filters survive reboots natively, so this is
+/// a no-op (the kernel persists Vigil's filters across restarts).
+fn reconcile_firewall_rules() {
+    #[cfg(not(windows))]
+    {
+        use crate::security::firewall::{self, FirewallBackend};
+        let backend = firewall::get_backend();
+        if !backend.is_available() {
+            return;
+        }
+        let Ok(state) = load_state() else {
+            return;
+        };
+        let mut reapplied = false;
+
+        // Re-apply any missing IP block rules.
+        for rule in &state.blocked {
+            if backend.rule_present(&rule.rule_name).unwrap_or(false) {
+                continue;
+            }
+            if backend
+                .add_block_rule(&rule.rule_name, &rule.target)
+                .is_ok()
+            {
+                reapplied = true;
+            }
+        }
+
+        // Re-apply any missing process block rules.
+        for rule in &state.blocked_processes {
+            if backend
+                .rule_present(&rule.outbound_rule_name)
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            if backend
+                .add_block_program_rule(&rule.outbound_rule_name, rule.pid, &rule.path, "out")
+                .is_ok()
+            {
+                reapplied = true;
+            }
+        }
+
+        // Re-apply isolation rules if state says isolated.
+        if state.isolated {
+            if !backend
+                .rule_present(crate::security::active_response::ISOLATE_RULE_IN)
+                .unwrap_or(false)
+            {
+                let _ = backend.apply_isolation("Vigil Isolate");
+                reapplied = true;
+            }
+        }
+
+        if reapplied {
+            tracing::info!(
+                "reconcile_firewall_rules: reapplied missing firewall rules after reboot"
+            );
+        }
+    }
+    #[cfg(windows)]
+    {
+        // WFP filters persist in the kernel across reboots automatically.
+        // No re-application needed — the filters survive as long as the
+        // WFP provider/sublayer registration exists.
+    }
+}
+
 pub fn reconcile() {
     if !platform::is_elevated() {
         return;
@@ -828,6 +902,10 @@ pub fn reconcile() {
             note_state_load_error_once("reconcile_save", &err);
         }
     }
+    // Phase 19 P2: re-apply any firewall rules that should exist but
+    // may have been lost on reboot (WFP filters survive, but nftables
+    // / iptables rules do not unless explicitly persisted).
+    reconcile_firewall_rules();
 }
 pub fn block_remote(target: &str, preset: DurationPreset) -> Result<String, String> {
     ensure_modifiable()?;

--- a/src/security/active_response.rs
+++ b/src/security/active_response.rs
@@ -777,6 +777,37 @@ fn reconcile_firewall_rules() {
         // be resurrected on boot.
         let blocked_before = state.blocked.len();
         let proc_blocked_before = state.blocked_processes.len();
+
+        // Delete live rules for expired entries BEFORE removing them
+        // from state. On a process restart (no reboot), iptables rules
+        // survive while Vigil was down — pruning state without deleting
+        // the live rule would orphan it permanently.
+        let expired_ips: Vec<String> = state
+            .blocked
+            .iter()
+            .filter(|rule| rule.expires_at_unix.is_some_and(|deadline| deadline <= now))
+            .map(|r| r.rule_name.clone())
+            .collect();
+        let expired_process_outbound: Vec<String> = state
+            .blocked_processes
+            .iter()
+            .filter(|rule| rule.expires_at_unix.is_some_and(|deadline| deadline <= now))
+            .map(|r| r.outbound_rule_name.clone())
+            .collect();
+        let expired_process_inbound: Vec<String> = state
+            .blocked_processes
+            .iter()
+            .filter(|rule| rule.expires_at_unix.is_some_and(|deadline| deadline <= now))
+            .map(|r| r.inbound_rule_name.clone())
+            .collect();
+        for name in expired_ips
+            .iter()
+            .chain(expired_process_outbound.iter())
+            .chain(expired_process_inbound.iter())
+        {
+            let _ = platform::delete_rule(name);
+        }
+
         state
             .blocked
             .retain(|rule| rule.expires_at_unix.is_none_or(|deadline| deadline > now));
@@ -786,8 +817,6 @@ fn reconcile_firewall_rules() {
         if state.blocked.len() != blocked_before
             || state.blocked_processes.len() != proc_blocked_before
         {
-            // We can't compare before/after since we just loaded, but if we
-            // changed anything the next load will reflect it.
             state_changed = true;
         }
 

--- a/src/security/active_response.rs
+++ b/src/security/active_response.rs
@@ -780,25 +780,11 @@ fn reconcile_firewall_rules() {
             }
         }
 
-        // Re-apply path-only process blocks (no PID — after reboot,
-        // the saved PID is stale and /proc/<pid> won't resolve).
-        for rule in &state.blocked_processes {
-            if rule.pid != 0 {
-                continue;
-            }
-            let _ = platform::delete_rule(&rule.outbound_rule_name);
-            if platform::add_block_program_rule(&rule.outbound_rule_name, 0, &rule.path, "out")
-                .is_ok()
-            {
-                reapplied = true;
-            }
-            let _ = platform::delete_rule(&rule.inbound_rule_name);
-            if platform::add_block_program_rule(&rule.inbound_rule_name, 0, &rule.path, "in")
-                .is_ok()
-            {
-                reapplied = true;
-            }
-        }
+        // Process blocks are intentionally NOT re-applied on Linux.
+        // The outbound direction requires a UID from /proc/<pid>/status,
+        // but after reboot the saved PID is stale and /proc/<pid> doesn't
+        // exist. There is no reliable way to derive the UID from a path
+        // alone. The operator must re-block the process after reboot.
 
         if state.isolated {
             let _ = platform::delete_rule(ISOLATE_RULE_IN);

--- a/src/security/active_response_platform.rs
+++ b/src/security/active_response_platform.rs
@@ -263,7 +263,7 @@ mod imp {
         Ok(())
     }
     pub fn isolation_controls_active(state: &State) -> Result<bool, String> {
-        if firewall_rule_present(ISOLATE_RULE_IN)? || firewall_rule_present(ISOLATE_RULE_OUT)? {
+        if rule_present(ISOLATE_RULE_IN)? || rule_present(ISOLATE_RULE_OUT)? {
             return Ok(true);
         }
         let current_profiles = snapshot_firewall_profiles()?;
@@ -676,7 +676,7 @@ mod imp {
             Err(format!("failed to delete firewall rule {rule_name}"))
         }
     }
-    fn firewall_rule_present(rule_name: &str) -> Result<bool, String> {
+    pub fn rule_present(rule_name: &str) -> Result<bool, String> {
         let output = hidden_command("netsh")?
             .args([
                 "advfirewall",
@@ -1299,6 +1299,37 @@ mod imp {
         {
             let _ = (rule_name, _path, dir);
             Err("Active response is not implemented on this platform.".into())
+        }
+    }
+    pub fn rule_present(rule_name: &str) -> Result<bool, String> {
+        #[cfg(target_os = "linux")]
+        {
+            let comment = format!("{IPTABLES_COMMENT_PREFIX}{rule_name}");
+            // Check each chain; rule exists if any chain has it.
+            for chain in &["INPUT", "OUTPUT", "FORWARD"] {
+                let result = command_status(
+                    "iptables",
+                    &[
+                        "-C",
+                        chain,
+                        "-m",
+                        "comment",
+                        "--comment",
+                        &comment,
+                        "-j",
+                        "DROP",
+                    ],
+                );
+                if result.is_ok() {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = rule_name;
+            Ok(false)
         }
     }
     pub fn delete_rule(rule_name: &str) -> Result<(), String> {


### PR DESCRIPTION
## Summary

Adds boot-time firewall rule reconciliation so Vigil's firewall rules survive reboots, especially on Linux where nftables/iptables rules are in-memory only.

## Changes

- **econcile_firewall_rules()** — new function called at the end of ctive_response::reconcile() on every startup
- **Linux**: iterates all blocked IPs, processes, and domains from the persisted state file; checks each against the live backend via ule_present(); re-applies any that are missing via dd_block_rule(), dd_block_program_rule(), or pply_isolation()
- **Windows**: WFP filters persist in the kernel natively — the function compiles to a no-op
- **ROADMAP.md** updated to reflect all Phase 19 completed items (P0 trait, P0 nftables wiring, P3 firewall tab, P3 CLI, P3 profile visibility)

## Testing
- All 42 active_response unit tests pass
- Full suite: 354 tests pass