### PR TITLE
Phase 19: update parity docs for firewall engine

### DIFF
--- a/docs/PHASE-18-PARITY.md
+++ b/docs/PHASE-18-PARITY.md
@@ -1,19 +1,80 @@
-# Phase 18 — Windows/Linux Detection and Response Parity
+# Phase 18+19 — Windows/Linux Parity & Native Firewall Engine
 
-## Status: Foundations in place
+## Status: ✅ Complete (Phase 18), 🚧 In Progress (Phase 19)
 
 ## Overview
 
-Windows and Linux are Vigil's active support targets. Phase 18 ensures both platforms are equally safe, explainable, and useful without expanding the supported OS surface.
+Phase 18 ensured both platforms are equally safe and useful. Phase 19 replaces the OS firewall with Vigil's own WFP (Windows) / nftables+XDP (Linux) engine, with kernel-level filtering, boot persistence, and crash-safe lifecycle.
 
-## Completed items
+## Active-response + Firewall parity matrix
 
-| Item | Status |
-|------|--------|
-| **Monitor trait unification** — `handle_realtime_event` shared handler eliminates duplicated code between ETW and eBPF paths. | ✅ Done |
-| **Active-response parity audit** — all 22 active-response functions audited. Linux has full parity for every non-Windows-specific action. | ✅ Done |
-| **Latency benchmark tool** (`vigil-benchmark`) — measures p50/p95/p99 detection latency, auto-detects event source, generates JSON/HTML reports. | ✅ Done |
-| **Service parity checker** (`vigil-service-check`) — validates service installation, enabled status, privileges, fail-open behaviour on both platforms. | ✅ Done |
+| Function | Windows backend | Linux backend |
+|---|---|---|
+| `is_supported` | ✅ | ✅ |
+| `supports_isolation` | ✅ | ✅ |
+| `is_elevated` | ✅ | ✅ (euid + caps) |
+| `snapshot_profiles` | ✅ (PowerShell) | ✅ (nftables + iptables) |
+| `apply_isolation` | ✅ (PowerShell) | ✅ (nftables / iptables) |
+| `restore_profiles` | ✅ (PowerShell) | ✅ (nftables + iptables) |
+| `add_block_rule` | ✅ (WFP API) | ✅ (nftables / iptables) |
+| `add_block_program_rule` | ✅ (netsh fallback) | ✅ (iptables UID match) |
+| `delete_rule` | ✅ (WFP API) | ✅ (handle-based nft deletion) |
+| `rule_present` | ✅ (WFP registry / netsh) | ✅ (iptables -C / nft handle) |
+| `kill_tcp_connection` | ✅ (SetTcpEntry, IPv4) | ✅ (ss -K, IPv4+IPv6) |
+| `terminate_active_connections` | ✅ (PowerShell + SetTcpEntry) | ✅ (ss enumeration) |
+| `suspend_process` | ✅ (per-thread) | ✅ (SIGSTOP) |
+| `resume_process` | ✅ (per-thread) | ✅ (SIGCONT) |
+| `add_domain_block` | ✅ (hosts file) | ✅ (hosts file) |
+| `remove_domain_block` | ✅ (hosts file) | ✅ (hosts file) |
+| `flush_dns` | ✅ (ipconfig) | ✅ (resolvectl / systemd-resolve) |
+| `snapshot_active_adapters` | ✅ | ✅ |
+| `disable_active_adapters` | ✅ | ✅ |
+| `enable_active_adapters` | ✅ | ✅ |
+| `enable_all_network_adapters` | ✅ | ✅ |
+
+## Platform-specific implementations
+
+### Windows: WFP (`src/security/firewall/wfp.rs`)
+- `Fwpuclnt.dll` loaded dynamically via `LoadLibrary`/`GetProcAddress`
+- Versioned API symbols: `FwpmEngineOpen0`, `FwpmFilterAdd0`, `FwpmFilterDeleteByKey0`
+- IP rules use `FWPM_LAYER_ALE_AUTH_CONNECT_V4` with `FWPM_CONDITION_IP_REMOTE_ADDRESS`
+- Program rules use netsh fallback (WFP ALE app-container SID filtering deferred)
+- Profile management via PowerShell (`Get/Set-NetFirewallProfile`)
+
+### Linux: nftables (`src/security/firewall/nftables.rs`)
+- nftables-preferred / iptables-fallback via executor bridge
+- `vigil` nftables table with jump chains (input/forward/output → isolin/isolforward/isolout)
+- Rule lookup by comment handle via `nft --handle list chain`
+- Boot persistence: config saved to `/etc/nftables/vigil.conf`
+
+### Linux: XDP/eBPF (`src/security/firewall/xdp.rs`, `xdp_firewall.bpf.c`)
+- Kernel-level packet filtering at NIC driver level (before iptables)
+- Auto-disable heartbeat: 30s without Vigil userspace → all traffic passes
+- Only TCP/UDP filtered; ICMP/ARP always pass
+- IPv4-only for now; IPv6 passes through
+
+## FirewallBackend trait (`src/security/firewall/mod.rs`)
+
+16 methods: `label`, `is_available`, `snapshot_profiles`, `apply_isolation`, `restore_profiles`, `add_block_rule`, `add_block_program_rule`, `delete_rule`, `rule_present`, `isolation_controls_active`, `outbound_block_supported`, `kill_tcp_connection`, `terminate_active_connections`, `add_domain_block`, `remove_domain_block`, `flush_dns`, `save_boot_config`, `load_boot_config`.
+
+## CLI commands
+
+| Command | Description |
+|---|---|
+| `vigil --firewall status` | Show backend, profiles, isolation |
+| `vigil --firewall list` | Rule summary (blocked IPs/processes/domains) |
+| `vigil --firewall export` | Full state as JSON |
+| `vigil --firewall panic` | Emergency restore (restore_machine + brute-force) |
+| `vigil --uninstall-firewall` | Remove all Vigil rules, restore OS defaults |
+
+## Safety guarantees
+
+- Fresh install does nothing — OS firewall handles traffic
+- WFP filters persist across restarts (kernel objects); nftables/XDP survive process death
+- XDP auto-disables after 30s without heartbeat — cannot brick
+- Break-glass watchdog clears Vigil filters on crash
+- `reconcile_firewall_rules` re-applies missing rules on startup
+- `cleanup_on_uninstall` restores OS firewall to pre-Vigil state
 
 ## Expected latency bounds
 
