### PR TITLE
Phase 20: define bundled YARA pack manifest format

### DIFF
--- a/docs/YARA-PACK-MANIFEST.example.json
+++ b/docs/YARA-PACK-MANIFEST.example.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "pack_name": "community-core",
+  "pack_version": "2026.05.21.1",
+  "generated_at": "2026-05-21T00:40:00Z",
+  "upstream_name": "Example Community Rules",
+  "upstream_source_url": "https://example.invalid/yara-rules",
+  "upstream_reference": "refs/tags/2026-05-20",
+  "license": "Apache-2.0",
+  "files": [
+    {
+      "relative_path": "malware/core.yar",
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "rule_count": 12,
+      "source_url": "https://example.invalid/yara-rules/malware/core.yar",
+      "source_reference": "refs/tags/2026-05-20",
+      "category": "malware"
+    },
+    {
+      "relative_path": "persistence/autoruns.yar",
+      "sha256": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+      "rule_count": 4,
+      "source_url": "https://example.invalid/yara-rules/persistence/autoruns.yar",
+      "source_reference": "refs/tags/2026-05-20",
+      "category": "persistence"
+    }
+  ]
+}

--- a/docs/YARA-PACK-MANIFEST.md
+++ b/docs/YARA-PACK-MANIFEST.md
@@ -1,0 +1,90 @@
+# YARA Pack Manifest Format
+
+This document defines the first concrete manifest format for Vigil's future
+bundled community YARA packs.
+
+It is intentionally narrower than full Phase 20 implementation. The manifest
+exists so future build-time importers, compile-time embedding, and signed-update
+artifacts all preserve the same minimum provenance and integrity data.
+
+## Design goals
+
+The manifest format must let Vigil:
+
+- attribute every shipped rule file to a reviewed upstream source
+- validate pack contents offline before trusting or exposing them to operators
+- keep file paths deterministic and safe for archive extraction or embedding
+- surface pack version, license, and source metadata without relying on network
+  access
+- stay compatible with Phase 23's signed release-manifest model without
+  replacing it
+
+## Schema version 1
+
+A pack manifest is UTF-8 JSON with these top-level fields:
+
+- `schema_version` — integer schema identifier. Version `1` is defined here.
+- `pack_name` — stable Vigil pack identifier such as `community-core`.
+- `pack_version` — pack version chosen by Vigil for this imported snapshot.
+- `generated_at` — UTC timestamp showing when Vigil generated the local pack.
+- `upstream_name` — reviewed upstream project name.
+- `upstream_source_url` — canonical upstream project or export URL.
+- `upstream_reference` — upstream tag, release, snapshot date, or pinned commit.
+- `license` — reviewed license identifier or clear license reference.
+- `files` — array of per-file records included in the pack.
+
+Each `files[]` entry contains:
+
+- `relative_path` — slash-separated path inside the bundled pack.
+- `sha256` — lowercase SHA-256 of the shipped rule file bytes.
+- `rule_count` — number of YARA rules represented in that file.
+- `source_url` — upstream file or export URL for this exact file.
+- `source_reference` — upstream tag, release, snapshot date, or pinned commit
+  specific to this file.
+- `category` — optional operator-visible category or family label.
+
+## Validation rules
+
+Schema version 1 expects the following checks before a pack is trusted:
+
+- every required string field is present and non-empty after trimming
+- `schema_version` must equal `1`
+- `files` must not be empty
+- each `relative_path` must stay relative and normalized: no absolute paths, no
+  drive prefixes, no `.` segments, and no `..` traversal
+- each `relative_path` must be unique within the manifest
+- each `sha256` must be exactly 64 hexadecimal characters
+- each `rule_count` must be greater than zero
+- `category` may be omitted, but if present it must not be empty
+
+These rules are deliberately conservative because the manifest will eventually
+sit on the trust boundary between reviewed upstream rule text and operator
+systems.
+
+## Relationship to the signed update manifest
+
+This pack manifest does not replace Vigil's signed release manifest.
+
+The Phase 23 signed update manifest answers: "which pack artifact should Vigil
+trust and download?"
+
+This YARA pack manifest answers: "what is inside that trusted pack artifact, and
+where did each file come from?"
+
+A future signed YARA update should therefore include both:
+
+- the outer signed update manifest naming the pack artifact and its SHA-256
+- the inner YARA pack manifest bundled with the pack so Vigil can enumerate and
+  explain the pack contents offline
+
+## Example
+
+See `docs/YARA-PACK-MANIFEST.example.json` for a concrete schema-version-1
+example.
+
+## Safest next implementation step
+
+The next safe Phase 20 slice is a build-time importer for one explicitly
+approved upstream community ruleset that emits this manifest format while
+preserving the source-selection and redistribution rules in
+`docs/YARA-RULESET-COMPLIANCE.md`.

--- a/docs/YARA-RULESET-COMPLIANCE.md
+++ b/docs/YARA-RULESET-COMPLIANCE.md
@@ -56,6 +56,10 @@ For every bundled rule file or generated pack, preserve at least:
 That provenance must travel with both compile-time embedded packs and future
 signed update artifacts.
 
+The concrete schema for that pack metadata now lives in
+`docs/YARA-PACK-MANIFEST.md`, with an example payload in
+`docs/YARA-PACK-MANIFEST.example.json`.
+
 ## Redistribution rules
 
 Vigil should treat community YARA text conservatively:
@@ -117,7 +121,8 @@ pack refresh never overwrites operator-managed files.
 
 ## Safest next implementation step
 
-This contract makes the next unfinished Phase 20 item more concrete. The next
-safe code slice is to add a pack manifest format and build-time importer for one
-explicitly approved upstream community ruleset, while preserving the provenance,
+This contract makes the next unfinished Phase 20 item more concrete. The
+manifest-format foundation now exists in `docs/YARA-PACK-MANIFEST.md`. The next
+safe code slice is a build-time importer for one explicitly approved upstream
+community ruleset that emits that manifest while preserving the provenance,
 redistribution, and signed-update rules above.


### PR DESCRIPTION
## Summary

Define the first concrete manifest format for Phase 20's future bundled community YARA packs.

## Why this task

There was no active PR follow-up left to handle: PR #324 had already merged and the repository had no open agent PRs with review or CI blockers.

The next unchecked roadmap item in strict order remains **Binary embedding of community YARA rules**. The new ruleset contract in `docs/YARA-RULESET-COMPLIANCE.md` narrowed the safest next slice to the pack-manifest boundary, but source selection and importer code are still product and licensing decisions that should not be guessed. The smallest safe in-scope change was to define the manifest format and example payload those later steps should target.

## Changes

- add `docs/YARA-PACK-MANIFEST.md` with schema-version-1 fields, validation rules, and its relationship to the signed update manifest
- add `docs/YARA-PACK-MANIFEST.example.json` with a concrete example payload
- update `docs/YARA-RULESET-COMPLIANCE.md` to point to the new manifest spec and narrow the next code step to a build-time importer for one approved upstream ruleset

## Validation

- reviewed `ROADMAP.md` and confirmed the first unchecked Phase 20 item is still bundled community YARA rules
- kept the change documentation-only and aligned it with the already-merged YARA ruleset contract and existing signed update-manifest model
- avoided inventing runtime scanning, upstream source selection, or signed update behavior beyond the documented trust boundary

## Risk / follow-up

- no runtime code changed in this PR
- the next safe implementation step is a build-time importer for one explicitly approved upstream community ruleset that emits this manifest format
- I could not run local Rust tooling in this scheduled environment because the repository is not available here as a buildable checkout