### PR TITLE
Fix XDP backend LinuxCommandRunner import

### DIFF
--- a/src/security/firewall/xdp.rs
+++ b/src/security/firewall/xdp.rs
@@ -30,8 +30,8 @@
 
 use super::{FirewallBackend, FirewallProfileState, FirewallSnapshot};
 use crate::security::linux_command_plan::{
-    resolvectl_flush_caches, ss_kill_tcp_connection, systemd_resolve_flush_caches,
-    StdLinuxCommandRunner,
+    LinuxCommandRunner, StdLinuxCommandRunner, resolvectl_flush_caches, ss_kill_tcp_connection,
+    systemd_resolve_flush_caches,
 };
 use crate::security::linux_firewall_backend::{
     capture_iptables_policy_snapshot, select_firewall_backend, LinuxFirewallBackend,


### PR DESCRIPTION
## Summary
- import `LinuxCommandRunner` into `src/security/firewall/xdp.rs`
- restore method resolution for `StdLinuxCommandRunner.status()` and `.stdout()` calls
- unblock the `cargo clippy` failure introduced with the Phase 19 XDP backend merge

## Why
The merged Phase 19 change added several `StdLinuxCommandRunner` trait-method calls in `xdp.rs`, but the trait itself was not in scope. CI reported this as repeated `E0599` method-not-found errors plus follow-on inference failures.

## Validation
- matched the failure against the failing `CI` workflow log for the merged Phase 19 change
- confirmed `master` still lacked the import after the original PR merged
- kept the fix to the smallest possible source change