### PR TITLE
docs: define production endpoint protection readiness plan

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,6 +6,8 @@ Vigil's active support targets are **Windows and Linux**.
 
 For completed implementation history before Phase 16, use Git history and merged pull requests. This roadmap now tracks active and forward-looking work only.
 
+Production endpoint-protection claims are gated by [`docs/PRODUCTION-ENDPOINT-PROTECTION-PLAN.md`](docs/PRODUCTION-ENDPOINT-PROTECTION-PLAN.md). That plan defines the transparency, safety, reliability, testing, update-trust, and release-evidence bar required before Vigil should be marketed as production endpoint protection.
+
 ---
 
 ## Phase 16 — Public Vulnerability Intelligence & Advisory Feeds 🚧 FOUNDATIONS IN PLACE
@@ -268,44 +270,3 @@ Modern detections hinge on who, not just what. Adds identity attribution so aler
 - [ ] **Directory linkage** — resolve local users to directory identities via per-tenant connector.
 - [ ] **Privileged-account differentiation** — raise alerts on privileged users and service accounts more aggressively than standard users.
 - [ ] **Lateral-movement signal** — detect "this endpoint authenticated to N new internal hosts in a short window" as a first-class scoring input.
-- [ ] **Identity surface in UI and reports** — show user context in inspector, alerts, and compliance reports.
-
----
-
-## Phase 30 — Playbook Builder & SaaS-session Visibility (PRO backlog)
-
-Two differentiators bundled together because each alone is narrow, but together they round out the modern endpoint story.
-
-### Low-code response playbooks
-
-- [ ] **GUI rule builder** in the fleet console on top of the existing response-rule engine.
-- [ ] **Pre-built playbooks** — ransomware-like behaviour → isolate + capture PCAP + memory-dump + page; LoLBAS + new country → require approval before block.
-- [ ] **Dry-run and rollback window** — every action has a reversible TTL and an operator undo button before commitment.
-
-### Browser / SaaS-session visibility
-
-- [ ] **Tab / SaaS-app attribution** — correlate connections to browser tab identity and known SaaS destinations where possible.
-- [ ] **OAuth token exfil signal** — detect anomalous cross-origin token flows.
-- [ ] **Per-SaaS data-volume anomaly** — baseline typical outbound volume per SaaS destination and flag deviations.
-
----
-
-## Version Plan
-
-| Version | Phase | Description | Status |
-|---|---|---|---|
-| 6.x | 16 | Public vulnerability intelligence & advisory feeds | ✅ Complete |
-| 7.x | 17 | Protocol expansion | ✅ Complete |
-| 8.x | 18 | Windows/Linux detection and response parity | 🚧 Foundations in place |
-| 9.x | 19 | Native OS firewall engine | 🚧 Foundations in place |
-| 10.x | 20 | YARA signature integration | 🚧 Foundations in place |
-| 11.x | 21 | Security posture dashboard | 🔲 Backlog |
-| 12.x | 22 | Jitter-aware C2 beaconing detection | 🔲 Backlog |
-| 13.x | 23 | Signed auto-update channel | 🔲 Backlog |
-| 14.x | 24 | File integrity monitoring | 🔲 Backlog |
-| PRO 1.x | 25 | Cloud fleet console & integrations | 🔲 Backlog |
-| PRO 1.x | 26 | MSP multi-tenant & white-label | 🔲 Backlog |
-| PRO 1.x | 27 | Managed threat intel feed | 🔲 Backlog |
-| PRO 1.x | 28 | Compliance reporting pack | 🔲 Backlog |
-| PRO 1.x | 29 | Identity & user context | 🔲 Backlog |
-| PRO 1.x | 30 | Playbook builder & SaaS-session visibility | 🔲 Backlog |

