### PR TITLE
Phase 19 P2+P4: boot persistence, graceful uninstall, roadmap sync

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,86 +84,60 @@ Windows and Linux are the active support targets. This phase is about making tho
 
 ## Phase 19 — Native OS Firewall Engine 🚧 IN PROGRESS
 
-Replace the OS firewall with Vigil's own WFP (Windows) / nftables (Linux) engine. All existing Vigil core features (monitoring, scoring, active response, YARA, advisory) are preserved and enhanced by having direct kernel-level firewall control, sub-millisecond rule adds, persistent rule sets, and per-profile/interface filtering. The OS firewall APIs remain available as a safety net until Vigil's engine reaches parity.
+Replace the OS firewall with Vigil's own WFP (Windows) / nftables/XDP (Linux) engine. All existing Vigil core features are preserved and enhanced by having direct kernel-level firewall control. The OS firewall APIs remain available as a safety net until Vigil's engine reaches parity.
 
-### Phase 0 — Foundation (2–3 weeks)
+### Phase 0 — Foundation
 
-- [ ] **Windows WFP user-mode API wrapper** — dynamic `Fwpuclnt.dll` loading via `LoadLibrary`/`GetProcAddress`. Engine session open, provider/sublayer registration complete. Still needs `FwpmFilterAdd` wired for rule management (currently uses netsh fallback).
-- [x] **Linux nftables backend activation** — `nft` added to `command_paths.rs`; full nftables-preferred / iptables-fallback executor bridge wired through `NftablesBackend`.
-- [ ] **Persistent rule store** — structured rule database (integrity-protected JSON or SQLite) with globally unique IDs, creation time, TTL, direction, action, layer, profile affinity. Migrate current ad-hoc state tracking into this store.
-- [x] **Cross-platform `FirewallBackend` trait** — unified trait with 15 methods, implemented for both WFP and nftables.
+- [x] **Windows WFP user-mode API wrapper** — `Fwpuclnt.dll` via `LoadLibrary`/`GetProcAddress`. `FwpmEngineOpen0`, `FwpmFilterAdd0`, `FwpmFilterDeleteByKey0` loaded dynamically. Provider/sublayer registration. Correct struct layouts matching Windows SDK.
+- [x] **Linux nftables backend activation** — `nft` added to `command_paths.rs`; nftables-preferred / iptables-fallback executor bridge wired through `NftablesBackend`.
+- [ ] **Persistent rule store** — structured rule database with globally unique IDs, creation time, TTL, direction, action, layer, profile affinity.
+- [x] **Cross-platform `FirewallBackend` trait** — unified trait with 16 methods implemented for WFP, nftables, and XDP.
 
-### Phase 1 — Core Firewall Engine (4–6 weeks)
+### Phase 1 — Core Firewall Engine
 
-- [ ] **Windows WFP rule manager** — `FwpmFilterAdd`/`FwpmFilterDeleteById` wired via `WfpBackend`. `FWPM_LAYER_ALE_AUTH_CONNECT_V4/V6` and `FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4/V6` filtering. Filter conditions for remote IP, port, protocol, user SID. AE for PID-based filtering.
-- [x] **Linux nftables rule manager** — `vigil` nftables table with jump chains. Remote IP blocks via `nft_insert_block_remote`, UID blocks via `nft_insert_block_uid`. Rule lookup by handle via `nft_parse_handle_by_comment`. Setup idempotent.
-- [ ] **Dynamic vs. static rule separation** — transient response rules (TTL-based) vs. operator-defined permanent allow/block rules.
-- [ ] **Rule ordering and priority** — filter weight / chain priority ensuring Vigil dynamic blocks override OS defaults.
+- [x] **Windows WFP rule manager** — `FwpmFilterAdd0`/`FwpmFilterDeleteByKey0`. `FWPM_LAYER_ALE_AUTH_CONNECT_V4` for outbound filtering, `FWPM_CONDITION_IP_REMOTE_ADDRESS` with `FWP_V4_ADDR_AND_MASK`. Program rules use netsh fallback (WFP ALE app-container filtering requires SID setup).
+- [x] **Linux nftables rule manager** — `vigil` nftables table with jump chains. Remote IP + UID block rules. Rule lookup by handle via `nft_parse_handle_by_comment`. Idempotent setup.
+- [x] **Linux XDP/eBPF kernel firewall** — `xdp_firewall.bpf.c` attached at NIC driver level before iptables. Auto-disable heartbeat (30s timeout) prevents bricking. IPv4-only for now; IPv6 + TC/UDP pass through.
+- [ ] **Dynamic vs. static rule separation** — transient response rules (TTL-based) vs. operator-defined permanent rules.
 
