### PR TITLE
Phase 20: mirror verified local YARA rules into SQLite catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,15 +77,17 @@ Phase 20's first safe foundation is integrity-checked local YARA rule intake.
 Operators can stage `.yar` or `.yara` files under the Vigil data directory in
 `yara-rules/`, with a matching `.sha256` sidecar beside each rule file.
 
-Verify those local rule files and record provenance with:
+Verify those local rule files, record provenance, and mirror the parsed rule
+catalog into Vigil's protected local state with:
 
 ```bash
 vigil --yara-rule-status
 ```
 
 This command does not run YARA scans yet. It verifies trusted intake for future
-process and memory scanning work and fails closed on missing or mismatched
-sidecars.
+process and memory scanning work, mirrors normalized per-file and per-rule
+metadata into the local SQLite state database, and fails closed on missing or
+mismatched sidecars.
 
 The future bundled community-rules path also has an explicit compliance and
 signed-update contract in
@@ -258,53 +260,3 @@ Common settings include:
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `alert_threshold` | 3 | Minimum score to trigger an alert |
-| `poll_interval_secs` | 5 | Seconds between full connection polls |
-| `log_all_connections` | false | Log every connection, not just suspicious ones |
-| `autostart` | true | Launch Vigil at login |
-| `trusted_processes` | shipped defaults | Process names exempt from low-level scoring |
-
----
-
-## Running before login
-
-Vigil can install a boot-time monitor so monitoring starts before any user logs
-in. This is useful for detecting early persistence and pre-user activity.
-
-| OS | Install | Remove |
-|---|---|---|
-| Windows | `vigil.exe --install-service` | `vigil.exe --uninstall-service` |
-| Linux | `sudo vigil --install-service` | `sudo vigil --uninstall-service` |
-
-Under the hood:
-
-- Windows uses Task Scheduler with an `ONSTART` task that runs Vigil as `SYSTEM`.
-- Linux writes a systemd unit at `/etc/systemd/system/vigil.service` and enables it with `systemctl enable --now vigil.service`.
-
-Startup safety rule: Vigil must fail open. A Vigil bug, hang, network failure,
-advisory-cache failure, package-inventory failure, or service-mode error must
-not repeatedly prevent the machine from reaching a usable login/session state.
-
----
-
-## Logs
-
-Log files land in the Vigil data directory and rotate daily. Open the log folder
-from the tray icon context menu with **Open Logs Folder**.
-
-Audit events include active response actions, integrity scan summaries,
-uninstall attempts, and other security-relevant changes.
-
----
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on bug reports, feature
-requests, and pull requests.
-
----
-
-## License
-
-[MIT](LICENSE)
-
-[latest release]: https://github.com/YMRYMR/vigil/releases/latest

--- a/src/yara_rules.rs
+++ b/src/yara_rules.rs
@@ -5,16 +5,22 @@
 //! integrity sidecars and provenance tracking so untrusted rules fail closed.
 
 use crate::security::{integrity, operator_provenance};
+use crate::storage::db::StorageDb;
+use rusqlite::params;
 use serde::Deserialize;
+use serde_json::json;
 use sha2::{Digest, Sha256};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const RULE_DIR: &str = "yara-rules";
 const MAX_RULE_FILES: usize = 256;
 const MAX_RULE_FILE_BYTES: u64 = 4 * 1024 * 1024;
 const MAX_SCAN_DEPTH: usize = 4;
+const LOCAL_SOURCE_KEY: &str = "operator-local";
+const LOCAL_SOURCE_KIND: &str = "operator_local";
 const BUNDLED_PACK_MANIFEST_JSON: &str =
     include_str!(concat!(env!("OUT_DIR"), "/bundled_yara_pack_manifest.json"));
 