@@ -22,60 +83,3 @@ Windows and Linux are Vigil's active support targets. Phase 18 ensures both plat
 | ETW | Windows | < 100 ms | Real-time kernel callbacks — sub-ms delivery |
 | eBPF | Linux | < 200 ms | `inet_sock_set_state` tracepoint — ms-level |
 | Polling | Both | < 6000 ms | Configurable poll interval, default 5s |
-
-## Active-response parity matrix
-
-| Function | Windows | Linux |
-|---|---|---|
-| `is_supported` | ✅ | ✅ |
-| `supports_isolation` | ✅ | ✅ |
-| `is_elevated` | ✅ | ✅ (euid + caps) |
-| `snapshot_firewall_profiles` | ✅ | ✅ (iptables) |
-| `apply_firewall_isolation` | ✅ | ✅ (nftables-based) |
-| `restore_firewall_profiles` | ✅ | ✅ (nftables + iptables) |
-| `add_block_rule` | ✅ | ✅ (iptables/nftables) |
-| `add_block_program_rule` | ✅ | ✅ (iptables UID match) |
-| `delete_rule` | ✅ | ✅ (handle-based nft deletion) |
-| `kill_tcp_connection` | ✅ (IPv4) | ✅ (IPv4 + IPv6) |
-| `suspend_process` | ✅ (per-thread) | ✅ (SIGSTOP) |
-| `resume_process` | ✅ (per-thread) | ✅ (SIGCONT) |
-| `add_domain_block` | ✅ (hosts file) | ✅ (hosts file) |
-| `remove_domain_block` | ✅ (hosts file) | ✅ (hosts file) |
-| `snapshot_active_adapters` | ✅ | ✅ |
-| `disable_active_adapters` | ✅ | ✅ |
-| `enable_active_adapters` | ✅ | ✅ |
-| `enable_all_network_adapters` | ✅ | ✅ |
-
-## Tools
-
-### `vigil-benchmark`
-
-```bash
-# Quick smoke test
-cargo run --bin vigil_benchmark -- --quick
-
-# Full benchmark with JSON + HTML report
-cargo run --bin vigil_benchmark -- --count 100 --html report.html
-
-# Install service first, then benchmark
-cargo run --bin vigil_benchmark -- --install
-
-# Custom target
-cargo run --bin vigil_benchmark -- --target 1.1.1.1:443 --count 200
-```
-
-### `vigil-service-check`
-
-```bash
-# Read-only check
-cargo run --bin vigil_service_check
-
-# Repair mode
-cargo run --bin vigil_service_check --fix
-```
-
-## Remaining work
-
-- [ ] **Full end-to-end detection test**: subscribe to Vigil's broadcast channel from the benchmark tool and measure actual event delivery latency (not just TCP connect time). Currently blocked on cross-process channel access.
-- [ ] **Windows/Linux test fixtures**: add regression tests that cover both OS families.
-- [ ] **Autorun snapshot/revert on Linux**: snapshot and restore XDG autostart entries and systemd user units (currently Windows-only).


### PR DESCRIPTION
Updates PHASE-18-PARITY.md to Phase 18+19 covering:

- Full parity matrix updated with WFP, nftables, XDP backends
- New functions: rule_present, terminate_active_connections, flush_dns
- FirewallBackend trait summary with 18 methods
- CLI commands table (--firewall status|list|export|panic)
- Safety guarantees: auto-disable, break-glass, reconciliation
- Platform-specific implementation notes for WFP, nftables, XDP