### PR TITLE
Phase 20: add verified local YARA rule intake foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,24 @@ vigil --verify-update-manifest Vigil-latest-update-manifest.json Vigil-latest-up
 
 ---
 
+## Local YARA Rule Intake
+
+Phase 20's first safe foundation is integrity-checked local YARA rule intake.
+Operators can stage `.yar` or `.yara` files under the Vigil data directory in
+`yara-rules/`, with a matching `.sha256` sidecar beside each rule file.
+
+Verify those local rule files and record provenance with:
+
+```bash
+vigil --yara-rule-status
+```
+
+This command does not run YARA scans yet. It verifies trusted intake for future
+process and memory scanning work and fails closed on missing or mismatched
+sidecars.
+
+---
+
 ## What Vigil does
 
 ### Detect and surface suspicious activity

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -149,7 +149,7 @@ Add signature-based malware detection alongside the existing behavioural heurist
 - [ ] **Process scan on creation** — scan the executable path with YARA when a new process is detected; score bump on match.
 - [ ] **Memory region scan** — scan selected process memory (e.g., `--dump` target) for in-memory malware that hides from disk scanning.
 - [ ] **YARA rule management UI** — show matched rules in the inspector, allow operators to toggle rule categories, and view rule metadata (author, description, reference).
-- [ ] **Custom rule import** — let operators drop their own `.yar` files alongside blocklists, verified by `.sha256` sidecar (same integrity model as response rules).
+- [ ] **Custom rule import** — let operators drop their own `.yar` files alongside blocklists, verified by `.sha256` sidecar (same integrity model as response rules). Intake/status foundation is now exposed through `vigil --yara-rule-status`.
 
 ---
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ mod tls_artifacts;
 mod types;
 mod ui;
 mod version_compare;
+mod yara_rules;
 
 pub use platform::{autostart, break_glass, service, tray};
 pub use security::{
@@ -311,6 +312,16 @@ fn main() {
         }
     }
 