--- a/docs/PRODUCTION-ENDPOINT-PROTECTION-PLAN.md
+++ b/docs/PRODUCTION-ENDPOINT-PROTECTION-PLAN.md
@@ -1,0 +1,166 @@
+# Vigil Production Endpoint Protection Plan
+
+This document turns Vigil's endpoint-protection goal into an implementation and release-readiness contract.
+
+The target is a local Windows/Linux endpoint protection system that is transparent to the operator, safe by default, secure against tampering, reliable across upgrades and crashes, and honest about what it can and cannot protect.
+
+## Product principles
+
+1. **Transparent protection** — every alert, score change, block, quarantine, update, and policy decision must expose the evidence and rule path that caused it.
+2. **Safe by default** — fresh installs observe before they disrupt. Destructive or connectivity-breaking actions require explicit policy, clear UI state, and reversible recovery.
+3. **Fail open for availability** — Vigil must never repeatedly prevent login, networking, package updates, remote administration, or safe uninstall because one Vigil component failed.
+4. **Fail closed for trust inputs** — signed update manifests, bundled rule manifests, protected policy, and Vigil-owned evidence must be rejected on missing, stale, mismatched, or unverifiable integrity metadata.
+5. **Least privilege by mode** — user-mode observation must remain useful. Privileged service, firewall, process, forensic, and memory features must be isolated and auditable.
+6. **No hidden judgement** — reputation, advisory, YARA, firewall, heuristic, and response-rule decisions must be inspectable locally without requiring a cloud account.
+7. **Measured reliability** — production claims require repeatable test evidence, not just implemented features.
+
+## Production readiness levels
+
+### Level 0 — Development build
+
+A build may be useful for local development, but it is not user-trustworthy yet.
+
+Required evidence:
+
+- Compiles on the supported targets touched by the change.
+- Unit tests for changed pure logic where practical.
+- No knowingly stale or misleading user-facing claims.
+
+### Level 1 — Alpha operator build
+
+A build may be used by technical operators on non-critical machines.
+
+Required evidence:
+
+- CI passes on Windows and Linux.
+- Install, launch, observe, quit, and uninstall smoke tests are documented for both supported OS families.
+- Disruptive controls are disabled by default or guarded by explicit confirmation.
+- Logs and audit trail explain every protection action.
+- Known gaps are visible in the user guide and release notes.
+
+### Level 2 — Beta protection build
+
+A build may be recommended for controlled daily-driver testing by informed users.
+
+Required evidence:
+
+- Health/status surface shows whether real-time monitoring, polling fallback, advisory cache, YARA rules, response rules, firewall backend, service mode, and update trust are working.
+- Upgrade and rollback tests pass across at least the previous two release lines.
+- Crash/restart tests prove break-glass recovery, firewall reconciliation, and policy integrity behavior.
+- False-positive review pass against a benign software corpus.
+- Malware/suspicious-behavior lab pass against documented offline samples and synthetic attacks.
+- Rule and advisory update paths are signed, atomic, rollback-safe, and auditable.
+
+### Level 3 — Production endpoint protection
+
+A build may be marketed as endpoint protection for non-expert users.
+
+Required evidence:
+
+- Reproducible release checklist for Windows installer, Linux package/AppImage, signed manifests, attestations, and uninstall verification.
+- Real-time file/process/network coverage matrix for Windows and Linux, including privilege requirements and fallback behavior.
+- Independent or adversarial validation report for detection coverage and containment safety.
+- Long-running stability soak tests on Windows and Linux.
+- Clear privacy statement and local-data inventory.
+- Emergency recovery path documented and tested without requiring the GUI.
+- User-facing status never says protected unless the required protection subsystems are actually healthy.
+
+## Core workstreams
+
+### 1. Protection health and transparency
+
+Goal: a user can answer "am I protected right now?" without reading logs.
+
+Required deliverables:
+
+- `vigil status --json` for scripting and support.
+- GUI security posture dashboard.
+- Tray health state with explicit degraded reasons.
+- Per-subsystem status for monitoring backend, polling fallback, firewall backend, YARA rules, advisory cache, response rules, update trust, service mode, audit log, and break-glass state.
+- Status must distinguish **healthy**, **degraded**, **disabled by policy**, **needs elevation**, **failed open**, and **unknown**.
+
+### 2. Safe response and containment
+
+Goal: containment prevents damage without creating a new outage.
+
+Required deliverables:
+
+- Dry-run/simulation mode for response rules.
+- Reversible action ledger with operator-visible owner, reason, scope, TTL, and rollback command.
+- Connectivity safety checks before isolation and long-lived firewall changes.
+- Firewall panic and break-glass tests in CI-friendly virtualized environments where possible.
+- Default policies that observe first and require explicit escalation.
+
+### 3. Detection coverage
+
+Goal: cover the common endpoint threat paths honestly and explainably.
+
+Required deliverables:
+
+- Process and connection behavior scoring coverage matrix.
+- YARA executable scanning hardened and surfaced in UI.
+- Memory-region scanning with bounded dumps and fail-open safety.
+- Jitter-aware beaconing detection.
+- File integrity monitoring for critical paths.
+- Advisory matching limited to explainable, high-confidence local product matches.
+- Every detection reason maps to local evidence and, where appropriate, ATT&CK tags.
+
+### 4. Trust, tamper resistance, and updates
+
+Goal: operators can trust what Vigil is running and what data it consumes.
+
+Required deliverables:
+
+- Signed threat-data update channel with atomic apply and rollback.
+- Transparency log for update manifests and rule-pack provenance.
+- Protected local policy and evidence integrity checks.
+- Tamper events surfaced in status, logs, and UI.
+- Release artifacts signed or attested, with documented verification commands.
+
+### 5. Reliability and platform parity
+
+Goal: Windows and Linux behavior is predictable, tested, and honest.
+
+Required deliverables:
+
+- Windows/Linux feature matrix in the user guide.
+- VM smoke-test harness for install, service mode, monitoring, response, update, uninstall, and recovery.
+- Startup fail-open tests.
+- Upgrade/rollback tests.
+- Long-run soak tests for UI mode and service mode.
+- Performance budgets for CPU, memory, event latency, scan queue backpressure, and disk writes.
+
+### 6. User trust and non-expert safety
+
+Goal: non-expert users can use Vigil without accidentally breaking their machine or misunderstanding alerts.
+
+Required deliverables:
+
+- Plain-language alert explanations.
+- Guided first-run observe mode.
+- Safe defaults for auto response and allowlist-only mode.
+- Warnings before actions that can break networking or kill important processes.
+- Help text that names uncertainty instead of overstating confidence.
+- Privacy and local-data documentation.
+
+## Near-term implementation order
+
+1. Implement `vigil status --json` and the internal subsystem health model.
+2. Build the GUI security posture dashboard on top of the same health model.
+3. Add response-rule dry-run mode and action ledger export.
+4. Surface YARA executable scan results in the Inspector before expanding memory scanning.
+5. Add signed threat-data update polling for rule packs and blocklists.
+6. Add VM smoke tests for install, service, firewall panic, recovery, and uninstall.
+7. Complete jitter-aware beaconing and file integrity monitoring only after status/recovery surfaces are reliable.
+
+## Release claim policy
+
+Until Level 3 evidence exists, public language should avoid broad claims such as "keeps any machine protected" or "antivirus replacement".
+
+Preferred current wording:
+
+> Vigil is an alpha-stage Windows/Linux endpoint monitoring and response tool with transparent scoring, local-first advisory context, active-response foundations, and YARA foundations.
+
+Preferred future wording after Level 3 evidence:
+
+> Vigil is a local-first Windows/Linux endpoint protection system with transparent detection, signed threat intelligence, safe active response, and auditable recovery.


### PR DESCRIPTION
## Summary
- add a production endpoint-protection plan that defines the transparency, safety, reliability, testing, update-trust, and release-evidence bar for Vigil
- link the plan from the roadmap so future endpoint-protection claims are gated by explicit readiness levels
- keep this as documentation only; no runtime behavior changes

## Why
Vigil can become a real endpoint protection system, but the project needs a visible contract for when it is safe to claim that. This plan keeps the next work focused on health status, safe response, detection coverage, trust/update integrity, reliability, and non-expert safety.

## Validation
- documentation-only change
- no code or workflow changes

## Closed
Superseded because the roadmap edit accidentally dropped Phase 30 and the Version Plan from the branch. A corrected doc-only PR will keep the existing roadmap untouched.