@@ -29,8 +35,25 @@ include!(concat!(env!("OUT_DIR"), "/bundled_yara_pack_files.rs"));
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VerifiedRuleFile {
     pub path: PathBuf,
+    pub relative_path: String,
+    pub sha256: String,
+    pub size_bytes: u64,
     pub source_text: String,
     pub observation: operator_provenance::Observation,
+    pub parsed_rules: Vec<ParsedRule>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedRule {
+    pub rule_name: String,
+    pub namespace: String,
+    pub category: Option<String>,
+    pub author: Option<String>,
+    pub description: Option<String>,
+    pub reference: Option<String>,
+    pub tags: Vec<String>,
+    pub strings_count: usize,
+    pub metadata: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -41,8 +64,15 @@ pub struct RuleLoadReport {
     pub failures: usize,
     pub sidecars: usize,
     pub skipped: usize,
+    pub cataloged_rules: usize,
     pub files: Vec<VerifiedRuleFile>,
     pub errors: Vec<String>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+struct PersistSummary {
+    mirrored_files: usize,
+    mirrored_rules: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -96,6 +126,7 @@ pub fn run_status_cli() -> Result<(), String> {
     println!();
 
     let report = load_verified_rules()?;
+    let persist = persist_rule_catalog(&report)?;
     println!("Local YARA rule directory: {}", report.root.display());
     if !report.root.exists() {
         println!("No local YARA rule directory found yet.");
@@ -107,13 +138,22 @@ pub fn run_status_cli() -> Result<(), String> {
     println!("Failures: {}", report.failures);
     println!("Rule sidecars: {}", report.sidecars);
     println!("Skipped non-rule files: {}", report.skipped);
+    println!("Cataloged rules: {}", report.cataloged_rules);
+    println!(
+        "Mirrored local YARA catalog into state DB: {} files, {} rules",
+        persist.mirrored_files, persist.mirrored_rules
+    );
 
     for file in &report.files {
         println!(
-            "  [{}] {}",
+            "  [{}] {} ({} rules)",
             observation_label(&file.observation),
-            file.path.display()
+            file.path.display(),
+            file.parsed_rules.len()
         );
+        for rule in &file.parsed_rules {
+            println!("      - {}", rule.rule_name);
+        }
     }
     for err in &report.errors {
         eprintln!("  [error] {err}");
@@ -126,6 +166,194 @@ pub fn run_status_cli() -> Result<(), String> {
         ));
     }
     Ok(())
+}
+
+fn persist_rule_catalog(report: &RuleLoadReport) -> Result<PersistSummary, String> {
+    let db = StorageDb::global()?;
+    ensure_catalog_tables(&db)?;
+    db.begin()?;
+    match replace_catalog_rows(&db, report) {
+        Ok(summary) => {
+            db.commit()?;
+            db.checkpoint()?;
+            Ok(summary)
+        }
+        Err(err) => {
+            let _ = db.rollback();
+            Err(err)
+        }
+    }
+}
+
+fn ensure_catalog_tables(db: &StorageDb) -> Result<(), String> {
+    let conn = db.conn()?;
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS yara_source (
+            source_key    TEXT PRIMARY KEY NOT NULL,
+            source_kind   TEXT NOT NULL,
+            source_url    TEXT NOT NULL DEFAULT '',
+            fetched_unix  INTEGER NOT NULL DEFAULT 0,
+            expires_unix  INTEGER NOT NULL DEFAULT 0,
+            status        TEXT NOT NULL DEFAULT 'ok',
+            last_error    TEXT NOT NULL DEFAULT ''
+        );
+
+        CREATE TABLE IF NOT EXISTS yara_rule_file (
+            file_key           TEXT PRIMARY KEY NOT NULL,
+            source_key         TEXT NOT NULL REFERENCES yara_source(source_key),
+            path_or_relative_path TEXT NOT NULL DEFAULT '',
+            sha256             TEXT NOT NULL DEFAULT '',
+            size_bytes         INTEGER NOT NULL DEFAULT 0,
+            rule_count         INTEGER NOT NULL DEFAULT 0,
+            enabled            INTEGER NOT NULL DEFAULT 1,
+            observation        TEXT NOT NULL DEFAULT '',
+            payload_json       TEXT NOT NULL DEFAULT '{}'
+        );
+
+        CREATE TABLE IF NOT EXISTS yara_rule (
+            rule_key        TEXT PRIMARY KEY NOT NULL,
+            file_key        TEXT NOT NULL REFERENCES yara_rule_file(file_key),
+            rule_name       TEXT NOT NULL,
+            namespace       TEXT NOT NULL DEFAULT '',
+            category        TEXT NOT NULL DEFAULT '',
+            author          TEXT NOT NULL DEFAULT '',
+            description     TEXT NOT NULL DEFAULT '',
+            reference       TEXT NOT NULL DEFAULT '',
+            tags_json       TEXT NOT NULL DEFAULT '[]',
+            strings_count   INTEGER NOT NULL DEFAULT 0,
+            payload_json    TEXT NOT NULL DEFAULT '{}'
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_yara_rule_file_source
+            ON yara_rule_file(source_key);
+        CREATE INDEX IF NOT EXISTS idx_yara_rule_file_sha256
+            ON yara_rule_file(sha256);
+        CREATE INDEX IF NOT EXISTS idx_yara_rule_source_name
+            ON yara_rule(rule_name);
+        CREATE INDEX IF NOT EXISTS idx_yara_rule_file_key
+            ON yara_rule(file_key);
+        ",
+    )
+    .map_err(|e| format!("bootstrap YARA catalog tables: {e}"))?;
+    Ok(())
+}
+
+fn replace_catalog_rows(db: &StorageDb, report: &RuleLoadReport) -> Result<PersistSummary, String> {
+    let conn = db.conn()?;
+    let fetched_unix = unix_now();
+    conn.execute(
+        "INSERT INTO yara_source
+         (source_key, source_kind, source_url, fetched_unix, expires_unix, status, last_error)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+         ON CONFLICT(source_key) DO UPDATE SET
+         source_kind = excluded.source_kind,
+         source_url = excluded.source_url,
+         fetched_unix = excluded.fetched_unix,
+         expires_unix = excluded.expires_unix,
+         status = excluded.status,
+         last_error = excluded.last_error",
+        params![
+            LOCAL_SOURCE_KEY,
+            LOCAL_SOURCE_KIND,
+            "",
+            fetched_unix,
+            0u64,
+            if report.failures > 0 { "error" } else { "ok" },
+            report.errors.join(" | "),
+        ],
+    )
+    .map_err(|e| format!("upsert YARA source: {e}"))?;
+
+    conn.execute(
+        "DELETE FROM yara_rule
+         WHERE file_key IN (
+             SELECT file_key FROM yara_rule_file WHERE source_key = ?1
+         )",
+        [LOCAL_SOURCE_KEY],
+    )
+    .map_err(|e| format!("clear YARA rules: {e}"))?;
+    conn.execute(
+        "DELETE FROM yara_rule_file WHERE source_key = ?1",
+        [LOCAL_SOURCE_KEY],
+    )
+    .map_err(|e| format!("clear YARA rule files: {e}"))?;
+
+    let mut file_stmt = conn
+        .prepare(
+            "INSERT INTO yara_rule_file
+             (file_key, source_key, path_or_relative_path, sha256, size_bytes,
+              rule_count, enabled, observation, payload_json)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        )
+        .map_err(|e| format!("prepare YARA file insert: {e}"))?;
+    let mut rule_stmt = conn
+        .prepare(
+            "INSERT INTO yara_rule
+             (rule_key, file_key, rule_name, namespace, category, author,
+              description, reference, tags_json, strings_count, payload_json)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+        )
+        .map_err(|e| format!("prepare YARA rule insert: {e}"))?;
+
+    let mut mirrored_rules = 0usize;
+    for file in &report.files {
+        let file_key = stable_key("yara_file", &file.relative_path);
+        let file_payload = json!({
+            "relative_path": file.relative_path,
+            "absolute_path": file.path.display().to_string(),
+            "sha256": file.sha256,
+            "size_bytes": file.size_bytes,
+            "observation": observation_label(&file.observation),
+            "rule_names": file
+                .parsed_rules
+                .iter()
+                .map(|rule| rule.rule_name.clone())
+                .collect::<Vec<_>>(),
+        });
+        file_stmt
+            .execute(params![
+                file_key,
+                LOCAL_SOURCE_KEY,
+                file.relative_path,
+                file.sha256,
+                file.size_bytes,
+                file.parsed_rules.len(),
+                1i64,
+                observation_label(&file.observation),
+                file_payload.to_string(),
+            ])
+            .map_err(|e| format!("insert YARA rule file {}: {e}", file.relative_path))?;
+
+        for rule in &file.parsed_rules {
+            let rule_key = stable_key("yara_rule", &format!("{}::{}", file.relative_path, rule.rule_name));
+            let payload = json!({
+                "metadata": rule.metadata,
+                "tags": rule.tags,
+            });
+            rule_stmt
+                .execute(params![
+                    rule_key,
+                    file_key,
+                    rule.rule_name,
+                    rule.namespace,
+                    rule.category.clone().unwrap_or_default(),
+                    rule.author.clone().unwrap_or_default(),
+                    rule.description.clone().unwrap_or_default(),
+                    rule.reference.clone().unwrap_or_default(),
+                    serde_json::to_string(&rule.tags).unwrap_or_else(|_| "[]".to_string()),
+                    rule.strings_count,
+                    payload.to_string(),
+                ])
+                .map_err(|e| format!("insert YARA rule {}: {e}", rule.rule_name))?;
+            mirrored_rules += 1;
+        }
+    }
+
+    Ok(PersistSummary {
+        mirrored_files: report.files.len(),
+        mirrored_rules,
+    })
 }
 
 fn print_bundled_pack_status() -> Result<(), String> {
@@ -357,10 +585,17 @@ fn load_verified_rules_with_registry(
             }
         }
 
+        let relative_path = relative_rule_path(root, &path)?;
+        let parsed_rules = parse_rule_definitions(&source_text, &relative_path);
+        report.cataloged_rules += parsed_rules.len();
         report.files.push(VerifiedRuleFile {
             path,
+            relative_path,
+            sha256: sha256_hex(source_text.as_bytes()),
+            size_bytes: metadata.len(),
             source_text,
             observation,
+            parsed_rules,
         });
     }
 
@@ -410,6 +645,193 @@ fn collect_rule_files(
         }
     }
     Ok(())
+}
+
+fn parse_rule_definitions(source_text: &str, relative_path: &str) -> Vec<ParsedRule> {
+    let namespace = Path::new(relative_path)
+        .parent()
+        .map(|parent| parent.to_string_lossy().replace('\\', "/"))
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "default".to_string());
+
+    let mut rules = Vec::new();
+    let mut current_header = String::new();
+    let mut current_body = Vec::new();
+    let mut brace_depth = 0i32;
+    let mut inside_rule = false;
+
+    for line in source_text.lines() {
+        if !inside_rule {
+            if looks_like_rule_start(line) {
+                inside_rule = true;
+                current_header = line.trim().to_string();
+                brace_depth = line.chars().filter(|ch| *ch == '{').count() as i32
+                    - line.chars().filter(|ch| *ch == '}').count() as i32;
+                current_body.clear();
+                if brace_depth <= 0 {
+                    if let Some(rule) =
+                        parse_rule_from_header_and_body(&current_header, &current_body, &namespace)
+                    {
+                        rules.push(rule);
+                    }
+                    inside_rule = false;
+                }
+            }
+            continue;
+        }
+
+        brace_depth += line.chars().filter(|ch| *ch == '{').count() as i32;
+        brace_depth -= line.chars().filter(|ch| *ch == '}').count() as i32;
+        current_body.push(line.to_string());
+        if brace_depth <= 0 {
+            if let Some(rule) =
+                parse_rule_from_header_and_body(&current_header, &current_body, &namespace)
+            {
+                rules.push(rule);
+            }
+            current_header.clear();
+            current_body.clear();
+            inside_rule = false;
+        }
+    }
+
+    rules
+}
+
+fn parse_rule_from_header_and_body(
+    header: &str,
+    body: &[String],
+    namespace: &str,
+) -> Option<ParsedRule> {
+    let header_without_brace = header.split('{').next()?.trim();
+    let header_tokens: Vec<&str> = header_without_brace.split_whitespace().collect();
+    let rule_index = header_tokens.iter().position(|token| *token == "rule")?;
+    let rule_name = header_tokens.get(rule_index + 1)?.trim().to_string();
+    if rule_name.is_empty() {
+        return None;
+    }
+
+    let tags = header_without_brace
+        .split(':')
+        .nth(1)
+        .map(|tail| {
+            tail.split_whitespace()
+                .map(|tag| tag.trim_matches(',').to_string())
+                .filter(|tag| !tag.is_empty())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let mut metadata_lines = Vec::new();
+    let mut strings_count = 0usize;
+    let mut in_meta = false;
+    let mut in_strings = false;
+
+    for line in body {
+        let trimmed = line.trim();
+        if trimmed == "meta:" {
+            in_meta = true;
+            in_strings = false;
+            continue;
+        }
+        if trimmed == "strings:" {
+            in_meta = false;
+            in_strings = true;
+            continue;
+        }
+        if trimmed == "condition:" {
+            in_meta = false;
+            in_strings = false;
+            continue;
+        }
+        if in_meta {
+            metadata_lines.push(trimmed.to_string());
+        }
+        if in_strings && trimmed.starts_with('$') {
+            strings_count += 1;
+        }
+    }
+
+    let metadata = parse_meta_section(&metadata_lines);
+    let category = metadata.get("category").cloned();
+    let author = metadata.get("author").cloned();
+    let description = metadata
+        .get("description")
+        .cloned()
+        .or_else(|| metadata.get("desc").cloned());
+    let reference = metadata
+        .get("reference")
+        .cloned()
+        .or_else(|| metadata.get("ref").cloned());
+
+    Some(ParsedRule {
+        rule_name,
+        namespace: namespace.to_string(),
+        category,
+        author,
+        description,
+        reference,
+        tags,
+        strings_count,
+        metadata,
+    })
+}
+
+fn parse_meta_section(lines: &[String]) -> BTreeMap<String, String> {
+    let mut metadata = BTreeMap::new();
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with("//") {
+            continue;
+        }
+        let Some((key, raw_value)) = trimmed.split_once('=') else {
+            continue;
+        };
+        let key = key.trim().to_lowercase();
+        let value = normalize_meta_value(raw_value);
+        if !key.is_empty() && !value.is_empty() {
+            metadata.insert(key, value);
+        }
+    }
+    metadata
+}
+
+fn normalize_meta_value(raw_value: &str) -> String {
+    let trimmed = raw_value.trim().trim_end_matches(',').trim();
+    let unquoted = trimmed
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .unwrap_or(trimmed);
+    unquoted.trim().to_string()
+}
+
+fn looks_like_rule_start(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with("rule ")
+        || trimmed.starts_with("private rule ")
+        || trimmed.starts_with("global rule ")
+        || trimmed.starts_with("private global rule ")
+        || trimmed.starts_with("global private rule ")
+}
+
+fn relative_rule_path(root: &Path, path: &Path) -> Result<String, String> {
+    let relative = path
+        .strip_prefix(root)
+        .map_err(|e| format!("failed to normalize YARA rule path {}: {e}", path.display()))?;
+    let display = relative.to_string_lossy().replace('\\', "/");
+    ensure_normalized_relative_path(&display, "local_rule.relative_path")?;
+    Ok(display)
+}
+
+fn stable_key(kind: &str, value: &str) -> String {
+    sha256_hex(format!("{kind}:{value}").as_bytes())
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 fn is_rule_file(path: &Path) -> bool {
@@ -478,14 +900,7 @@ fn ensure_normalized_relative_path(path: &str, field_name: &str) -> Result<(), S
 fn count_rule_definitions(source_text: &str) -> usize {
     source_text
         .lines()
-        .filter(|line| {
-            let trimmed = line.trim_start();
-            trimmed.starts_with("rule ")
-                || trimmed.starts_with("private rule ")
-                || trimmed.starts_with("global rule ")
-                || trimmed.starts_with("private global rule ")
-                || trimmed.starts_with("global private rule ")
-        })
+        .filter(|line| looks_like_rule_start(line))
         .count()
 }
 
@@ -500,7 +915,6 @@ fn sha256_hex(data: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn empty_rule_directory_reports_clean_status() {
@@ -512,6 +926,7 @@ mod tests {
         assert_eq!(report.verified, 0);
         assert_eq!(report.failures, 0);
         assert_eq!(report.sidecars, 0);
+        assert_eq!(report.cataloged_rules, 0);
         assert!(report.files.is_empty());
 
         let _ = fs::remove_dir_all(dir);
@@ -537,13 +952,16 @@ mod tests {
         assert_eq!(report.failures, 0);
         assert_eq!(report.sidecars, 1);
         assert_eq!(report.skipped, 0);
+        assert_eq!(report.cataloged_rules, 1);
         assert_eq!(report.files[0].source_text, body);
+        assert_eq!(report.files[0].parsed_rules.len(), 1);
 
         let report = load_verified_rules_with_registry(&dir, &registry).unwrap();
         assert_eq!(report.verified, 1);
         assert_eq!(report.warnings, 0);
         assert_eq!(report.failures, 0);
         assert_eq!(report.sidecars, 1);
+        assert_eq!(report.cataloged_rules, 1);
         assert!(report.skipped >= 1);
 
         let _ = fs::remove_dir_all(dir);
@@ -566,6 +984,7 @@ mod tests {
         assert_eq!(report.verified, 0);
         assert_eq!(report.failures, 1);
         assert_eq!(report.sidecars, 1);
+        assert_eq!(report.cataloged_rules, 0);
         assert_eq!(report.files.len(), 0);
 
         let _ = fs::remove_dir_all(dir);
@@ -582,6 +1001,7 @@ mod tests {
         assert_eq!(report.verified, 0);
         assert_eq!(report.sidecars, 0);
         assert_eq!(report.skipped, 1);
+        assert_eq!(report.cataloged_rules, 0);
 
         let _ = fs::remove_dir_all(dir);
     }
@@ -598,6 +1018,7 @@ mod tests {
         assert_eq!(report.failures, 0);
         assert_eq!(report.sidecars, 1);
         assert_eq!(report.skipped, 0);
+        assert_eq!(report.cataloged_rules, 0);
 
         let _ = fs::remove_dir_all(dir);
     }
@@ -675,6 +1096,35 @@ global rule visible_sample {
 }
 "#;
         assert_eq!(count_rule_definitions(source), 2);
+    }
+
+    #[test]
+    fn parser_extracts_rule_metadata_and_tags() {
+        let source = r#"
+private rule suspicious_sample : malware c2 {
+    meta:
+        author = "analyst"
+        description = "suspicious sample"
+        reference = "https://example.invalid/rule"
+        category = "research"
+    strings:
+        $a = "alpha"
+        $b = "beta"
+    condition:
+        any of them
+}
+"#;
+        let rules = parse_rule_definitions(source, "research/sample.yar");
+        assert_eq!(rules.len(), 1);
+        let rule = &rules[0];
+        assert_eq!(rule.rule_name, "suspicious_sample");
+        assert_eq!(rule.namespace, "research");
+        assert_eq!(rule.category.as_deref(), Some("research"));
+        assert_eq!(rule.author.as_deref(), Some("analyst"));
+        assert_eq!(rule.description.as_deref(), Some("suspicious sample"));
+        assert_eq!(rule.reference.as_deref(), Some("https://example.invalid/rule"));
+        assert_eq!(rule.tags, vec!["malware".to_string(), "c2".to_string()]);
+        assert_eq!(rule.strings_count, 2);
     }
 
     fn unique_temp_dir() -> PathBuf {


### PR DESCRIPTION
## Summary
- extend `vigil --yara-rule-status` so verified local YARA rules are mirrored into the protected SQLite state database
- parse a normalized per-file and per-rule catalog from operator-managed `.yar/.yara` inputs
- document that the YARA status command now verifies sidecars, records provenance, and keeps the local catalog in sync

## Details
- add lazy-initialized `yara_source`, `yara_rule_file`, and `yara_rule` tables in the existing state DB
- keep operator-file provenance as the trust boundary, then mirror verified rule metadata into SQLite in the same integrity-checkpoint flow
- capture stable file metadata such as relative path, digest, observation state, and parsed rule names
- extract lightweight rule metadata (`author`, `description`, `reference`, `category`, tags) for later UI and scan integration work

## Notes
- this does not run YARA scans yet; it builds the catalog foundation for later process and memory scanning work
- I could not run local Rust builds or tests in this workspace because the repository was not available as a writable local checkout here