+    if args.iter().any(|a| a == "--yara-rule-status") {
+        match yara_rules::run_status_cli() {
+            Ok(()) => std::process::exit(0),
+            Err(err) => {
+                eprintln!("{err}");
+                std::process::exit(1);
+            }
+        }
+    }
+
     if let Some(idx) = args.iter().position(|a| a == "--sync-nvd") {
         let force = args
             .iter()
@@ -533,7 +544,7 @@ fn main() {
                 i += 1;
             }
             "--help" | "-h" => {
-                println!("Vigil v{} — real-time network threat monitor\n\nUsage:  vigil [flags]\n\nFlags:\n  --install-service              register Vigil as a boot-time service\n  --uninstall-service            remove the boot-time service\n  --break-glass-recover          watchdog entrypoint for network recovery\n  --verify-update-manifest       MANIFEST SIG\n                                 verify a signed release manifest against the embedded trust anchor\n  --import-nvd-snapshot          SNAPSHOT.json [MORE.json ...]\n                                 import or merge one or more NVD CVE JSON snapshots into the protected advisory cache\n  --sync-nvd [--force]           fetch or incrementally refresh the protected NVD CVE cache from the live API\n  --advisory-cache-status        show advisory cache status and source health\n  --import-nvd-change-history    SNAPSHOT.json [MORE.json ...]\n                                 import or merge one or more NVD CVE change-history JSON snapshots into the protected change-history cache\n  --sync-nvd-change-history [--force]\n                                 fetch or incrementally refresh the protected NVD CVE change-history cache from the live API\n  --advisory-change-history-status\n                                 show NVD change-history cache status and source health\n  --advisory-match-status        join the protected software inventory with the advisory cache\n                                 and print explainable local matches\n  --import-euvd                  SNAPSHOT.json [MORE.json ...]\n                                 import or merge one or more operator-supplied EUVD JSON snapshots into the protected advisory cache\n  --import-jvn                   SNAPSHOT.json|RSS.xml [MORE ...]\n                                 import or merge one or more JVN / JVN iPedia JSON or JVNDBRSS XML snapshots into the protected advisory cache\n  --import-ncsc                  SNAPSHOT.json|RSS.xml [MORE ...]\n                                 import or merge one or more NCSC public advisory RSS or mirrored JSON snapshots into the protected advisory cache\n  --import-bsi                   SNAPSHOT.json|RSS.xml [MORE ...]\n                                 import or merge one or more BSI or CERT-Bund public advisory RSS or mirrored JSON snapshots into the protected advisory cache\n  --service-mode                 internal headless service entrypoint\n  --data-dir PATH                override Vigil data/config directory\n  -h, --help                     show this help and exit\n\nRun with no flags to launch the GUI.", env!("CARGO_PKG_VERSION"));
+                println!("Vigil v{} — real-time network threat monitor\n\nUsage:  vigil [flags]\n\nFlags:\n  --install-service              register Vigil as a boot-time service\n  --uninstall-service            remove the boot-time service\n  --break-glass-recover          watchdog entrypoint for network recovery\n  --verify-update-manifest       MANIFEST SIG\n                                 verify a signed release manifest against the embedded trust anchor\n  --yara-rule-status             verify local `.yar` / `.yara` files under the Vigil data directory\n                                 and report integrity/provenance intake status\n  --import-nvd-snapshot          SNAPSHOT.json [MORE.json ...]\n                                 import or merge one or more NVD CVE JSON snapshots into the protected advisory cache\n  --sync-nvd [--force]           fetch or incrementally refresh the protected NVD CVE cache from the live API\n  --advisory-cache-status        show advisory cache status and source health\n  --import-nvd-change-history    SNAPSHOT.json [MORE.json ...]\n                                 import or merge one or more NVD CVE change-history JSON snapshots into the protected change-history cache\n  --sync-nvd-change-history [--force]\n                                 fetch or incrementally refresh the protected NVD CVE change-history cache from the live API\n  --advisory-change-history-status\n                                 show NVD change-history cache status and source health\n  --advisory-match-status        join the protected software inventory with the advisory cache\n                                 and print explainable local matches\n  --import-euvd                  SNAPSHOT.json [MORE.json ...]\n                                 import or merge one or more operator-supplied EUVD JSON snapshots into the protected advisory cache\n  --import-jvn                   SNAPSHOT.json|RSS.xml [MORE ...]\n                                 import or merge one or more JVN / JVN iPedia JSON or JVNDBRSS XML snapshots into the protected advisory cache\n  --import-ncsc                  SNAPSHOT.json|RSS.xml [MORE ...]\n                                 import or merge one or more NCSC public advisory RSS or mirrored JSON snapshots into the protected advisory cache\n  --import-bsi                   SNAPSHOT.json|RSS.xml [MORE ...]\n                                 import or merge one or more BSI or CERT-Bund public advisory RSS or mirrored JSON snapshots into the protected advisory cache\n  --service-mode                 internal headless service entrypoint\n  --data-dir PATH                override Vigil data/config directory\n  -h, --help                     show this help and exit\n\nRun with no flags to launch the GUI.", env!("CARGO_PKG_VERSION"));
                 std::process::exit(0);
             }
             _ => {}

--- a/src/security/operator_provenance.rs
+++ b/src/security/operator_provenance.rs
@@ -66,6 +66,10 @@ pub fn observe_operator_file_checked(kind: &str, path: &Path) -> Result<Observat
     observe_operator_file_inner(kind, path, &registry_path(), true)
 }
 
