### PR TITLE
style: rustfmt Windows WFP foundation module

### DIFF
--- a/src/security/windows_wfp.rs
+++ b/src/security/windows_wfp.rs
@@ -11,8 +11,7 @@ use windows::Win32::System::LibraryLoader::{FreeLibrary, GetProcAddress, LoadLib
 
 const FWP_E_ALREADY_EXISTS_STATUS: u32 = 0x8032_0009;
 const VIGIL_WFP_PROVIDER_KEY: GUID = GUID::from_u128(0x3b6f3d34_6150_4e3c_9169_7df0c5f1cb52);
-const VIGIL_WFP_SUBLAYER_KEY: GUID =
-    GUID::from_u128(0xe7fae0d0_3af1_4b9f_88ea_ee11e08c9c4a);
+const VIGIL_WFP_SUBLAYER_KEY: GUID = GUID::from_u128(0xe7fae0d0_3af1_4b9f_88ea_ee11e08c9c4a);
 const VIGIL_WFP_SUBLAYER_WEIGHT: u16 = 0x7000;
 
 type FwpmEngineOpen0Fn = unsafe extern "system" fn(
@@ -76,7 +75,9 @@ impl WfpApi {
             (self.engine_open)(PCWSTR::null(), 0, std::ptr::null(), &session, &mut handle)
         };
         if status != 0 {
-            return Err(format!("open WFP engine session failed with 0x{status:08x}"));
+            return Err(format!(
+                "open WFP engine session failed with 0x{status:08x}"
+            ));
         }
         Ok(WfpSession { api: self, handle })
     }

--- a/src/security/windows_wfp.rs
+++ b/src/security/windows_wfp.rs
@@ -57,8 +57,8 @@ struct WfpApi {
 
 impl WfpApi {
     unsafe fn load() -> Result<Self, String> {
-        let module = LoadLibraryW(w!("Fwpuclnt.dll"))
-            .map_err(|err| format!("load Fwpuclnt.dll: {err}"))?;
+        let module =
+            LoadLibraryW(w!("Fwpuclnt.dll")).map_err(|err| format!("load Fwpuclnt.dll: {err}"))?;
         Ok(Self {
             module,
             engine_open: load_symbol(module, b"FwpmEngineOpen0\0")?,


### PR DESCRIPTION
## Summary

Apply the `cargo fmt` formatting expected by CI to `src/security/windows_wfp.rs`.

## Why

PR #311 merged with the new Windows WFP foundation code, but the file still differs from `rustfmt` output, which is enough to fail the format check.

## Changes

- format the WFP sublayer GUID constant onto one line
- format the `LoadLibraryW` assignment the way `rustfmt` expects
- wrap the long `open WFP engine session failed` error return as `rustfmt` outputs it

## Validation

- matched the failing `cargo fmt --check` diff from the CI log for PR #311

## Risk

Formatting only; no behavior change.