### PR TITLE
Trigger release builds when a GitHub release is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Summary
- listen for `release.published` in the release workflow
- keep the existing tag-push and manual dispatch triggers intact

## Why
Publishing a release from the GitHub web UI was creating the tag and release page, but not kicking off the installer build pipeline. This makes the workflow respond to the release event as well, so GitHub UI releases generate binaries and release assets the same way tag-push releases do.