+pub(crate) fn registry_file_path() -> PathBuf {
+    registry_path()
+}
+
 #[allow(dead_code)]
 pub(crate) fn observe_operator_file_at(
     kind: &str,

--- a/src/yara_rules.rs
+++ b/src/yara_rules.rs
@@ -1,0 +1,323 @@
+//! Local YARA rule intake foundations.
+//!
+//! Phase 20 needs a safe place for operator-supplied `.yar` and `.yara` files
+//! before the runtime scan engine lands. This module reuses Vigil's existing
+//! integrity sidecars and provenance tracking so untrusted rules fail closed.
+
+use crate::security::{integrity, operator_provenance};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const RULE_DIR: &str = "yara-rules";
+const MAX_RULE_FILES: usize = 256;
+const MAX_RULE_FILE_BYTES: u64 = 4 * 1024 * 1024;
+const MAX_SCAN_DEPTH: usize = 4;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedRuleFile {
+    pub path: PathBuf,
+    pub source_text: String,
+    pub observation: operator_provenance::Observation,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct RuleLoadReport {
+    pub root: PathBuf,
+    pub verified: usize,
+    pub warnings: usize,
+    pub failures: usize,
+    pub skipped: usize,
+    pub files: Vec<VerifiedRuleFile>,
+    pub errors: Vec<String>,
+}
+
+pub fn rule_dir() -> PathBuf {
+    crate::config::data_dir().join(RULE_DIR)
+}
+
+pub fn load_verified_rules() -> Result<RuleLoadReport, String> {
+    load_verified_rules_with_registry(
+        &rule_dir(),
+        &operator_provenance::registry_file_path(),
+    )
+}
+
+pub fn run_status_cli() -> Result<(), String> {
+    let report = load_verified_rules()?;
+    println!("YARA rule directory: {}", report.root.display());
+    if !report.root.exists() {
+        println!("No local YARA rule directory found yet.");
+        return Ok(());
+    }
+
+    println!("Verified rules: {}", report.verified);
+    println!("Warnings: {}", report.warnings);
+    println!("Failures: {}", report.failures);
+    println!("Skipped non-rule files: {}", report.skipped);
+
+    for file in &report.files {
+        println!("  [{}] {}", observation_label(&file.observation), file.path.display());
+    }
+    for err in &report.errors {
+        eprintln!("  [error] {err}");
+    }
+
+    if report.failures > 0 {
+        return Err(format!(
+            "one or more local YARA rules failed integrity intake ({})",
+            report.failures
+        ));
+    }
+    Ok(())
+}
+
+fn load_verified_rules_with_registry(
+    root: &Path,
+    registry_path: &Path,
+) -> Result<RuleLoadReport, String> {
+    let mut report = RuleLoadReport {
+        root: root.to_path_buf(),
+        ..RuleLoadReport::default()
+    };
+    if !root.exists() {
+        return Ok(report);
+    }
+    if !root.is_dir() {
+        return Err(format!(
+            "YARA rule path {} exists but is not a directory",
+            root.display()
+        ));
+    }
+
+    let mut candidates = Vec::new();
+    collect_rule_files(root, &mut candidates, 0, &mut report)?;
+    candidates.sort();
+    if candidates.len() > MAX_RULE_FILES {
+        return Err(format!(
+            "refusing to load more than {MAX_RULE_FILES} YARA rule files from {}",
+            root.display()
+        ));
+    }
+
+    for path in candidates {
+        let metadata = fs::metadata(&path)
+            .map_err(|e| format!("failed to stat YARA rule {}: {e}", path.display()))?;
+        if metadata.len() > MAX_RULE_FILE_BYTES {
+            report.failures += 1;
+            report.errors.push(format!(
+                "YARA rule {} exceeds the {} byte safety limit",
+                path.display(),
+                MAX_RULE_FILE_BYTES
+            ));
+            continue;
+        }
+
+        let (source_text, _) = match integrity::read_verified_to_string(&path, "YARA rule") {
+            Ok(ok) => ok,
+            Err(err) => {
+                report.failures += 1;
+                report.errors.push(err);
+                continue;
+            }
+        };
+
+        let observation = match operator_provenance::observe_operator_file_at(
+            "yara_rule",
+            &path,
+            registry_path,
+        ) {
+            Ok(observation) => observation,
+            Err(err) => {
+                report.failures += 1;
+                report.errors.push(format!(
+                    "failed to record YARA rule provenance for {}: {err}",
+                    path.display()
+                ));
+                continue;
+            }
+        };
+
+        match observation {
+            operator_provenance::Observation::Unchanged => {
+                report.verified += 1;
+            }
+            operator_provenance::Observation::FirstSeen
+            | operator_provenance::Observation::Changed => {
+                report.verified += 1;
+                report.warnings += 1;
+            }
+            operator_provenance::Observation::Missing
+            | operator_provenance::Observation::Unreadable => {
+                report.failures += 1;
+                report.errors.push(format!(
+                    "YARA rule {} could not be tracked as a readable operator file",
+                    path.display()
+                ));
+                continue;
+            }
+        }
+
+        report.files.push(VerifiedRuleFile {
+            path,
+            source_text,
+            observation,
+        });
+    }
+
+    Ok(report)
+}
+
+fn collect_rule_files(
+    dir: &Path,
+    out: &mut Vec<PathBuf>,
+    depth: usize,
+    report: &mut RuleLoadReport,
+) -> Result<(), String> {
+    if depth > MAX_SCAN_DEPTH {
+        return Ok(());
+    }
+    let entries = fs::read_dir(dir)
+        .map_err(|e| format!("failed to read YARA rule directory {}: {e}", dir.display()))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("failed to read YARA directory entry: {e}"))?;
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(|e| {
+            format!("failed to inspect YARA directory entry {}: {e}", path.display())
+        })?;
+        if file_type.is_symlink() {
+            report.skipped += 1;
+            continue;
+        }
+        if file_type.is_dir() {
+            collect_rule_files(&path, out, depth + 1, report)?;
+            continue;
+        }
+        if !file_type.is_file() {
+            report.skipped += 1;
+            continue;
+        }
+        if is_rule_file(&path) {
+            out.push(path);
+        } else {
+            report.skipped += 1;
+        }
+    }
+    Ok(())
+}
+
+fn is_rule_file(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|ext| ext.to_str()),
+        Some("yar") | Some("yara")
+    )
+}
+
+fn observation_label(observation: &operator_provenance::Observation) -> &'static str {
+    match observation {
+        operator_provenance::Observation::Unchanged => "verified",
+        operator_provenance::Observation::FirstSeen => "new",
+        operator_provenance::Observation::Changed => "changed",
+        operator_provenance::Observation::Missing => "missing",
+        operator_provenance::Observation::Unreadable => "unreadable",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha2::{Digest, Sha256};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn empty_rule_directory_reports_clean_status() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let registry = dir.join("operator-file-provenance.json");
+
+        let report = load_verified_rules_with_registry(&dir, &registry).unwrap();
+        assert_eq!(report.verified, 0);
+        assert_eq!(report.failures, 0);
+        assert!(report.files.is_empty());
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn verified_rule_file_loads_with_sidecar() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let registry = dir.join("operator-file-provenance.json");
+        let path = dir.join("sample.yar");
+        let body = "rule sample { condition: true }\n";
+        fs::write(&path, body).unwrap();
+        fs::write(
+            integrity::sidecar_path(&path),
+            format!("{}  sample.yar\n", sha256_hex(body.as_bytes())),
+        )
+        .unwrap();
+
+        let report = load_verified_rules_with_registry(&dir, &registry).unwrap();
+        assert_eq!(report.verified, 1);
+        assert_eq!(report.warnings, 1);
+        assert_eq!(report.failures, 0);
+        assert_eq!(report.files[0].source_text, body);
+
+        let report = load_verified_rules_with_registry(&dir, &registry).unwrap();
+        assert_eq!(report.verified, 1);
+        assert_eq!(report.warnings, 0);
+        assert_eq!(report.failures, 0);
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn mismatched_sidecar_fails_closed() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let registry = dir.join("operator-file-provenance.json");
+        let path = dir.join("broken.yar");
+        fs::write(&path, "rule broken { condition: true }\n").unwrap();
+        fs::write(
+            integrity::sidecar_path(&path),
+            "0000000000000000000000000000000000000000000000000000000000000000  broken.yar\n",
+        )
+        .unwrap();
+
+        let report = load_verified_rules_with_registry(&dir, &registry).unwrap();
+        assert_eq!(report.verified, 0);
+        assert_eq!(report.failures, 1);
+        assert_eq!(report.files.len(), 0);
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn non_rule_files_are_skipped() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let registry = dir.join("operator-file-provenance.json");
+        fs::write(dir.join("notes.txt"), "ignore\n").unwrap();
+
+        let report = load_verified_rules_with_registry(&dir, &registry).unwrap();
+        assert_eq!(report.verified, 0);
+        assert_eq!(report.skipped, 1);
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    fn sha256_hex(data: &[u8]) -> String {
+        let digest = Sha256::digest(data);
+        digest
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>()
+    }
+
+    fn unique_temp_dir() -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("vigil-yara-rule-test-{nanos}"))
+    }
+}

