### PR TITLE
Track closed connection lifetimes in activity history

### DIFF
--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -60,12 +60,14 @@ fn handle_realtime_event(
             "CLOSED" | "TIME_WAIT" | "CLOSE_WAIT" | "DELETE_TCB"
         ) {
             if let Some(info) = known.remove(&key) {
+                let snapshot = finalize_closed_snapshot(info);
                 let _ = tx.send(ConnEvent::Closed {
-                    pid: info.pid,
-                    local: info.local_addr.clone(),
-                    remote: info.remote_addr.clone(),
-                    snapshot: Box::new(finalize_closed_snapshot(info)),
+                    pid: snapshot.pid,
+                    local: snapshot.local_addr.clone(),
+                    remote: snapshot.remote_addr.clone(),
+                    snapshot: Box::new(snapshot.clone()),
                 });
+                let _ = tx.send(ConnEvent::New(snapshot));
             }
         }
         return;
@@ -374,12 +376,14 @@ async fn poll_loop(
                 let stale: Vec<ConnKey> = known.keys().filter(|k| !current_keys.contains(*k)).cloned().collect();
                 for key in stale {
                     if let Some(info) = known.remove(&key) {
+                        let snapshot = finalize_closed_snapshot(info);
                         let _ = tx.send(ConnEvent::Closed {
-                            pid: info.pid,
-                            local: info.local_addr.clone(),
-                            remote: info.remote_addr.clone(),
-                            snapshot: Box::new(finalize_closed_snapshot(info)),
+                            pid: snapshot.pid,
+                            local: snapshot.local_addr.clone(),
+                            remote: snapshot.remote_addr.clone(),
+                            snapshot: Box::new(snapshot.clone()),
                         });
+                        let _ = tx.send(ConnEvent::New(snapshot));
                     }
                 }
                 let active_pids: HashSet<u32> = known.keys().map(|k| k.pid).collect();

--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -64,6 +64,7 @@ fn handle_realtime_event(
                     pid: info.pid,
                     local: info.local_addr.clone(),
                     remote: info.remote_addr.clone(),
+                    snapshot: Box::new(finalize_closed_snapshot(info)),
                 });
             }
         }
@@ -377,6 +378,7 @@ async fn poll_loop(
                             pid: info.pid,
                             local: info.local_addr.clone(),
                             remote: info.remote_addr.clone(),
+                            snapshot: Box::new(finalize_closed_snapshot(info)),
                         });
                     }
                 }
@@ -449,6 +451,9 @@ fn process_conn(
             },
             status: raw_conn.status.clone(),
             protocol: raw_conn.protocol,
+            first_seen_unix: unix_now(),
+            closed_unix: None,
+            duration_secs: None,
             score: 0,
             reasons: vec![],
             attack_tags: vec![],
@@ -476,6 +481,7 @@ fn process_conn(
         return;
     }
     let total_start = std::time::Instant::now();
+    let first_seen_unix = unix_now();
 
     let proc = process::collect(raw_conn.pid, svc_map);
     let t_process = total_start.elapsed();
@@ -694,6 +700,9 @@ fn process_conn(
         remote_addr,
         status: raw_conn.status.clone(),
         protocol: raw_conn.protocol,
+        first_seen_unix,
+        closed_unix: None,
+        duration_secs: None,
         score: score_value,
         reasons: reasons.clone(),
         attack_tags,
@@ -727,6 +736,22 @@ fn process_conn(
         return;
     };
     let _ = tx.send(event);
+}
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn finalize_closed_snapshot(mut info: ConnInfo) -> ConnInfo {
+    let closed_unix = unix_now();
+    info.timestamp = Local::now().format("%H:%M:%S").to_string();
+    info.status = "CLOSED".to_string();
+    info.closed_unix = Some(closed_unix);
+    info.duration_secs = Some(closed_unix.saturating_sub(info.first_seen_unix));
+    info
 }
 
 /// Returns `true` when an address string contains a publicly routable IP.

--- a/src/types.rs
+++ b/src/types.rs
@@ -42,6 +42,12 @@ pub struct ConnInfo {
     pub status: String,
     #[serde(default)]
     pub protocol: TransportProtocol,
+    #[serde(default)]
+    pub first_seen_unix: u64,
+    #[serde(default)]
+    pub closed_unix: Option<u64>,
+    #[serde(default)]
+    pub duration_secs: Option<u64>,
 
     pub score: u8,
     pub reasons: Vec<String>,
@@ -88,6 +94,9 @@ pub enum ConnEvent {
         pid: u32,
         local: String,
         remote: String,
+        timestamp: String,
+        closed_unix: u64,
+        duration_secs: Option<u64>,
     },
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -90,14 +90,7 @@ pub struct ConnInfo {
 pub enum ConnEvent {
     New(ConnInfo),
     Alert(ConnInfo),
-    Closed {
-        pid: u32,
-        local: String,
-        remote: String,
-        timestamp: String,
-        closed_unix: u64,
-        duration_secs: Option<u64>,
-    },
+    Closed(ConnInfo),
 }
 
 #[allow(dead_code)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -90,7 +90,12 @@ pub struct ConnInfo {
 pub enum ConnEvent {
     New(ConnInfo),
     Alert(ConnInfo),
-    Closed(ConnInfo),
+    Closed {
+        pid: u32,
+        local: String,
+        remote: String,
+        snapshot: Box<ConnInfo>,
+    },
 }
 
 #[allow(dead_code)]

--- a/src/ui/inspector.rs
+++ b/src/ui/inspector.rs
@@ -459,6 +459,12 @@ fn show_detail(
             };
             kv(ui, "Protocol", proto_label);
             kv(ui, "Time", &conn.timestamp);
+            if let Some(duration_secs) = conn.duration_secs {
+                kv(ui, "Duration", &format_duration_secs(duration_secs));
+            }
+            if conn.closed_unix.is_some() {
+                kv(ui, "Ended", "yes");
+            }
             if !conn.attack_tags.is_empty() {
                 kv(ui, "ATT&CK", &conn.attack_tags.join(", "));
             }
@@ -1399,6 +1405,18 @@ fn warn_btn(text: &str) -> egui::Button<'_> {
         .fill(theme::WARN_BG)
         .stroke(egui::Stroke::new(1.0, theme::WARN))
         .corner_radius(6.0)
+}
+fn format_duration_secs(secs: u64) -> String {
+    let hours = secs / 3_600;
+    let mins = (secs % 3_600) / 60;
+    let secs = secs % 60;
+    if hours > 0 {
+        format!("{hours}h {mins:02}m {secs:02}s")
+    } else if mins > 0 {
+        format!("{mins}m {secs:02}s")
+    } else {
+        format!("{secs}s")
+    }
 }
 fn format_remaining(duration: std::time::Duration) -> String {
     let secs = duration.as_secs();


### PR DESCRIPTION
## Summary
- record first-seen and closed timestamps for connections
- compute connection duration when a connection ends
- surface duration details in the inspector for selected closed connections
- publish final closed connection snapshots back into activity history without adding work to the UI hot path

## Notes
- I could not run local builds in this environment, so this should get a normal compile/test pass in CI.
- This improves same-session visibility of ended connections. It does not, by itself, add persisted replay of pre-login history after the GUI starts.