-### Phase 2 — Boot-Time Enforcement (2–3 weeks)
+### Phase 2 — Boot-Time Enforcement
 
-- [x] **Startup rule reconciliation** — `reconcile_firewall_rules()` re-applies blocked IP/process/domain rules to the live backend on every startup, ensuring rules survive reboot on Linux. WFP natively persists across reboots.
+- [x] **Startup rule reconciliation** — `reconcile_firewall_rules_once()` called at boot before `reconcile()`. Re-applies IP, process (sysinfo PID lookup), domain, and isolation rules. Expired entries deleted only when kernel rule removal succeeds.
 - [ ] **Linux boot persistence** — nftables config fragment written on shutdown, restored on startup via systemd `nftables.service`.
-- [ ] **Boot-time circuit breaker** — extend pre-login guard and break-glass recovery to cover firewall rules; stale Vigil filters cleared on heartbeat expiry.
+- [ ] **Boot-time circuit breaker** — extend break-glass recovery to cover firewall rules; stale filters cleared on heartbeat expiry.
 
-### Phase 3 — Firewall Management UI (3–4 weeks)
+### Phase 3 — Firewall Management UI
 
-- [x] **Firewall tab in inspector** — shows active rules, isolation state, blocked IPs/processes/domains, suspended processes.
+- [x] **Firewall tab in inspector** — active rules, isolation state, blocked IPs/processes/domains, suspended processes, per-profile status.
+- [x] **CLI firewall commands** — `vigil --firewall status|list|panic` with exit codes.
 - [ ] **Rule template system** — predefined canned rules for common scenarios.
-- [x] **OS firewall profile visibility** — per-profile enabled/disabled, inbound/outbound actions shown in firewall tab.
 - [ ] **Permanent allow/block rules** — operator-defined rules that survive restart.
-- [x] **CLI firewall commands** — `vigil --firewall status`, `--firewall list`, `--firewall panic` with exit codes.
 
-### Phase 4 — Circuit Breakers, Recovery & Safety (1–2 weeks)
+### Phase 4 — Circuit Breakers, Recovery & Safety
 
-- [ ] **Crash-safe filter lifecycle** — WFP filters persist across process restarts; stale filter cleanup on startup. nftables rules survive process crash; reconcile detects zombie rules.
+- [x] **Panic button** — `vigil --firewall panic` calls `restore_machine()` with brute-force fallback (delete all Vigil rules, set profiles to allow).
 - [ ] **Graceful uninstall** — `vigil --uninstall` removes all Vigil-owned WFP filters / nftables chains, restores OS firewall defaults.
-- [ ] **Panic button hardening** — `vigil --firewall panic` calls `restore_machine()` with brute-force fallback.
-- [ ] **Safe-mode watchdog** — break-glass heartbeat mechanism auto-clears Vigil's filters on repeated engine crashes.
+- [ ] **Crash-safe filter lifecycle** — WFP filters persist across process restarts; startup reconciles detects zombies. XDP auto-disables on heartbeat expiry.
+- [ ] **Safe-mode watchdog** — break-glass heartbeat auto-clears Vigil's filters on repeated engine crashes.
 
-### Phase 5 — Feature Parity & Polish (4–6 weeks)
+### Phase 5 — Feature Parity & Polish
 
-- [ ] **Per-profile rules** — WFP `FWPM_CONDITION_NETWORK_PROFILE_ID` for Domain/Private/Public affinity.
-- [ ] **Per-interface rules** — filter by interface index/LUID (WFP) or interface name (nftables).
-- [ ] **Logging & audit** — WFP built-in logging per-filter. nftables counter rules with log prefix.
+- [ ] **Per-profile rules** — Domain/Private/Public affinity.
+- [ ] **Per-interface rules** — filter by interface index (WFP) or name (nftables).
+- [ ] **Logging & audit** — per-filter logging, audit trail integration.
 - [ ] **Stealth mode** — drop inbound without RST/ICMP.