--- a/src/yara_rules.rs
+++ b/src/yara_rules.rs
@@ -36,7 +36,10 @@ pub fn rule_dir() -> PathBuf {
 }
 
 pub fn load_verified_rules() -> Result<RuleLoadReport, String> {
-    load_verified_rules_with_registry(&rule_dir(), &operator_provenance::registry_file_path())
+    load_verified_rules_with_registry(
+        &rule_dir(),
+        &operator_provenance::registry_file_path(),
+    )
 }
 
 pub fn run_status_cli() -> Result<(), String> {
@@ -53,11 +56,7 @@ pub fn run_status_cli() -> Result<(), String> {
     println!("Skipped non-rule files: {}", report.skipped);
 
     for file in &report.files {
-        println!(
-            "  [{}] {}",
-            observation_label(&file.observation),
-            file.path.display()
-        );
+        println!("  [{}] {}", observation_label(&file.observation), file.path.display());
     }
     for err in &report.errors {
         eprintln!("  [error] {err}");
@@ -183,10 +182,7 @@ fn collect_rule_files(
         let entry = entry.map_err(|e| format!("failed to read YARA directory entry: {e}"))?;
         let path = entry.path();
         let file_type = entry.file_type().map_err(|e| {
-            format!(
-                "failed to inspect YARA directory entry {}: {e}",
-                path.display()
-            )
+            format!("failed to inspect YARA directory entry {}: {e}", path.display())
         })?;
         if file_type.is_symlink() {
             report.skipped += 1;

--- a/src/yara_rules.rs
+++ b/src/yara_rules.rs
@@ -36,10 +36,7 @@ pub fn rule_dir() -> PathBuf {
 }
 
 pub fn load_verified_rules() -> Result<RuleLoadReport, String> {
-    load_verified_rules_with_registry(
-        &rule_dir(),
-        &operator_provenance::registry_file_path(),
-    )
+    load_verified_rules_with_registry(&rule_dir(), &operator_provenance::registry_file_path())
 }
 
 pub fn run_status_cli() -> Result<(), String> {
@@ -56,7 +53,11 @@ pub fn run_status_cli() -> Result<(), String> {
     println!("Skipped non-rule files: {}", report.skipped);
 
     for file in &report.files {
-        println!("  [{}] {}", observation_label(&file.observation), file.path.display());
+        println!(
+            "  [{}] {}",
+            observation_label(&file.observation),
+            file.path.display()
+        );
     }
     for err in &report.errors {
         eprintln!("  [error] {err}");
@@ -182,7 +183,10 @@ fn collect_rule_files(
         let entry = entry.map_err(|e| format!("failed to read YARA directory entry: {e}"))?;
         let path = entry.path();
         let file_type = entry.file_type().map_err(|e| {
-            format!("failed to inspect YARA directory entry {}: {e}", path.display())
+            format!(
+                "failed to inspect YARA directory entry {}: {e}",
+                path.display()
+            )
         })?;
         if file_type.is_symlink() {
             report.skipped += 1;


### PR DESCRIPTION
## Summary

Add the smallest safe Phase 20 slice now that no active agent PR is open: a verified local YARA rule intake foundation.

## Changes

- add `src/yara_rules.rs` with local `.yar` / `.yara` discovery under the Vigil data directory
- require existing `.sha256` sidecars for every local rule file and fail closed on missing or mismatched integrity
- reuse protected operator provenance tracking for first-seen / changed rule files
- add `vigil --yara-rule-status` to report verified rules, warnings, failures, and skipped non-rule files
- document the new intake/status flow in `README.md`
- note the intake/status foundation on the Phase 20 roadmap item

## Why this task

The roadmap's first unchecked Phase 20 item is community-rule embedding, but that still needs an explicit upstream ruleset, licensing decision, and signed update plumbing. This PR takes the smallest concrete in-scope slice that is already safe to ship without guessing at those product decisions: trusted intake for operator-supplied YARA rule files.

## Validation

- added focused unit tests in `src/yara_rules.rs` for empty directories, valid sidecars, mismatched sidecars, and skipped non-rule files
- reused existing integrity and provenance helpers rather than introducing a second trust model

## Risk / follow-up

- this does not compile or execute YARA rules yet; it only prepares trusted local inputs for later Phase 20 work
- I could not run the Rust test suite from this scheduled environment because the repository checkout is not available locally here