### PR TITLE
Clarify shipped YARA scan behavior in operator docs

### DIFF
--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -196,7 +196,9 @@ vigil --verify-update-manifest Vigil-latest-update-manifest.json Vigil-latest-up
 
 ## Local YARA rule intake
 
-Vigil's current Phase 20 YARA work is limited to trusted local rule intake. It does not run YARA scans yet, but it already lets you stage custom rules using the same integrity and provenance model as other operator-managed inputs.
+Vigil now uses the reviewed bundled rules plus any verified operator-local rules for bounded runtime executable scanning. When Vigil first sees a readable executable for a newly observed process, it can scan that on-disk executable in the background and surface matches through the normal score reasons as `YARA rule: <name>`.
+
+`vigil --yara-rule-status` remains the operator-facing intake command. The command itself does not run scans. It verifies which local rules under `yara-rules/` are trusted enough to join the runtime ruleset and records their provenance.
 
 1. Run `vigil --yara-rule-status` if you want Vigil to print the exact `yara-rules/` directory path it expects on your machine.
 2. Place each `.yar` or `.yara` file under that directory with a matching `.sha256` sidecar beside it. For example, `sample.yar` should have `sample.yar.sha256`.
@@ -213,6 +215,8 @@ vigil --yara-rule-status
 - any failure means Vigil did not accept that rule because the sidecar is missing, unreadable, or mismatched.
 
 Warnings on first load or after an intentional rule edit are expected because Vigil records provenance instead of silently treating every local change as corruption.
+
+The next YARA roadmap slice is still narrower than broad live-memory scanning. The safest follow-up remains selected-memory targets such as operator-visible or already-captured process dumps on supported platforms, while preserving the same fail-open behavior as the shipped executable scan path.
 
 ## Advisory snapshot imports
 

--- a/docs/YARA-PROCESS-SCAN.md
+++ b/docs/YARA-PROCESS-SCAN.md
@@ -161,6 +161,7 @@ The executable-scan wiring described here now lives in `src/yara_scan.rs` and
 `src/monitor/mod.rs::process_conn()`.
 
 The safest next code change is therefore the next unchecked roadmap item:
-memory-region scanning, while preserving the same trust boundary, explainable
-match surfacing, and fail-open runtime behavior used by the shipped executable
-scan slice.
+selected-memory scanning that starts from operator-visible, already-captured
+process-dump targets on supported platforms, while preserving the same trust
+boundary, explainable match surfacing, and fail-open runtime behavior used by
+the shipped executable scan slice.


### PR DESCRIPTION
## Summary
- correct the user guide so it reflects the shipped Phase 20 executable-scan foundation
- clarify that `vigil --yara-rule-status` verifies trusted rule intake but does not itself run scans
- narrow the documented next memory-scan slice to selected, operator-visible process-dump targets on supported platforms

## Why
The roadmap's next explicit unfinished item is Phase 20 memory-region scanning. While inspecting that path, I found the operator docs still said Vigil does not run YARA scans yet, which no longer matches the runtime executable-scan foundation already on `master`.

This PR keeps scope small and safe: it fixes the stale docs and tightens the follow-up contract before broader memory-scanning work lands.

## Validation
- reviewed `ROADMAP.md`
- reviewed `src/yara_scan.rs`
- reviewed `src/monitor/mod.rs::process_conn()`
- reviewed the current user-facing YARA guidance in `docs/USER-GUIDE.md` and `docs/YARA-PROCESS-SCAN.md`

## Risk
Low. Documentation-only change; no runtime behavior changes.