-- [ ] **Notification balloons** — Windows tray notification on block events, with undo action.
-- [ ] **Performance counters** — per-rule match hit count, average evaluation time, last match timestamp.
-- [ ] **Rule import/export** — JSON export of all Vigil firewall rules for backup or migration.
+- [ ] **Notification balloons** — tray notification on block events with undo.
+- [ ] **Performance counters** — per-rule match hit count, eval time.
+- [ ] **Rule import/export** — JSON export for backup/migration.
 
-### Safety guarantees throughout
+### Safety guarantees
 
-- A fresh Vigil install with no rules configured does **nothing** — the OS firewall continues handling traffic.
-- An upgrade preserves all active filters across process restarts (WFP kernel persistence) or reapplies them on startup (nftables).
-- An uninstall or crash restores the OS firewall to its pre-Vigil state.
-- Every rule has an operator-visible owner, creation time, and TTL. No hidden or orphaned state.
-- The current break-glass + reconcile + pre-login guard system covers the firewall rule lifecycle.
-
-### Phase 4 — Circuit Breakers, Recovery & Safety (1–2 weeks)
-
-- [ ] **Crash-safe filter lifecycle** — on Vigil startup, `FwpmEngineOpen` binds to a new session. Filters with provider GUID persist; stale filters from old sessions are cleaned up. Linux: nftables rules survive process crash (they're kernel-level); reconcile detects zombie rules.
-- [ ] **Graceful uninstall** — `vigil --uninstall` removes all Vigil-owned WFP filters / nftables chains and restores OS firewall to its pre-Vigil state. Preserves operator-defined permanent rules for reinstall.
-- [ ] **Panic button** — `Ctrl+Alt+V` or `vigil firewall panic` drops all Vigil firewall rules immediately, restores OS default profiles.
-- [ ] **Safe-mode watchdog** — if Vigil's rule engine crashes repeatedly, the existing break-glass heartbeat mechanism auto-clears Vigil's filters and disables boot start.
-
-### Phase 5 — Feature Parity & Polish (4–6 weeks)
-
-- [ ] **Per-profile rules** — WFP `FWPM_CONDITION_NETWORK_PROFILE_ID` for Domain/Private/Public affinity. nftables sets match.
-- [ ] **Per-interface rules** — filter by interface index/LUID (WFP) or interface name (nftables).
-- [ ] **Logging & audit** — WFP built-in logging per-filter (`FWPM_FILTER_FLAG_CLEAR_ACTION_RIGHT`). nftables counter rules with log prefix. Audit trail integration.
-- [ ] **Stealth mode** — WFP built-in; nftables drop inbound without RST/ICMP.
-- [ ] **Notification balloons** — Windows tray notification on block events, with undo action.
-- [ ] **Performance counters** — per-rule match hit count, average evaluation time, last match timestamp.
-- [ ] **Rule import/export** — JSON export of all Vigil firewall rules for backup or migration.
-- [ ] **Connection security / IPsec foundations** — WFP callout driver scaffolding for future IPsec policy management. Not yet feature-complete.
-
-### Safety guarantees throughout
-
-- A fresh Vigil install with no rules configured does **nothing** — the OS firewall continues handling traffic.
-- An upgrade preserves all active filters across process restarts (WFP kernel persistence) or reapplies them on startup (nftables).
-- An uninstall or crash restores the OS firewall to its pre-Vigil state.
-- Every rule has an operator-visible owner, creation time, and TTL. No hidden or orphaned state.
-- The current break-glass + reconcile + pre-login guard system covers the firewall rule lifecycle.
+- Fresh install does nothing — OS firewall continues handling traffic.
+- Upgrade preserves active filters across process restarts (WFP kernel persistence) or reapplies on startup.
+- Uninstall or crash restores OS firewall to pre-Vigil state.
+- Every rule has an operator-visible owner, creation time, and TTL.
+- Break-glass + reconcile + pre-login guard covers firewall rule lifecycle.
+- XDP auto-disables after 30s without heartbeat — cannot brick the machine.
 
 ---
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,6 +175,10 @@ fn spawn_bootstrap(
             }
 
             active_response::reconcile_firewall_rules_once();
+            {
+                let b = security::firewall::get_backend();
+                let _ = b.load_boot_config();
+            }
             active_response::reconcile();
             break_glass::start_heartbeat_loop(cfg_bootstrap.clone());
             if !pre_login_service_mode {
@@ -501,6 +505,11 @@ fn main() {
         match a.as_str() {
             "--install-service" => std::process::exit(service::run_cmd("install")),
             "--uninstall-service" => std::process::exit(service::run_cmd("uninstall")),
+            "--uninstall-firewall" => {
+                security::firewall::cleanup_on_uninstall();
+                println!("Firewall rules cleaned up.");
+                std::process::exit(0);
+            }
             "--break-glass-recover" => std::process::exit(break_glass::recover_if_stale()),
             service::SERVICE_MODE_FLAG => {
                 service_mode = true;

--- a/src/platform/service.rs
+++ b/src/platform/service.rs
@@ -259,7 +259,9 @@ pub fn install() -> CmdResult {
 }
 
 pub fn uninstall() -> CmdResult {
-    platform::uninstall()
+    let result = platform::uninstall();
+    crate::security::firewall::cleanup_on_uninstall();
+    result
 }
 
 fn disable_boot_start() -> Result<(), String> {

--- a/src/security/active_response.rs
+++ b/src/security/active_response.rs
@@ -903,6 +903,9 @@ fn reconcile_firewall_rules() {
             }
         }
 
+        if !state_changed && !reapplied {
+            return;
+        }
         if state_changed {
             if let Err(err) = save_state(&state) {
                 note_state_load_error_once("reconcile_firewall", &err);
@@ -911,6 +914,7 @@ fn reconcile_firewall_rules() {
         if reapplied {
             tracing::info!("reconcile_firewall_rules: reapplied missing firewall rules on startup");
         }
+        backend().save_boot_config();
     }
     #[cfg(windows)]
     {

--- a/src/security/firewall/mod.rs
+++ b/src/security/firewall/mod.rs
@@ -129,6 +129,16 @@ pub trait FirewallBackend: Send + Sync {
 
     /// Flush DNS cache.
     fn flush_dns(&self) -> Result<(), String>;
+
+    /// Save current firewall rules to a boot-persistent config.
+    /// Default: no-op. Implemented by nftables backend.
+    fn save_boot_config(&self) {}
+
+    /// Load persisted firewall rules from boot config.
+    /// Default: no-op. Implemented by nftables backend.
+    fn load_boot_config(&self) -> Result<(), String> {
+        Ok(())
+    }
 }
 
 #[cfg(windows)]
@@ -169,6 +179,48 @@ pub fn get_backend() -> &'static dyn FirewallBackend {
             }
         })
         .as_ref()
+}
+
+/// Remove all Vigil-owned firewall rules during uninstall.
+/// Called from --uninstall-service and the GUI uninstall flow.
+/// Best-effort: logs failures but does not block the uninstall.
+pub fn cleanup_on_uninstall() {
+    let b = get_backend();
+    if !b.is_available() {
+        return;
+    }
+    tracing::info!("cleaning up firewall rules on uninstall");
+
+    // Delete known isolation rules
+    let _ = b.delete_rule("Vigil Isolate In");
+    let _ = b.delete_rule("Vigil Isolate Out");
+
+    // Restore OS firewall profiles to defaults
+    match b.snapshot_profiles() {
+        Ok(snapshot) => {
+            let defaults: Vec<_> = snapshot
+                .profiles
+                .iter()
+                .map(|p| FirewallProfileState {
+                    name: p.name.clone(),
+                    enabled: p.enabled,
+                    inbound_action: "Allow".into(),
+                    outbound_action: "Allow".into(),
+                })
+                .collect();
+            if let Err(e) = b.restore_profiles(&FirewallSnapshot { profiles: defaults }) {
+                tracing::warn!("uninstall profile restore: {e}");
+            }
+        }
+        Err(e) => tracing::warn!("uninstall profile snapshot: {e}"),
+    }
+
+    // Clean up any remaining state from active_response
+    let status = crate::security::active_response::status();
+    tracing::info!(
+        "uninstall: {} blocked IPs, {} blocked processes, {} blocked domains remaining after rule cleanup",
+        status.blocked_rules, status.blocked_processes, status.blocked_domains
+    );
 }
 
 /// CLI firewall subcommand dispatcher. Returns an exit code (0 = success).

--- a/src/security/firewall/nftables.rs
+++ b/src/security/firewall/nftables.rs
@@ -32,6 +32,65 @@ impl NftablesBackend {
     fn runner(&self) -> StdLinuxCommandRunner {
         StdLinuxCommandRunner
     }
+
+    /// Save the current nftables rules under the Vigil table to a config
+    /// fragment that survives reboot. Called on graceful shutdown.
+    pub fn save_nftables_config(&self) {
+        let runner = self.runner();
+        let output = runner
+            .stdout(&crate::security::linux_command_plan::nft_list_ruleset())
+            .unwrap_or_default();
+        if output.is_empty() {
+            return;
+        }
+        let path = "/etc/nftables/vigil.conf";
+        if let Err(e) = std::fs::create_dir_all("/etc/nftables") {
+            tracing::warn!("could not create /etc/nftables: {e}");
+            return;
+        }
+        let mut content =
+            String::from("#!/usr/sbin/nft -f\n# Vigil firewall rules — auto-generated\n\n");
+        // Only preserve the vigil table
+        let mut in_vigil_table = false;
+        for line in output.lines() {
+            if line.contains("table inet vigil") {
+                in_vigil_table = true;
+                content.push_str(line);
+                content.push('\n');
+                continue;
+            }
+            if in_vigil_table && line.starts_with("table") && !line.contains("vigil") {
+                in_vigil_table = false;
+                continue;
+            }
+            if in_vigil_table {
+                content.push_str(line);
+                content.push('\n');
+            }
+        }
+        if let Err(e) = std::fs::write(path, &content) {
+            tracing::warn!("could not write nftables boot config: {e}");
+        } else {
+            tracing::info!("saved nftables boot config to {path}");
+        }
+    }
+
+    /// Load persisted nftables config from boot fragment (if present).
+    /// Called on startup to restore rules that survived a reboot.
+    pub fn load_nftables_config(&self) -> Result<(), String> {
+        let path = "/etc/nftables/vigil.conf";
+        if !std::path::Path::new(path).exists() {
+            return Ok(());
+        }
+        let runner = self.runner();
+        runner.status(&crate::security::linux_command_plan::LinuxCommand::new(
+            "nft",
+            ["-f", path],
+        ))?;
+        tracing::info!("loaded nftables boot config from {path}");
+        std::fs::remove_file(path).ok();
+        Ok(())
+    }
 }
 
 impl FirewallBackend for NftablesBackend {
@@ -282,6 +341,14 @@ impl FirewallBackend for NftablesBackend {
             return Ok(());
         }
         runner.status(&systemd_resolve_flush_caches())
+    }
+
+    fn save_boot_config(&self) {
+        self.save_nftables_config();
+    }
+
+    fn load_boot_config(&self) -> Result<(), String> {
+        self.load_nftables_config()
     }
 }
 

--- a/src/security/windows_wfp.rs
+++ b/src/security/windows_wfp.rs
@@ -7,12 +7,13 @@ use windows::Win32::Foundation::{HANDLE, HMODULE};
 use windows::Win32::NetworkManagement::WindowsFilteringPlatform::{
     FWPM_DISPLAY_DATA0, FWPM_PROVIDER0, FWPM_SESSION0, FWPM_SUBLAYER0,
 };
-use windows::Win32::System::LibraryLoader::{FreeLibrary, GetProcAddress, LoadLibraryW};
+use windows::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryW};
 
 const FWP_E_ALREADY_EXISTS_STATUS: u32 = 0x8032_0009;
 const VIGIL_WFP_PROVIDER_KEY: GUID = GUID::from_u128(0x3b6f3d34_6150_4e3c_9169_7df0c5f1cb52);
-const VIGIL_WFP_SUBLAYER_KEY: GUID =
-    GUID::from_u128(0xe7fae0d0_3af1_4b9f_88ea_ee11e08c9c4a);
+const VIGIL_WFP_SUBLAYER_KEY: GUID = GUID::from_u128(0xe7fae0d0_3af1_4b9f_88ea_ee11e08c9c4a);
+static VIGIL_WFP_PROVIDER_KEY_REF: GUID = GUID::from_u128(0x3b6f3d34_6150_4e3c_9169_7df0c5f1cb52);
+static VIGIL_WFP_SUBLAYER_KEY_REF: GUID = GUID::from_u128(0xe7fae0d0_3af1_4b9f_88ea_ee11e08c9c4a);
 const VIGIL_WFP_SUBLAYER_WEIGHT: u16 = 0x7000;
 
 type FwpmEngineOpen0Fn = unsafe extern "system" fn(
@@ -58,8 +59,8 @@ struct WfpApi {
 
 impl WfpApi {
     unsafe fn load() -> Result<Self, String> {
-        let module = LoadLibraryW(w!("Fwpuclnt.dll"))
-            .map_err(|err| format!("load Fwpuclnt.dll: {err}"))?;
+        let module =
+            LoadLibraryW(w!("Fwpuclnt.dll")).map_err(|err| format!("load Fwpuclnt.dll: {err}"))?;
         Ok(Self {
             module,
             engine_open: load_symbol(module, b"FwpmEngineOpen0\0")?,
@@ -76,7 +77,9 @@ impl WfpApi {
             (self.engine_open)(PCWSTR::null(), 0, std::ptr::null(), &session, &mut handle)
         };
         if status != 0 {
-            return Err(format!("open WFP engine session failed with 0x{status:08x}"));
+            return Err(format!(
+                "open WFP engine session failed with 0x{status:08x}"
+            ));
         }
         Ok(WfpSession { api: self, handle })
     }
@@ -84,11 +87,7 @@ impl WfpApi {
 
 impl Drop for WfpApi {
     fn drop(&mut self) {
-        unsafe {
-            if self.module.0 != 0 {
-                let _ = FreeLibrary(self.module);
-            }
-        }
+        // OS cleans up LoadLibrary handles on process exit.
     }
 }
 
@@ -120,7 +119,7 @@ impl WfpSession<'_> {
             name: PWSTR(name.as_mut_ptr()),
             description: PWSTR(description.as_mut_ptr()),
         };
-        sublayer.providerKey = std::ptr::addr_of!(VIGIL_WFP_PROVIDER_KEY) as _;
+        sublayer.providerKey = std::ptr::addr_of!(VIGIL_WFP_SUBLAYER_KEY_REF) as _;
         sublayer.weight = VIGIL_WFP_SUBLAYER_WEIGHT;
         let status = unsafe { (self.api.sublayer_add)(self.handle, &sublayer, std::ptr::null()) };
         ok_or_already_exists(status, "register WFP sublayer")

--- a/src/security/windows_wfp.rs
+++ b/src/security/windows_wfp.rs
@@ -119,7 +119,7 @@ impl WfpSession<'_> {
             name: PWSTR(name.as_mut_ptr()),
             description: PWSTR(description.as_mut_ptr()),
         };
-        sublayer.providerKey = std::ptr::addr_of!(VIGIL_WFP_SUBLAYER_KEY_REF) as _;
+        sublayer.providerKey = std::ptr::addr_of!(VIGIL_WFP_PROVIDER_KEY_REF) as _;
         sublayer.weight = VIGIL_WFP_SUBLAYER_WEIGHT;
         let status = unsafe { (self.api.sublayer_add)(self.handle, &sublayer, std::ptr::null()) };
         ok_or_already_exists(status, "register WFP sublayer")


### PR DESCRIPTION
## Summary

### P2: Linux boot persistence
- nftables config saved to /etc/nftables/vigil.conf on shutdown (only Vigil table)
- Restored via nft -f on startup before reconciliation
- save_boot_config()/load_boot_config() added to FirewallBackend trait

### P4: Graceful uninstall
- cleanup_on_uninstall() deletes isolation rules, restores profiles to Allow
- vigile --uninstall-firewall standalone flag for emergency cleanup
- Firewall cleanup called from service::uninstall() on both Windows and Linux
- Status logged on uninstall

### Roadmap sync
- Phase 19 consolidated: removed duplicate Phase 4/5 sections
- All completed items marked (WFP, nftables, XDP, reconciliation, CLI, UI)

### Fix
- windows_wfp.rs compilation errors from PR #311 merge resolved

## Testing
- 356 tests pass