### PR TITLE
docs: sync Phase 20 roadmap status with merged YARA foundations

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -141,15 +141,16 @@ Replace the OS firewall with Vigil's own WFP (Windows) / nftables/XDP (Linux) en
 
 ---
 
-## Phase 20 — YARA Signature Integration (OPEN backlog)
+## Phase 20 — YARA Signature Integration 🚧 FOUNDATIONS IN PLACE
 
 Add signature-based malware detection alongside the existing behavioural heuristics. YARA scans new processes and selected memory regions on creation, catches known malware families that behavioural scoring alone misses, and feeds matches into the existing scoring pipeline with clear `YARA rule: <name>` reasons and ATT&CK tags.
 
-- [ ] **Binary embedding of community YARA rules** — bundle a curated ruleset (e.g. Valhalla, YARA Forge) at compile time, updated via signed auto-update (Phase 23).
+- [x] **Binary embedding of community YARA rules foundations** — one reviewed MIT-licensed InQuest snapshot is vendored under `third_party/yara/inquest-community-core/`; `build.rs` generates a bundled-pack manifest plus embedded file index at compile time, and `vigil --yara-rule-status` validates the bundled hashes and rule counts offline. Signed refresh still belongs to Phase 23.
 - [ ] **Process scan on creation** — scan the executable path with YARA when a new process is detected; score bump on match.
 - [ ] **Memory region scan** — scan selected process memory (e.g., `--dump` target) for in-memory malware that hides from disk scanning.
 - [ ] **YARA rule management UI** — show matched rules in the inspector, allow operators to toggle rule categories, and view rule metadata (author, description, reference).
-- [ ] **Custom rule import** — let operators drop their own `.yar` files alongside blocklists, verified by `.sha256` sidecar (same integrity model as response rules). Intake/status foundation is now exposed through `vigil --yara-rule-status`.
+- [x] **Custom rule import foundations** — operators can drop `.yar` files alongside blocklists, verified by `.sha256` sidecars (same integrity model as response rules); `vigil --yara-rule-status` records provenance, validates intake, and mirrors parsed rule metadata into the protected SQLite state catalog for later scan and UI work.
+- [x] **Pack manifest validation foundation** — `vigil --validate-yara-pack-manifest PATH/TO/manifest.json` validates schema-version-1 bundled-pack metadata so future reviewed imports and signed-update payloads share the same provenance contract.
 
 ---
 
@@ -297,7 +298,7 @@ Two differentiators bundled together because each alone is narrow, but together 
 | 7.x | 17 | Protocol expansion | ✅ Complete |
 | 8.x | 18 | Windows/Linux detection and response parity | 🚧 Foundations in place |
 | 9.x | 19 | Native OS firewall engine | 🚧 Foundations in place |
-| 10.x | 20 | YARA signature integration | 🔲 Backlog |
+| 10.x | 20 | YARA signature integration | 🚧 Foundations in place |
 | 11.x | 21 | Security posture dashboard | 🔲 Backlog |
 | 12.x | 22 | Jitter-aware C2 beaconing detection | 🔲 Backlog |
 | 13.x | 23 | Signed auto-update channel | 🔲 Backlog |

--- a/docs/YARA-PACK-MANIFEST.md
+++ b/docs/YARA-PACK-MANIFEST.md
@@ -91,10 +91,20 @@ A future signed YARA update should therefore include both:
 See `docs/YARA-PACK-MANIFEST.example.json` for a concrete schema-version-1
 example.
 
+## Current foundation status
+
+The schema and validator are no longer just a paper design:
+
+- `vigil --validate-yara-pack-manifest` now validates schema-version-1 manifest
+  metadata offline
+- `build.rs` generates a bundled-pack manifest at compile time from reviewed
+  pack metadata under `third_party/yara/inquest-community-core/`
+- `vigil --yara-rule-status` validates the embedded bundled-pack manifest and
+  bundled file hashes before reporting operator-visible status
+
 ## Safest next implementation step
 
-The manifest validator now gives maintainers a safe offline gate for future
-bundle metadata. The next safe code slice remains a build-time importer for one
-explicitly approved upstream community ruleset that emits this manifest format
-while preserving the source-selection and redistribution rules in
-`docs/YARA-RULESET-COMPLIANCE.md`.
+The next safe Phase 20 slice is runtime scan integration on top of the existing
+trusted-pack foundation: use the already embedded and validated bundled pack for
+process-on-create scanning before expanding to memory scanning, richer UI, or
+broader category controls.

--- a/docs/YARA-RULESET-COMPLIANCE.md
+++ b/docs/YARA-RULESET-COMPLIANCE.md
@@ -119,10 +119,21 @@ Bundled rules and operator-imported rules must keep separate provenance so a
 local custom-rule edit never appears to be a vendor pack update, and a bundled
 pack refresh never overwrites operator-managed files.
 
+## Current foundation status
+
+The first safe bundled-pack slice is now in the tree:
+
+- one reviewed MIT-licensed InQuest snapshot is imported at build time under
+  `third_party/yara/inquest-community-core/`
+- compile-time manifest generation preserves upstream URL, pinned reference,
+  license, category, SHA-256, and rule-count metadata
+- `vigil --yara-rule-status` validates the embedded pack before surfacing it to
+  operators, keeping bundled provenance separate from operator-managed local
+  rules
+
 ## Safest next implementation step
 
-This contract makes the next unfinished Phase 20 item more concrete. The
-manifest-format foundation now exists in `docs/YARA-PACK-MANIFEST.md`. The next
-safe code slice is a build-time importer for one explicitly approved upstream
-community ruleset that emits that manifest while preserving the provenance,
-redistribution, and signed-update rules above.
+The next safe Phase 20 step is to use that already reviewed and validated pack
+for process-on-create scanning. Broader source expansion, category toggles, and
+memory scanning can stay behind that narrower execution path so Vigil does not
+skip ahead to a larger and less-auditable YARA integration all at once.


### PR DESCRIPTION
## Summary
- update `ROADMAP.md` so Phase 20 is marked as `FOUNDATIONS IN PLACE` instead of untouched backlog
- mark the already merged bundled-pack, local custom-rule intake, and pack-manifest validator foundations as done with precise scope notes
- refresh the YARA manifest and ruleset-contract docs so their “next step” guidance points at runtime scan integration instead of already-merged groundwork

## Why this task
There were no open PRs, no open issues, and no active CI or review blockers to follow up on in `YMRYMR/vigil`.

The repo’s primary planning source had drifted behind the codebase after the recent merged Phase 20 PRs (`#333`, `#334`, `#335`). Leaving that mismatch in place would keep future scheduled runs and human triage pointed at work that is already on `master`, which is exactly the kind of duplicate churn this automation should avoid.

## Scope
This PR is documentation-only. It does not claim that YARA process or memory scanning is done.

It only records the foundations already present on `master`:
- reviewed bundled-pack import and compile-time embedding
- offline bundled-pack manifest validation
- operator-local `.yar` intake with `.sha256` sidecars and protected catalog mirroring

## Validation
I validated the status update against the current `master` code and merged PR history:
- `build.rs`
- `src/yara_rules.rs`
- `third_party/yara/inquest-community-core/pack-metadata.json`
- merged PRs `#333`, `#334`, and `#335`

I could not run the Rust test suite in this scheduled environment because the repository is not available as a local checkout in the container; this pass is based on code inspection and GitHub-side repository state.