### PR TITLE
yara: preserve bundled pack foundation work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,9 @@ ksni = { version = "0.3", default-features = false, features = ["blocking", "tok
 
 [build-dependencies]
 png = "0.18"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.11"
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,62 @@
 //   falls back to generating `assets/vigil.ico` (16 / 32 / 48 px).
 //   The selected .ico is embedded via `winres`.
 
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+#[derive(Debug, Deserialize)]
+struct ImportedPackMetadata {
+    pack_name: String,
+    pack_version: String,
+    generated_at: String,
+    upstream_name: String,
+    upstream_source_url: String,
+    upstream_reference: String,
+    license: String,
+    files: Vec<ImportedPackFileMetadata>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ImportedPackFileMetadata {
+    relative_path: String,
+    source_path: String,
+    source_url: String,
+    source_reference: String,
+    category: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct GeneratedPackManifest<'a> {
+    schema_version: u32,
+    pack_name: &'a str,
+    pack_version: &'a str,
+    generated_at: &'a str,
+    upstream_name: &'a str,
+    upstream_source_url: &'a str,
+    upstream_reference: &'a str,
+    license: &'a str,
+    files: Vec<GeneratedPackFileManifest<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+struct GeneratedPackFileManifest<'a> {
+    relative_path: &'a str,
+    sha256: String,
+    rule_count: usize,
+    source_url: &'a str,
+    source_reference: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    category: Option<&'a str>,
+}
+
+#[derive(Debug)]
+struct EmbeddedPackFile {
+    relative_path: String,
+    repo_path: String,
+}
+
 fn main() {
     // Regenerate resources when script or icon assets change.
     println!("cargo:rerun-if-changed=build.rs");
@@ -19,6 +75,7 @@ fn main() {
     println!("cargo:rerun-if-changed=assets/vigil_tray_red.ico");
     println!("cargo:rerun-if-changed=assets/vigil.png");
     println!("cargo:rerun-if-changed=assets/vigil.ico");
+    println!("cargo:rerun-if-changed=third_party/yara/inquest-community-core");
 
     std::fs::create_dir_all("assets").expect("failed to create assets/");
 
@@ -54,6 +111,7 @@ fn main() {
     ensure_tray_ico("assets/vigil_tray_green.ico", 0x22, 0xC5, 0x5E);
     ensure_tray_ico("assets/vigil_tray_orange.ico", 0xF5, 0x9E, 0x0B);
     ensure_tray_ico("assets/vigil_tray_red.ico", 0xEF, 0x44, 0x44);
+    generate_bundled_yara_pack();
 
     if std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() == "windows" {
         embed_windows_icon();
@@ -81,6 +139,152 @@ fn ensure_tray_ico(path: &str, r: u8, g: u8, b: u8) {
     }
     let ico = make_ico(&[16, 32, 48], r, g, b);
     std::fs::write(path, &ico).unwrap_or_else(|e| panic!("failed to write {path}: {e}"));
+}
+
+fn generate_bundled_yara_pack() {
+    let pack_root = Path::new("third_party/yara/inquest-community-core");
+    let metadata_path = pack_root.join("pack-metadata.json");
+    let metadata: ImportedPackMetadata = serde_json::from_str(
+        &fs::read_to_string(&metadata_path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", metadata_path.display())),
+    )
+    .unwrap_or_else(|e| panic!("failed to parse {}: {e}", metadata_path.display()));
+
+    assert_non_empty(&metadata.pack_name, "pack_name");
+    assert_non_empty(&metadata.pack_version, "pack_version");
+    assert_non_empty(&metadata.generated_at, "generated_at");
+    assert_non_empty(&metadata.upstream_name, "upstream_name");
+    assert_non_empty(&metadata.upstream_source_url, "upstream_source_url");
+    assert_non_empty(&metadata.upstream_reference, "upstream_reference");
+    assert_non_empty(&metadata.license, "license");
+    if metadata.files.is_empty() {
+        panic!("{} must list at least one bundled YARA rule file", metadata_path.display());
+    }
+
+    let mut manifest_files = Vec::with_capacity(metadata.files.len());
+    let mut embedded_files = Vec::with_capacity(metadata.files.len());
+    for file in &metadata.files {
+        assert_non_empty(&file.relative_path, "files[].relative_path");
+        assert_non_empty(&file.source_path, "files[].source_path");
+        assert_non_empty(&file.source_url, "files[].source_url");
+        assert_non_empty(&file.source_reference, "files[].source_reference");
+        if let Some(category) = &file.category {
+            assert_non_empty(category, "files[].category");
+        }
+        ensure_normalized_relative_path(&file.relative_path, "files[].relative_path");
+        ensure_normalized_relative_path(&file.source_path, "files[].source_path");
+
+        let source_fs_path = pack_root.join(&file.source_path);
+        let source_text = fs::read_to_string(&source_fs_path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", source_fs_path.display()));
+        let rule_count = count_rule_definitions(&source_text);
+        if rule_count == 0 {
+            panic!(
+                "bundled YARA file {} does not contain any rule definitions",
+                source_fs_path.display()
+            );
+        }
+        manifest_files.push(GeneratedPackFileManifest {
+            relative_path: &file.relative_path,
+            sha256: sha256_hex(source_text.as_bytes()),
+            rule_count,
+            source_url: &file.source_url,
+            source_reference: &file.source_reference,
+            category: file.category.as_deref(),
+        });
+        embedded_files.push(EmbeddedPackFile {
+            relative_path: file.relative_path.clone(),
+            repo_path: normalize_repo_path(&source_fs_path),
+        });
+    }
+
+    let manifest = GeneratedPackManifest {
+        schema_version: 1,
+        pack_name: &metadata.pack_name,
+        pack_version: &metadata.pack_version,
+        generated_at: &metadata.generated_at,
+        upstream_name: &metadata.upstream_name,
+        upstream_source_url: &metadata.upstream_source_url,
+        upstream_reference: &metadata.upstream_reference,
+        license: &metadata.license,
+        files: manifest_files,
+    };
+
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR missing"));
+    fs::write(
+        out_dir.join("bundled_yara_pack_manifest.json"),
+        serde_json::to_string_pretty(&manifest)
+            .expect("failed to serialize generated bundled YARA manifest"),
+    )
+    .expect("failed to write bundled YARA manifest");
+    fs::write(
+        out_dir.join("bundled_yara_pack_files.rs"),
+        render_embedded_file_index(&embedded_files),
+    )
+    .expect("failed to write bundled YARA embedded file index");
+}
+
+fn render_embedded_file_index(files: &[EmbeddedPackFile]) -> String {
+    let mut rendered = String::from("const EMBEDDED_BUNDLED_RULE_FILES: &[EmbeddedBundledRuleFile] = &[\n");
+    for file in files {
+        rendered.push_str(&format!(
+            "    EmbeddedBundledRuleFile {{ relative_path: {relative_path:?}, source_text: include_str!(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/{repo_path}\")) }},\n",
+            relative_path = file.relative_path,
+            repo_path = file.repo_path,
+        ));
+    }
+    rendered.push_str("];\n");
+    rendered
+}
+
+fn normalize_repo_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn assert_non_empty(value: &str, field_name: &str) {
+    if value.trim().is_empty() {
+        panic!("{field_name} must not be empty");
+    }
+}
+
+fn ensure_normalized_relative_path(path: &str, field_name: &str) {
+    if path.trim().is_empty() {
+        panic!("{field_name} must not be empty");
+    }
+    if path.contains('\\') {
+        panic!("{field_name} must use slash-separated relative paths: {path}");
+    }
+    let candidate = Path::new(path);
+    for component in candidate.components() {
+        match component {
+            Component::Normal(_) => {}
+            Component::CurDir | Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                panic!("{field_name} must stay normalized and relative: {path}");
+            }
+        }
+    }
+}
+
+fn count_rule_definitions(source_text: &str) -> usize {
+    source_text
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            trimmed.starts_with("rule ")
+                || trimmed.starts_with("private rule ")
+                || trimmed.starts_with("global rule ")
+                || trimmed.starts_with("private global rule ")
+                || trimmed.starts_with("global private rule ")
+        })
+        .count()
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    let digest = Sha256::digest(data);
+    digest
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>()
 }
 
 // ── ICO generation ────────────────────────────────────────────────────────────

--- a/src/yara_rules.rs
+++ b/src/yara_rules.rs
@@ -5,13 +5,26 @@
 //! integrity sidecars and provenance tracking so untrusted rules fail closed.
 
 use crate::security::{integrity, operator_provenance};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 const RULE_DIR: &str = "yara-rules";
 const MAX_RULE_FILES: usize = 256;
 const MAX_RULE_FILE_BYTES: u64 = 4 * 1024 * 1024;
 const MAX_SCAN_DEPTH: usize = 4;
+const BUNDLED_PACK_MANIFEST_JSON: &str =
+    include_str!(concat!(env!("OUT_DIR"), "/bundled_yara_pack_manifest.json"));
+
+#[derive(Debug, Clone, Copy)]
+struct EmbeddedBundledRuleFile {
+    relative_path: &'static str,
+    source_text: &'static str,
+}
+
+include!(concat!(env!("OUT_DIR"), "/bundled_yara_pack_files.rs"));
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VerifiedRuleFile {
@@ -32,6 +45,44 @@ pub struct RuleLoadReport {
     pub errors: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BundledPackStatus {
+    manifest: BundledPackManifest,
+    files: Vec<BundledPackFileStatus>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BundledPackFileStatus {
+    relative_path: String,
+    rule_count: usize,
+    category: Option<String>,
+    source_reference: String,
+    source_url: String,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+struct BundledPackManifest {
+    schema_version: u32,
+    pack_name: String,
+    pack_version: String,
+    generated_at: String,
+    upstream_name: String,
+    upstream_source_url: String,
+    upstream_reference: String,
+    license: String,
+    files: Vec<BundledPackManifestFile>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+struct BundledPackManifestFile {
+    relative_path: String,
+    sha256: String,
+    rule_count: usize,
+    source_url: String,
+    source_reference: String,
+    category: Option<String>,
+}
+
 pub fn rule_dir() -> PathBuf {
     crate::config::data_dir().join(RULE_DIR)
 }
@@ -41,8 +92,11 @@ pub fn load_verified_rules() -> Result<RuleLoadReport, String> {
 }
 
 pub fn run_status_cli() -> Result<(), String> {
+    print_bundled_pack_status()?;
+    println!();
+
     let report = load_verified_rules()?;
-    println!("YARA rule directory: {}", report.root.display());
+    println!("Local YARA rule directory: {}", report.root.display());
     if !report.root.exists() {
         println!("No local YARA rule directory found yet.");
         return Ok(());
@@ -72,6 +126,149 @@ pub fn run_status_cli() -> Result<(), String> {
         ));
     }
     Ok(())
+}
+
+fn print_bundled_pack_status() -> Result<(), String> {
+    let Some(pack) = load_bundled_pack_status()? else {
+        println!("Bundled YARA pack: none");
+        return Ok(());
+    };
+
+    println!(
+        "Bundled YARA pack: {} {}",
+        pack.manifest.pack_name, pack.manifest.pack_version
+    );
+    println!("Generated at: {}", pack.manifest.generated_at);
+    println!(
+        "Upstream: {} ({})",
+        pack.manifest.upstream_name, pack.manifest.license
+    );
+    println!("Source URL: {}", pack.manifest.upstream_source_url);
+    println!("Source reference: {}", pack.manifest.upstream_reference);
+    println!("Bundled files: {}", pack.files.len());
+    for file in &pack.files {
+        let category = file.category.as_deref().unwrap_or("uncategorized");
+        println!(
+            "  [bundled] {} ({category}, {} rules)",
+            file.relative_path, file.rule_count
+        );
+    }
+
+    Ok(())
+}
+
+fn load_bundled_pack_status() -> Result<Option<BundledPackStatus>, String> {
+    if EMBEDDED_BUNDLED_RULE_FILES.is_empty() {
+        return Ok(None);
+    }
+    validate_bundled_pack(BUNDLED_PACK_MANIFEST_JSON, EMBEDDED_BUNDLED_RULE_FILES).map(Some)
+}
+
+fn validate_bundled_pack(
+    manifest_json: &str,
+    embedded_files: &[EmbeddedBundledRuleFile],
+) -> Result<BundledPackStatus, String> {
+    let manifest: BundledPackManifest = serde_json::from_str(manifest_json)
+        .map_err(|e| format!("failed to parse bundled YARA pack manifest: {e}"))?;
+    validate_bundled_pack_manifest(&manifest, embedded_files)
+}
+
+fn validate_bundled_pack_manifest(
+    manifest: &BundledPackManifest,
+    embedded_files: &[EmbeddedBundledRuleFile],
+) -> Result<BundledPackStatus, String> {
+    if manifest.schema_version != 1 {
+        return Err(format!(
+            "unsupported bundled YARA manifest schema version {}",
+            manifest.schema_version
+        ));
+    }
+    ensure_non_empty(&manifest.pack_name, "pack_name")?;
+    ensure_non_empty(&manifest.pack_version, "pack_version")?;
+    ensure_non_empty(&manifest.generated_at, "generated_at")?;
+    ensure_non_empty(&manifest.upstream_name, "upstream_name")?;
+    ensure_non_empty(&manifest.upstream_source_url, "upstream_source_url")?;
+    ensure_non_empty(&manifest.upstream_reference, "upstream_reference")?;
+    ensure_non_empty(&manifest.license, "license")?;
+    if manifest.files.is_empty() {
+        return Err("bundled YARA pack manifest must list at least one file".into());
+    }
+
+    let mut embedded_by_path = HashMap::with_capacity(embedded_files.len());
+    for file in embedded_files {
+        if embedded_by_path.insert(file.relative_path, file.source_text).is_some() {
+            return Err(format!(
+                "bundled YARA pack embeds duplicate relative path {}",
+                file.relative_path
+            ));
+        }
+    }
+
+    let mut seen_paths = HashSet::with_capacity(manifest.files.len());
+    let mut files = Vec::with_capacity(manifest.files.len());
+    for file in &manifest.files {
+        ensure_non_empty(&file.relative_path, "files[].relative_path")?;
+        ensure_normalized_relative_path(&file.relative_path, "files[].relative_path")?;
+        if !seen_paths.insert(file.relative_path.clone()) {
+            return Err(format!(
+                "bundled YARA pack manifest lists duplicate relative path {}",
+                file.relative_path
+            ));
+        }
+        ensure_lower_hex_sha256(&file.sha256, "files[].sha256")?;
+        if file.rule_count == 0 {
+            return Err(format!(
+                "bundled YARA pack file {} must have a positive rule_count",
+                file.relative_path
+            ));
+        }
+        ensure_non_empty(&file.source_url, "files[].source_url")?;
+        ensure_non_empty(&file.source_reference, "files[].source_reference")?;
+        if let Some(category) = &file.category {
+            ensure_non_empty(category, "files[].category")?;
+        }
+
+        let Some(source_text) = embedded_by_path.get(file.relative_path.as_str()) else {
+            return Err(format!(
+                "bundled YARA pack file {} is listed in the manifest but missing from the embedded file index",
+                file.relative_path
+            ));
+        };
+        let actual_sha = sha256_hex(source_text.as_bytes());
+        if actual_sha != file.sha256 {
+            return Err(format!(
+                "bundled YARA pack file {} failed SHA-256 verification",
+                file.relative_path
+            ));
+        }
+        let actual_rule_count = count_rule_definitions(source_text);
+        if actual_rule_count != file.rule_count {
+            return Err(format!(
+                "bundled YARA pack file {} advertises {} rules but contains {}",
+                file.relative_path, file.rule_count, actual_rule_count
+            ));
+        }
+
+        files.push(BundledPackFileStatus {
+            relative_path: file.relative_path.clone(),
+            rule_count: file.rule_count,
+            category: file.category.clone(),
+            source_reference: file.source_reference.clone(),
+            source_url: file.source_url.clone(),
+        });
+    }
+
+    if embedded_by_path.len() != seen_paths.len() {
+        return Err(
+            "bundled YARA embedded file index contains files that are missing from the manifest"
+                .into(),
+        );
+    }
+
+    Ok(BundledPackStatus {
+        manifest: manifest.clone(),
+        files,
+    })
 }
 
 fn load_verified_rules_with_registry(
@@ -245,10 +442,64 @@ fn observation_label(observation: &operator_provenance::Observation) -> &'static
     }
 }
 
+fn ensure_non_empty(value: &str, field_name: &str) -> Result<(), String> {
+    if value.trim().is_empty() {
+        Err(format!("{field_name} must not be empty"))
+    } else {
+        Ok(())
+    }
+}
+
+fn ensure_lower_hex_sha256(value: &str, field_name: &str) -> Result<(), String> {
+    if value.len() != 64 || !value.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f')) {
+        return Err(format!("{field_name} must be exactly 64 lowercase hex characters"));
+    }
+    Ok(())
+}
+
+fn ensure_normalized_relative_path(path: &str, field_name: &str) -> Result<(), String> {
+    if path.contains('\\') {
+        return Err(format!("{field_name} must use slash-separated relative paths: {path}"));
+    }
+    let candidate = Path::new(path);
+    for component in candidate.components() {
+        match component {
+            Component::Normal(_) => {}
+            Component::CurDir | Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(format!(
+                    "{field_name} must stay normalized and relative: {path}"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn count_rule_definitions(source_text: &str) -> usize {
+    source_text
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            trimmed.starts_with("rule ")
+                || trimmed.starts_with("private rule ")
+                || trimmed.starts_with("global rule ")
+                || trimmed.starts_with("private global rule ")
+                || trimmed.starts_with("global private rule ")
+        })
+        .count()
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    let digest = Sha256::digest(data);
+    digest
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sha2::{Digest, Sha256};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
@@ -351,12 +602,79 @@ mod tests {
         let _ = fs::remove_dir_all(dir);
     }
 
-    fn sha256_hex(data: &[u8]) -> String {
-        let digest = Sha256::digest(data);
-        digest
-            .iter()
-            .map(|byte| format!("{byte:02x}"))
-            .collect::<String>()
+    #[test]
+    fn bundled_pack_validation_rejects_traversal_paths() {
+        let manifest = BundledPackManifest {
+            schema_version: 1,
+            pack_name: "community-core".into(),
+            pack_version: "2026.05.22.1".into(),
+            generated_at: "2026-05-22T10:20:00Z".into(),
+            upstream_name: "InQuest yara-rules".into(),
+            upstream_source_url: "https://github.com/InQuest/yara-rules".into(),
+            upstream_reference: "fd87530863cca77384f37ae5485707a02207d715".into(),
+            license: "MIT".into(),
+            files: vec![BundledPackManifestFile {
+                relative_path: "../escape.rule".into(),
+                sha256: sha256_hex(b"rule sample { condition: true }\n"),
+                rule_count: 1,
+                source_url: "https://example.invalid/rule".into(),
+                source_reference: "abc123".into(),
+                category: Some("research".into()),
+            }],
+        };
+
+        let embedded = [EmbeddedBundledRuleFile {
+            relative_path: "../escape.rule",
+            source_text: "rule sample { condition: true }\n",
+        }];
+        let err = validate_bundled_pack_manifest(&manifest, &embedded).unwrap_err();
+        assert!(err.contains("normalized and relative"));
+    }
+
+    #[test]
+    fn bundled_pack_validation_rejects_hash_mismatch() {
+        let manifest = BundledPackManifest {
+            schema_version: 1,
+            pack_name: "community-core".into(),
+            pack_version: "2026.05.22.1".into(),
+            generated_at: "2026-05-22T10:20:00Z".into(),
+            upstream_name: "InQuest yara-rules".into(),
+            upstream_source_url: "https://github.com/InQuest/yara-rules".into(),
+            upstream_reference: "fd87530863cca77384f37ae5485707a02207d715".into(),
+            license: "MIT".into(),
+            files: vec![BundledPackManifestFile {
+                relative_path: "research/sample.rule".into(),
+                sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+                    .into(),
+                rule_count: 1,
+                source_url: "https://example.invalid/rule".into(),
+                source_reference: "abc123".into(),
+                category: Some("research".into()),
+            }],
+        };
+
+        let embedded = [EmbeddedBundledRuleFile {
+            relative_path: "research/sample.rule",
+            source_text: "rule sample { condition: true }\n",
+        }];
+        let err = validate_bundled_pack_manifest(&manifest, &embedded).unwrap_err();
+        assert!(err.contains("SHA-256 verification"));
+    }
+
+    #[test]
+    fn count_rule_definitions_handles_private_and_global_rules() {
+        let source = r#"
+private rule hidden_sample {
+    condition:
+        true
+}
+
+global rule visible_sample {
+    condition:
+        true
+}
+"#;
+        assert_eq!(count_rule_definitions(source), 2);
     }
 
     fn unique_temp_dir() -> PathBuf {

--- a/src/yara_rules.rs
+++ b/src/yara_rules.rs
@@ -465,7 +465,10 @@ fn ensure_normalized_relative_path(path: &str, field_name: &str) -> Result<(), S
     for component in candidate.components() {
         match component {
             Component::Normal(_) => {}
-            Component::CurDir | Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+            Component::CurDir
+            | Component::ParentDir
+            | Component::RootDir
+            | Component::Prefix(_) => {
                 return Err(format!(
                     "{field_name} must stay normalized and relative: {path}"
                 ));
@@ -644,8 +647,7 @@ mod tests {
             license: "MIT".into(),
             files: vec![BundledPackManifestFile {
                 relative_path: "research/sample.rule".into(),
-                sha256: "0000000000000000000000000000000000000000000000000000000000000000"
-                    .into(),
+                sha256: "0000000000000000000000000000000000000000000000000000000000000000".into(),
                 rule_count: 1,
                 source_url: "https://example.invalid/rule".into(),
                 source_reference: "abc123".into(),

--- a/third_party/yara/inquest-community-core/Base64_Encoded_Powershell_Directives.rule
+++ b/third_party/yara/inquest-community-core/Base64_Encoded_Powershell_Directives.rule
@@ -1,0 +1,63 @@
+rule Base64_Encoded_Powershell_Directives
+{
+    meta:
+        Author      = "InQuest Labs"
+        Reference   = "https://inquest.net/blog/2019/07/19/base64-encoded-powershell-pivots"
+        Samples     = "https://github.com/InQuest/malware-samples/tree/master/2019-07-Base64-Encoded-Powershell-Directives"
+        Description = "This signature detects base64 encoded Powershell directives."
+
+    strings:
+        // Copy-Item
+        $enc01 = /(Q\x32\x39weS\x31JdGVt[\x2b\x2f-\x39A-Za-z]|[\x2b\x2f-\x39A-Za-z][\x2b\x2f-\x39A-Za-z][\x31\x35\x39BFJNRVZdhlptx]Db\x33B\x35LUl\x30ZW[\x30-\x33]|[\x2b\x2f-\x39A-Za-z][\x30EUk]NvcHktSXRlb[Q-Za-f])/
+
+        // ForEach-Object
+        $enc02 = /(Rm\x39yRWFjaC\x31PYmplY\x33[Q-T]|[\x2b\x2f-\x39A-Za-z][\x2b\x2f-\x39A-Za-z][\x31\x35\x39BFJNRVZdhlptx]Gb\x33JFYWNoLU\x39iamVjd[A-P]|[\x2b\x2f-\x39A-Za-z][\x30EUk]ZvckVhY\x32gtT\x32JqZWN\x30[\x2b\x2f-\x39A-Za-z])/
+
+        // Get-ChildItem
+        $enc03 = /(R\x32V\x30LUNoaWxkSXRlb[Q-Za-f]|[\x2b\x2f-\x39A-Za-z][\x2b\x2f-\x39A-Za-z][\x31\x35\x39BFJNRVZdhlptx]HZXQtQ\x32hpbGRJdGVt[\x2b\x2f-\x39A-Za-z]|[\x2b\x2f-\x39A-Za-z][\x30EUk]dldC\x31DaGlsZEl\x30ZW[\x30-\x33])/
+
+        // Get-ItemPropertyValue
+        $enc04 = /(R\x32V\x30LUl\x30ZW\x31Qcm\x39wZXJ\x30eVZhbHVl[\x2b\x2f-\x39A-Za-z]|[\x2b\x2f-\x39A-Za-z][\x2b\x2f-\x39A-Za-z][\x31\x35\x39BFJNRVZdhlptx]HZXQtSXRlbVByb\x33BlcnR\x35VmFsdW[U-X]|[\x2b\x2f-\x39A-Za-z][\x30EUk]dldC\x31JdGVtUHJvcGVydHlWYWx\x31Z[Q-Za-f])/
+
+        // Get-Random
+        $enc05 = /(R\x32V\x30LVJhbmRvb[Q-Za-f]|[\x2b\x2f-\x39A-Za-z][\x2b\x2f-\x39A-Za-z][\x31\x35\x39BFJNRVZdhlptx]HZXQtUmFuZG\x39t[\x2b\x2f-\x39A-Za-z]|[\x2b\x2f-\x39A-Za-z][\x30EUk]dldC\x31SYW\x35kb\x32[\x30-\x33])/
+
+        // Join-Path
+        $enc06 = /(Sm\x39pbi\x31QYXRo[\x2b\x2f-\x39A-Za-z]|[\x2b\x2f-\x39A-Za-z][\x2b\x2f-\x39A-Za-z][\x31\x35\x39BFJNRVZdhlptx]Kb\x32luLVBhdG[g-j]|[\x2b\x2f-\x39A-Za-z][\x30EUk]pvaW\x34tUGF\x30a[A-P])/
+
+        // Move-Item
+        $enc07 = /(TW\x39\x32ZS\x31JdGVt[\x2b\x2f-\x39A-Za-z]|[\x2b\x2f-\x39A-Za-z][\x2b\x2f-\x39A-Za-z][\x31\x35\x39BFJNRVZdhlptx]Nb\x33ZlLUl\x30ZW[\x30-\x33]|[\x2b\x2f-\x39A-Za-z][\x30EUk]\x31vdmUtSXRlb[Q-Za-f])/
+
+        // New-Item
+        $enc08 = /(TmV\x33LUl\x30ZW[\x30-\x33]|[\x2b\x2f-\x39A-Za-z][\x2b\x2f-\x39A-Za-z][\x31\x35\x39BFJNRVZdhlptx]OZXctSXRlb[Q-Za-f]|[\x2b\x2f-\x39A-Za-z][\x30EUk]\x35ldy\x31JdGVt[\x2b\x2f-\x39A-Za-z])/
+
+        // New-Object
+        $enc09 = /(TmV\x33LU\x39iamVjd[A-P]|[\x2b\x2f-\x39A-Za-z][\x2b\x2f-\x39A-Za-z][\x31\x35\x39BFJNRVZdhlptx]OZXctT\x32JqZWN\x30[\x2b\x2f-\x39A-Za-z]|[\x2b\x2f-\x39A-Za-z][\x30EUk]\x35ldy\x31PYmplY\x33[Q-T])/
+
+        // Out-String
+        $enc10 = /(T\x33V\x30LVN\x30cmluZ[\x2b\x2f-\x39w-z]|[\x2b\x2f-\x39A-Za-z][\x2b\x2f-\x39A-Za-z][\x31\x35\x39BFJNRVZdhlptx]PdXQtU\x33RyaW\x35n[\x2b\x2f-\x39A-Za-z]|[\x2b\x2f-\x39A-Za-z][\x30EUk]\x39\x31dC\x31TdHJpbm[c-f])/
+
+        // Remove-Item
+        $enc11 = /(UmVtb\x33ZlLUl\x30ZW[\x30-\x33]|[\x2b\x2f-\x39A-Za-z][\x2b\x2f-\x39A-Za-z][\x31\x35\x39BFJNRVZdhlptx]SZW\x31vdmUtSXRlb[Q-Za-f]|[\x2b\x2f-\x39A-Za-z][\x31FVl]JlbW\x39\x32ZS\x31JdGVt[\x2b\x2f-\x39A-Za-z])/
+
+        // Select-Object
+        $enc12 = /(U\x32VsZWN\x30LU\x39iamVjd[A-P]|[\x2b\x2f-\x39A-Za-z][\x2b\x2f-\x39A-Za-z][\x31\x35\x39BFJNRVZdhlptx]TZWxlY\x33QtT\x32JqZWN\x30[\x2b\x2f-\x39A-Za-z]|[\x2b\x2f-\x39A-Za-z][\x31FVl]NlbGVjdC\x31PYmplY\x33[Q-T])/
+
+        // Sort-Object
+        $enc13 = /(U\x32\x39ydC\x31PYmplY\x33[Q-T]|[\x2b\x2f-\x39A-Za-z][\x2b\x2f-\x39A-Za-z][\x31\x35\x39BFJNRVZdhlptx]Tb\x33J\x30LU\x39iamVjd[A-P]|[\x2b\x2f-\x39A-Za-z][\x31FVl]NvcnQtT\x32JqZWN\x30[\x2b\x2f-\x39A-Za-z])/
+
+        // Split-Path
+        $enc14 = /(U\x33BsaXQtUGF\x30a[A-P]|[\x2b\x2f-\x39A-Za-z][\x2b\x2f-\x39A-Za-z][\x31\x35\x39BFJNRVZdhlptx]TcGxpdC\x31QYXRo[\x2b\x2f-\x39A-Za-z]|[\x2b\x2f-\x39A-Za-z][\x31FVl]NwbGl\x30LVBhdG[g-j])/
+
+        // Test-Path
+        $enc15 = /(VGVzdC\x31QYXRo[\x2b\x2f-\x39A-Za-z]|[\x2b\x2f-\x39A-Za-z][\x2b\x2f-\x39A-Za-z][\x31\x35\x39BFJNRVZdhlptx]UZXN\x30LVBhdG[g-j]|[\x2b\x2f-\x39A-Za-z][\x31FVl]Rlc\x33QtUGF\x30a[A-P])/
+
+        // Write-Host
+        $enc16 = /(V\x33JpdGUtSG\x39zd[A-P]|[\x2b\x2f-\x39A-Za-z][\x2b\x2f-\x39A-Za-z][\x31\x35\x39BFJNRVZdhlptx]Xcml\x30ZS\x31Ib\x33N\x30[\x2b\x2f-\x39A-Za-z]|[\x2b\x2f-\x39A-Za-z][\x31FVl]dyaXRlLUhvc\x33[Q-T])/
+
+        // [Convert]::FromBase64String
+        $enc17 = /([\x2b\x2f-\x39A-Za-z][\x2b\x2f-\x39A-Za-z][\x31\x35\x39BFJNRVZdhlptx][\x30\x32Dlu-vy][O]jpGcm\x39tQmFzZTY\x30U\x33RyaW\x35n[\x2b\x2f-\x39A-Za-z]|[\x2b\x2f-\x39A-Za-z][\x30\x32-\x33EG-HUW-Xkm-n][\x34\x38IMQUY]\x36OkZyb\x32\x31CYXNlNjRTdHJpbm[c-f]|[QZb-d][DTjz]o\x36RnJvbUJhc\x32U\x32NFN\x30cmluZ[\x2b\x2f-\x39w-z])/
+
+    condition:
+            any of ($enc*)
+}

--- a/third_party/yara/inquest-community-core/LICENSE.InQuest.txt
+++ b/third_party/yara/inquest-community-core/LICENSE.InQuest.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 InQuest
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/yara/inquest-community-core/pack-metadata.json
+++ b/third_party/yara/inquest-community-core/pack-metadata.json
@@ -1,0 +1,18 @@
+{
+  "pack_name": "community-core",
+  "pack_version": "2026.05.22.1",
+  "generated_at": "2026-05-22T10:20:00Z",
+  "upstream_name": "InQuest yara-rules",
+  "upstream_source_url": "https://github.com/InQuest/yara-rules",
+  "upstream_reference": "fd87530863cca77384f37ae5485707a02207d715",
+  "license": "MIT",
+  "files": [
+    {
+      "relative_path": "research/Base64_Encoded_Powershell_Directives.rule",
+      "source_path": "Base64_Encoded_Powershell_Directives.rule",
+      "source_url": "https://github.com/InQuest/yara-rules/blob/master/Base64_Encoded_Powershell_Directives.rule",
+      "source_reference": "fd87530863cca77384f37ae5485707a02207d715",
+      "category": "research"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- preserve the unmerged `phase20-yara-bundled-pack-foundation` branch in a reviewable path
- surface the branch delta adding bundled YARA pack plumbing, build-time handling, and initial third-party rule metadata
- keep this as a draft until the branch is reconciled with current `master` and CI is verified on the latest head

## Current branch scope
Based on comparison against current `master`, this branch changes:
- `Cargo.toml`
- `build.rs`
- `src/yara_rules.rs`
- `third_party/yara/inquest-community-core/Base64_Encoded_Powershell_Directives.rule`
- `third_party/yara/inquest-community-core/LICENSE.InQuest.txt`
- `third_party/yara/inquest-community-core/pack-metadata.json`

## Current status
- branch is 8 commits ahead of `master` and 21 commits behind it
- latest head includes `yara: apply rustfmt formatting`, which addresses the old `cargo fmt --check` failure from the May 22 CI run
- no workflow run is currently attached to the latest head commit, so CI has not yet verified this refreshed branch state
- this is a preservation PR, not a merge-ready PR

## Next useful action
Trigger or rerun the normal CI suite for the latest head, then rebase or otherwise reconcile this work with current `master` before requesting review or marking ready.