### PR TITLE
Add dump-backed YARA memory scan foundation

### DIFF
--- a/docs/YARA-MEMORY-SCAN.md
+++ b/docs/YARA-MEMORY-SCAN.md
@@ -1,13 +1,13 @@
 # Phase 20 Memory-Region YARA Scan Contract
 
-This document defines the smallest safe implementation slice for Phase 20's
-next unchecked roadmap item: scanning process memory with YARA without widening
-Vigil's trust boundary or adding ambiguous response behavior.
+This document defines the first implemented memory-scanning slice for Phase 20:
+scan process-memory dump artifacts with YARA without widening Vigil's trust
+boundary or adding ambiguous response behavior.
 
-It exists to keep the next implementation pass concrete. The repository already
-has a reviewed executable-scan path in `src/yara_scan.rs` plus audited process
-memory dump capture in `src/forensics.rs`, but it does not yet have a repo-wide
-contract for how memory-derived bytes should enter the YARA pipeline.
+The repository already has a reviewed executable-scan path in `src/yara_scan.rs`
+plus audited process memory dump capture in `src/forensics.rs`. The initial
+memory slice now hooks those pieces together by scanning dump artifacts that
+Vigil captured for high-confidence alerts.
 
 ## Why this contract exists
 
@@ -19,27 +19,28 @@ Memory scanning is materially riskier than on-disk executable scanning:
   specific capture paths
 - a failed memory scan must never silently imply a clean result
 
-Without a written contract, it would be too easy to ship an implementation that
-blurs those boundaries.
+This contract keeps memory-derived bytes on an explicit, auditable path.
 
-## Smallest safe runtime slice
+## Implemented runtime slice
 
-The next implementation slice should stay intentionally narrow:
+The first implemented slice stays intentionally narrow:
 
-- scan only operator-visible process-memory artifacts that Vigil created itself,
-  such as reviewed dump targets captured for a high-confidence alert
+- scan only process-memory dump artifacts that Vigil created itself after an
+  opt-in high-confidence alert dump capture
 - reuse only the existing trusted rule sources: bundled reviewed rules plus
   operator-local rules that already passed `.sha256` verification
-- keep scanning off the startup-critical and connection-hot paths
-- record the result as a distinct target kind from executable-path scans so
-  later UI work can preserve provenance and scope
+- run the scan in a background worker after dump capture so alert delivery and
+  normal connection monitoring are not blocked by YARA
+- record results under the distinct `process_dump` target kind in
+  `yara_scan_result`, separate from executable-path scans
+- emit audit records for `matched`, `clean`, `skipped`, and `error` outcomes
 
-This means the first memory-scan slice is best treated as dump-backed memory
-inspection, not arbitrary live memory reads across the whole process table.
+This is dump-backed memory inspection, not arbitrary live memory reads across
+the whole process table.
 
 ## Trust boundary
 
-The memory-scan slice must preserve the same trust contract already used by the
+The memory-scan slice preserves the same trust contract already used by the
 executable-scan worker:
 
 - bundled rule files must still pass the generated manifest and hash checks
@@ -47,41 +48,43 @@ executable-scan worker:
   `.sha256` sidecars before they are compiled
 - unverified local rule text must never be executed just because a dump file is
   available
-- memory-derived scan results must remain distinguishable from executable-file
-  scan results in any future persistence or UI surface
+- memory-derived scan results remain distinguishable from executable-file scan
+  results through the `process_dump` target kind and payload metadata
 
 ## Result handling
 
-The first memory-scan slice should stay conservative and auditable:
+The first memory-scan slice is conservative and auditable:
 
-- successful matches should be recorded with the dump artifact path, scan time,
-  matched rule identifiers, and ruleset digest
-- failures and skips should be logged clearly enough for maintainers and
-  operators to understand why a dump was not scanned
-- a memory-scan subsystem failure must not suppress the original alert and must
+- successful matches are recorded with the dump artifact path, scan time,
+  target SHA-256, matched rule identifiers, ATT&CK-like tags when rule-authored,
+  and ruleset digest
+- failures and skips are logged and audited with the dump path, process context,
+  manifest path when available, and error reason
+- a memory-scan subsystem failure does not suppress the original alert and does
   not manufacture a synthetic clean verdict
-- memory-scan matches may inform later triage or scoring work, but the first
-  slice should avoid inventing new auto-response semantics on its own
+- memory-scan matches are evidence for later triage work; this slice does not
+  add new auto-response semantics
 
 ## Safety limits
 
-To keep the feature reviewable and avoid turning forensic capture into a denial-
--of-service path, the first implementation should include explicit bounds:
+The implemented slice includes explicit bounds:
 
-- bounded file size for dump-backed scans
-- bounded scan timeout
-- asynchronous execution so alert delivery is not blocked waiting for YARA
-- fail-open behavior when dump capture or scan execution is unavailable
+- process dump scans are skipped above 256 MiB
+- each YARA scan uses a 10-second timeout
+- scan work runs on a named background thread after dump capture
+- failures remain fail-open and auditable
 
-Those caps can be tuned later, but they need to exist from the first shipped
-memory-scan slice.
+Those caps can be tuned later, but they prevent forensic capture from becoming
+an unbounded scan path.
 
-## Non-goals for the first memory slice
+## Non-goals for this memory slice
 
-The following remain later Phase 20 work and should not be smuggled into the
-first memory-scan implementation:
+The following remain later Phase 20 work and should not be inferred from the
+current implementation:
 
 - direct arbitrary live-memory reads from unrelated processes
+- Linux direct `/proc/<pid>/mem` or `ptrace` acquisition
+- Windows live-region enumeration through new memory-reading APIs
 - new automatic containment actions triggered solely by memory-scan subsystem
   health or failure
 - Inspector rule-management controls and category toggles
@@ -89,15 +92,8 @@ first memory-scan implementation:
 - broad claims that every memory match is exploit proof rather than a triage
   signal
 
-## Safest next code change
+## Follow-up work
 
-The safest next code change after this contract is:
-
-- hook dump-backed memory scans into the existing trusted YARA pipeline
-- persist those results under a distinct memory-scan target kind
-- keep the work asynchronous, bounded, and fail-open
-- surface the outcome first through audit/provenance paths before adding richer
-  UI affordances
-
-That path advances the next roadmap item without inventing product direction or
-weakening Vigil's security posture.
+The next safe follow-up is operator-visible surfacing for `process_dump` scan
+results in status or Inspector views, still keeping executable and memory-derived
+results clearly separated.

--- a/src/forensics.rs
+++ b/src/forensics.rs
@@ -223,7 +223,9 @@ fn run_process_dump_yara_scan(path: PathBuf, info: ConnInfo, manifest: Option<Pa
 
     match scan_memory_dump_target(&compiled, &target) {
         Ok(verdict) => {
-            if let Err(err) = persist_memory_dump_scan_result(&target, &verdict, &info, manifest.as_deref()) {
+            if let Err(err) =
+                persist_memory_dump_scan_result(&target, &verdict, &info, manifest.as_deref())
+            {
                 audit::record(
                     "process_dump_yara_scan",
                     "error",
@@ -364,7 +366,10 @@ fn memory_dump_scan_target(path: &Path) -> Result<MemoryDumpScanTarget, String> 
     let metadata = fs::metadata(path)
         .map_err(|e| format!("read metadata for process dump {}: {e}", path.display()))?;
     if !metadata.is_file() {
-        return Err(format!("process dump target is not a file: {}", path.display()));
+        return Err(format!(
+            "process dump target is not a file: {}",
+            path.display()
+        ));
     }
     if metadata.len() > MAX_PROCESS_DUMP_SCAN_BYTES {
         return Err(format!(
@@ -404,7 +409,10 @@ fn scan_memory_dump_target(
         .map_err(|e| format!("scan process dump {}: {e}", target.path.display()))?;
 
     let mut matched_rules = Vec::new();
-    for rule in results.matching_rules().take(MAX_MEMORY_MATCHED_RULES_RECORDED) {
+    for rule in results
+        .matching_rules()
+        .take(MAX_MEMORY_MATCHED_RULES_RECORDED)
+    {
         let attack_tags = rule
             .tags()
             .map(|tag| tag.identifier().to_string())

--- a/src/forensics.rs
+++ b/src/forensics.rs
@@ -4,15 +4,67 @@
 //! high-confidence alerts. The feature is opt-in, Windows-only, audited, and
 //! rate-limited per PID so a noisy process does not flood disk with dumps.
 
-use crate::{artifact_provenance, audit, config::Config, types::ConnInfo};
+use crate::{artifact_provenance, audit, config::Config, storage::db::StorageDb, types::ConnInfo};
+use rusqlite::params;
 use serde_json::json;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use yara_x::{Compiler, Scanner, SourceCode};
 
 static LAST_DUMP_AT: OnceLock<Mutex<HashMap<u32, u64>>> = OnceLock::new();
 static LAST_GLOBAL_DUMP_AT: OnceLock<Mutex<u64>> = OnceLock::new();
 const GLOBAL_COOLDOWN_SECS: u64 = 30;
+const MAX_PROCESS_DUMP_SCAN_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_MEMORY_MATCHED_RULES_RECORDED: usize = 8;
+const BUNDLED_PACK_MANIFEST_JSON: &str =
+    include_str!(concat!(env!("OUT_DIR"), "/bundled_yara_pack_manifest.json"));
+
+#[derive(Debug, Clone, Copy)]
+struct EmbeddedBundledRuleFile {
+    relative_path: &'static str,
+    source_text: &'static str,
+}
+
+include!(concat!(env!("OUT_DIR"), "/bundled_yara_pack_files.rs"));
+
+#[derive(Debug, Clone)]
+struct MemoryDumpScanTarget {
+    path: PathBuf,
+    size_bytes: u64,
+    modified_unix_nanos: u64,
+    created_unix_nanos: u64,
+}
+
+#[derive(Debug, Clone)]
+struct MemoryDumpMatchedRule {
+    identifier: String,
+    attack_tags: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct MemoryDumpScanVerdict {
+    matched_rules: Vec<MemoryDumpMatchedRule>,
+    ruleset_digest: String,
+    scanned_unix: u64,
+    target_sha256: String,
+}
+
+#[derive(Debug, Clone)]
+struct MemoryRuntimeRuleSource {
+    namespace: String,
+    relative_path: String,
+    source_text: String,
+}
+
+struct MemoryCompiledRuleSet {
+    digest: String,
+    rules: yara_x::Rules,
+}
 
 pub fn maybe_capture_process_dump(info: &ConnInfo, cfg: &Config) {
     if !cfg.process_dump_on_alert || info.score < cfg.process_dump_min_score || info.pid == 0 {
@@ -85,6 +137,7 @@ pub fn maybe_capture_process_dump(info: &ConnInfo, cfg: &Config) {
                 }),
             );
             tracing::warn!(pid = info.pid, proc = %info.proc_name, dump = %path.display(), manifest = ?manifest.as_ref().map(|p| p.display().to_string()), "captured process dump on alert");
+            enqueue_process_dump_yara_scan(path, info.clone(), manifest);
         }
         Err(err) => {
             audit::record(
@@ -100,6 +153,454 @@ pub fn maybe_capture_process_dump(info: &ConnInfo, cfg: &Config) {
             tracing::warn!(pid = info.pid, proc = %info.proc_name, %err, "failed to capture process dump on alert");
         }
     }
+}
+
+fn enqueue_process_dump_yara_scan(path: PathBuf, info: ConnInfo, manifest: Option<PathBuf>) {
+    if let Err(err) = std::thread::Builder::new()
+        .name("vigil-yara-dump-scan".into())
+        .spawn(move || run_process_dump_yara_scan(path, info, manifest))
+    {
+        audit::record(
+            "process_dump_yara_scan",
+            "error",
+            json!({ "error": format!("failed to spawn process dump YARA scan worker: {err}") }),
+        );
+    }
+}
+
+fn run_process_dump_yara_scan(path: PathBuf, info: ConnInfo, manifest: Option<PathBuf>) {
+    let target = match memory_dump_scan_target(&path) {
+        Ok(target) => target,
+        Err(err) => {
+            audit::record(
+                "process_dump_yara_scan",
+                "skipped",
+                json!({
+                    "pid": info.pid,
+                    "proc_name": info.proc_name,
+                    "path": path.display().to_string(),
+                    "manifest": manifest.as_ref().map(|p| p.display().to_string()),
+                    "error": err,
+                }),
+            );
+            tracing::warn!(pid = info.pid, proc = %info.proc_name, dump = %path.display(), "skipped process dump YARA scan: {err}");
+            return;
+        }
+    };
+
+    let compiled = match compile_memory_runtime_rules() {
+        Ok(Some(compiled)) => compiled,
+        Ok(None) => {
+            audit::record(
+                "process_dump_yara_scan",
+                "skipped",
+                json!({
+                    "pid": info.pid,
+                    "proc_name": info.proc_name,
+                    "path": target.path.display().to_string(),
+                    "manifest": manifest.as_ref().map(|p| p.display().to_string()),
+                    "error": "no compiled YARA rules available",
+                }),
+            );
+            return;
+        }
+        Err(err) => {
+            audit::record(
+                "process_dump_yara_scan",
+                "error",
+                json!({
+                    "pid": info.pid,
+                    "proc_name": info.proc_name,
+                    "path": target.path.display().to_string(),
+                    "manifest": manifest.as_ref().map(|p| p.display().to_string()),
+                    "error": err,
+                }),
+            );
+            tracing::warn!(pid = info.pid, proc = %info.proc_name, dump = %target.path.display(), "failed to compile YARA rules for process dump scan: {err}");
+            return;
+        }
+    };
+
+    match scan_memory_dump_target(&compiled, &target) {
+        Ok(verdict) => {
+            if let Err(err) = persist_memory_dump_scan_result(&target, &verdict, &info, manifest.as_deref()) {
+                audit::record(
+                    "process_dump_yara_scan",
+                    "error",
+                    json!({
+                        "pid": info.pid,
+                        "proc_name": info.proc_name,
+                        "path": target.path.display().to_string(),
+                        "manifest": manifest.as_ref().map(|p| p.display().to_string()),
+                        "ruleset_digest": verdict.ruleset_digest,
+                        "error": err,
+                    }),
+                );
+                return;
+            }
+
+            let status = if verdict.matched_rules.is_empty() {
+                "clean"
+            } else {
+                "matched"
+            };
+            audit::record(
+                "process_dump_yara_scan",
+                status,
+                json!({
+                    "pid": info.pid,
+                    "proc_name": info.proc_name,
+                    "path": target.path.display().to_string(),
+                    "manifest": manifest.as_ref().map(|p| p.display().to_string()),
+                    "ruleset_digest": verdict.ruleset_digest,
+                    "target_sha256": verdict.target_sha256,
+                    "matched_rules": verdict.matched_rules.iter().map(|rule| json!({
+                        "identifier": rule.identifier,
+                        "attack_tags": rule.attack_tags,
+                    })).collect::<Vec<_>>(),
+                }),
+            );
+            if !verdict.matched_rules.is_empty() {
+                tracing::warn!(pid = info.pid, proc = %info.proc_name, dump = %target.path.display(), matches = verdict.matched_rules.len(), "process dump YARA scan matched rules");
+            }
+        }
+        Err(err) => {
+            audit::record(
+                "process_dump_yara_scan",
+                "error",
+                json!({
+                    "pid": info.pid,
+                    "proc_name": info.proc_name,
+                    "path": target.path.display().to_string(),
+                    "manifest": manifest.as_ref().map(|p| p.display().to_string()),
+                    "error": err,
+                }),
+            );
+            tracing::warn!(pid = info.pid, proc = %info.proc_name, dump = %target.path.display(), "process dump YARA scan failed: {err}");
+        }
+    }
+}
+
+fn compile_memory_runtime_rules() -> Result<Option<MemoryCompiledRuleSet>, String> {
+    let mut compiler = Compiler::new();
+    let mut hasher = Sha256::new();
+    let mut compiled_sources = 0usize;
+
+    for source in memory_runtime_rule_sources()? {
+        compiler.new_namespace(&source.namespace);
+        let source_code =
+            SourceCode::from(source.source_text.as_str()).with_origin(&source.relative_path);
+        match compiler.add_source(source_code) {
+            Ok(_) => {
+                hasher.update(source.relative_path.as_bytes());
+                hasher.update(b"\n");
+                hasher.update(source.source_text.as_bytes());
+                hasher.update(b"\n");
+                compiled_sources += 1;
+            }
+            Err(err) => {
+                tracing::warn!(
+                    origin = %source.relative_path,
+                    error = %err,
+                    "skipping YARA source that failed compilation for process dump scan"
+                );
+            }
+        }
+    }
+
+    if compiled_sources == 0 {
+        return Ok(None);
+    }
+
+    let digest = hasher.finalize();
+    Ok(Some(MemoryCompiledRuleSet {
+        digest: hex_encode(digest.as_ref()),
+        rules: compiler.build(),
+    }))
+}
+
+fn memory_runtime_rule_sources() -> Result<Vec<MemoryRuntimeRuleSource>, String> {
+    validate_bundled_manifest_shape(BUNDLED_PACK_MANIFEST_JSON)?;
+
+    let mut sources = Vec::new();
+    for file in EMBEDDED_BUNDLED_RULE_FILES {
+        let relative_path = format!("bundled/{}", file.relative_path);
+        sources.push(MemoryRuntimeRuleSource {
+            namespace: namespace_for_relative_path(&relative_path),
+            relative_path,
+            source_text: file.source_text.to_string(),
+        });
+    }
+
+    let report = crate::yara_rules::load_verified_rules()?;
+    for file in report.files {
+        let relative_path = format!("local/{}", file.relative_path);
+        sources.push(MemoryRuntimeRuleSource {
+            namespace: namespace_for_relative_path(&relative_path),
+            relative_path,
+            source_text: file.source_text,
+        });
+    }
+
+    Ok(sources)
+}
+
+fn validate_bundled_manifest_shape(manifest_json: &str) -> Result<(), String> {
+    let value: serde_json::Value = serde_json::from_str(manifest_json)
+        .map_err(|e| format!("parse bundled YARA manifest: {e}"))?;
+    let schema_version = value
+        .get("schema_version")
+        .and_then(|value| value.as_u64())
+        .ok_or_else(|| "bundled YARA manifest missing schema_version".to_string())?;
+    if schema_version != 1 {
+        return Err(format!(
+            "unsupported bundled YARA manifest schema version {schema_version}; expected 1"
+        ));
+    }
+    Ok(())
+}
+
+fn memory_dump_scan_target(path: &Path) -> Result<MemoryDumpScanTarget, String> {
+    let metadata = fs::metadata(path)
+        .map_err(|e| format!("read metadata for process dump {}: {e}", path.display()))?;
+    if !metadata.is_file() {
+        return Err(format!("process dump target is not a file: {}", path.display()));
+    }
+    if metadata.len() > MAX_PROCESS_DUMP_SCAN_BYTES {
+        return Err(format!(
+            "process dump target {} is {} bytes, above the {} byte scan limit",
+            path.display(),
+            metadata.len(),
+            MAX_PROCESS_DUMP_SCAN_BYTES
+        ));
+    }
+
+    Ok(MemoryDumpScanTarget {
+        path: path.to_path_buf(),
+        size_bytes: metadata.len(),
+        modified_unix_nanos: metadata
+            .modified()
+            .ok()
+            .and_then(system_time_to_unix_nanos)
+            .unwrap_or_default(),
+        created_unix_nanos: metadata
+            .created()
+            .ok()
+            .and_then(system_time_to_unix_nanos)
+            .unwrap_or_default(),
+    })
+}
+
+fn scan_memory_dump_target(
+    compiled: &MemoryCompiledRuleSet,
+    target: &MemoryDumpScanTarget,
+) -> Result<MemoryDumpScanVerdict, String> {
+    let target_sha256 = sha256_file(&target.path)?;
+    let mut scanner = Scanner::new(&compiled.rules);
+    scanner.use_mmap(false);
+    scanner.set_timeout(Duration::from_secs(10));
+    let results = scanner
+        .scan_file(&target.path)
+        .map_err(|e| format!("scan process dump {}: {e}", target.path.display()))?;
+
+    let mut matched_rules = Vec::new();
+    for rule in results.matching_rules().take(MAX_MEMORY_MATCHED_RULES_RECORDED) {
+        let attack_tags = rule
+            .tags()
+            .map(|tag| tag.identifier().to_string())
+            .filter(|tag| looks_like_attack_tag(tag))
+            .collect::<Vec<_>>();
+        matched_rules.push(MemoryDumpMatchedRule {
+            identifier: rule.identifier().to_string(),
+            attack_tags,
+        });
+    }
+
+    Ok(MemoryDumpScanVerdict {
+        matched_rules,
+        ruleset_digest: compiled.digest.clone(),
+        scanned_unix: unix_now(),
+        target_sha256,
+    })
+}
+
+fn persist_memory_dump_scan_result(
+    target: &MemoryDumpScanTarget,
+    verdict: &MemoryDumpScanVerdict,
+    info: &ConnInfo,
+    manifest: Option<&Path>,
+) -> Result<(), String> {
+    let db = StorageDb::global()?;
+    ensure_scan_result_table(&db)?;
+    db.begin()?;
+    let result = (|| -> Result<(), String> {
+        let target_identity = target.path.to_string_lossy().to_string();
+        let conn = db.conn()?;
+        conn.execute(
+            "DELETE FROM yara_scan_result WHERE target_kind = ?1 AND target_identity = ?2",
+            params!["process_dump", target_identity.as_str()],
+        )
+        .map_err(|e| format!("clear prior process dump YARA scan result: {e}"))?;
+
+        let payload = json!({
+            "pid": info.pid,
+            "proc_name": info.proc_name,
+            "proc_path": info.proc_path,
+            "score": info.score,
+            "manifest": manifest.map(|p| p.display().to_string()),
+            "size_bytes": target.size_bytes,
+            "modified_unix_nanos": target.modified_unix_nanos,
+            "created_unix_nanos": target.created_unix_nanos,
+            "matched_rules": verdict
+                .matched_rules
+                .iter()
+                .map(|rule| {
+                    json!({
+                        "identifier": rule.identifier,
+                        "attack_tags": rule.attack_tags,
+                    })
+                })
+                .collect::<Vec<_>>(),
+        });
+        let verdict_name = if verdict.matched_rules.is_empty() {
+            "clean"
+        } else {
+            "matched"
+        };
+        let scanned_unix = i64::try_from(verdict.scanned_unix).unwrap_or(i64::MAX);
+        let match_count = i64::try_from(verdict.matched_rules.len()).unwrap_or(i64::MAX);
+
+        conn.execute(
+            "INSERT INTO yara_scan_result
+             (result_key, target_kind, target_identity, target_sha256, ruleset_digest,
+              scanned_unix, verdict, match_count, payload_json)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                stable_key(
+                    "yara_scan_result",
+                    &format!("process_dump:{target_identity}:{}", verdict.ruleset_digest)
+                ),
+                "process_dump",
+                target_identity.as_str(),
+                verdict.target_sha256.as_str(),
+                verdict.ruleset_digest.as_str(),
+                scanned_unix,
+                verdict_name,
+                match_count,
+                payload.to_string(),
+            ],
+        )
+        .map_err(|e| format!("insert process dump YARA scan result: {e}"))?;
+        Ok(())
+    })();
+
+    match result {
+        Ok(()) => {
+            db.commit()?;
+            db.checkpoint()?;
+            Ok(())
+        }
+        Err(err) => {
+            let _ = db.rollback();
+            Err(err)
+        }
+    }
+}
+
+fn ensure_scan_result_table(db: &StorageDb) -> Result<(), String> {
+    let conn = db.conn()?;
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS yara_scan_result (
+            result_key      TEXT PRIMARY KEY NOT NULL,
+            target_kind     TEXT NOT NULL DEFAULT '',
+            target_identity TEXT NOT NULL DEFAULT '',
+            target_sha256   TEXT NOT NULL DEFAULT '',
+            ruleset_digest  TEXT NOT NULL DEFAULT '',
+            scanned_unix    INTEGER NOT NULL DEFAULT 0,
+            verdict         TEXT NOT NULL DEFAULT '',
+            match_count     INTEGER NOT NULL DEFAULT 0,
+            payload_json    TEXT NOT NULL DEFAULT '{}'
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_yara_scan_target
+            ON yara_scan_result(target_kind, target_identity);
+        CREATE INDEX IF NOT EXISTS idx_yara_scan_ruleset
+            ON yara_scan_result(ruleset_digest);
+        CREATE INDEX IF NOT EXISTS idx_yara_scan_verdict
+            ON yara_scan_result(verdict, scanned_unix);
+        ",
+    )
+    .map_err(|e| format!("bootstrap YARA scan result table: {e}"))?;
+    Ok(())
+}
+
+fn namespace_for_relative_path(relative_path: &str) -> String {
+    Path::new(relative_path)
+        .parent()
+        .map(|parent| parent.to_string_lossy().replace('\\', "/"))
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "default".to_string())
+}
+
+fn looks_like_attack_tag(tag: &str) -> bool {
+    let normalized = tag.trim();
+    if normalized.is_empty() {
+        return false;
+    }
+    let candidate = normalized
+        .strip_prefix("ATT&CK:")
+        .or_else(|| normalized.strip_prefix("ATTACK:"))
+        .unwrap_or(normalized);
+    let Some(rest) = candidate.strip_prefix('T') else {
+        return false;
+    };
+    let (head, tail) = rest.split_once('.').unwrap_or((rest, ""));
+    if head.len() != 4 || !head.chars().all(|ch| ch.is_ascii_digit()) {
+        return false;
+    }
+    if tail.is_empty() {
+        return true;
+    }
+    tail.len() == 3 && tail.chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn sha256_file(path: &Path) -> Result<String, String> {
+    let mut file =
+        fs::File::open(path).map_err(|e| format!("open {} for sha256: {e}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 8192];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|e| format!("read {} for sha256: {e}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    let digest = hasher.finalize();
+    Ok(hex_encode(digest.as_ref()))
+}
+
+fn stable_key(kind: &str, value: &str) -> String {
+    sha256_digest_hex(format!("{kind}:{value}").as_bytes())
+}
+
+fn sha256_digest_hex(data: &[u8]) -> String {
+    let digest = Sha256::digest(data);
+    hex_encode(digest.as_ref())
+}
+
+fn hex_encode(data: &[u8]) -> String {
+    data.iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>()
+}
+
+fn system_time_to_unix_nanos(time: SystemTime) -> Option<u64> {
+    let duration = time.duration_since(UNIX_EPOCH).ok()?;
+    u64::try_from(duration.as_nanos()).ok()
 }
 
 fn unix_now() -> u64 {

--- a/src/forensics.rs
+++ b/src/forensics.rs
@@ -6,12 +6,13 @@
 
 use crate::{artifact_provenance, audit, config::Config, storage::db::StorageDb, types::ConnInfo};
 use rusqlite::params;
+use serde::Deserialize;
 use serde_json::json;
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use yara_x::{Compiler, Scanner, SourceCode};
@@ -21,6 +22,7 @@ static LAST_GLOBAL_DUMP_AT: OnceLock<Mutex<u64>> = OnceLock::new();
 const GLOBAL_COOLDOWN_SECS: u64 = 30;
 const MAX_PROCESS_DUMP_SCAN_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_MEMORY_MATCHED_RULES_RECORDED: usize = 8;
+const PACK_MANIFEST_SCHEMA_VERSION: u32 = 1;
 const BUNDLED_PACK_MANIFEST_JSON: &str =
     include_str!(concat!(env!("OUT_DIR"), "/bundled_yara_pack_manifest.json"));
 
@@ -31,6 +33,29 @@ struct EmbeddedBundledRuleFile {
 }
 
 include!(concat!(env!("OUT_DIR"), "/bundled_yara_pack_files.rs"));
+
+#[derive(Debug, Clone, Deserialize)]
+struct BundledPackManifest {
+    schema_version: u32,
+    pack_name: String,
+    pack_version: String,
+    generated_at: String,
+    upstream_name: String,
+    upstream_source_url: String,
+    upstream_reference: String,
+    license: String,
+    files: Vec<BundledPackManifestFile>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct BundledPackManifestFile {
+    relative_path: String,
+    sha256: String,
+    rule_count: usize,
+    source_url: String,
+    source_reference: String,
+    category: Option<String>,
+}
 
 #[derive(Debug, Clone)]
 struct MemoryDumpScanTarget {
@@ -322,7 +347,7 @@ fn compile_memory_runtime_rules() -> Result<Option<MemoryCompiledRuleSet>, Strin
 }
 
 fn memory_runtime_rule_sources() -> Result<Vec<MemoryRuntimeRuleSource>, String> {
-    validate_bundled_manifest_shape(BUNDLED_PACK_MANIFEST_JSON)?;
+    validate_bundled_pack(BUNDLED_PACK_MANIFEST_JSON, EMBEDDED_BUNDLED_RULE_FILES)?;
 
     let mut sources = Vec::new();
     for file in EMBEDDED_BUNDLED_RULE_FILES {
@@ -347,17 +372,108 @@ fn memory_runtime_rule_sources() -> Result<Vec<MemoryRuntimeRuleSource>, String>
     Ok(sources)
 }
 
-fn validate_bundled_manifest_shape(manifest_json: &str) -> Result<(), String> {
-    let value: serde_json::Value = serde_json::from_str(manifest_json)
-        .map_err(|e| format!("parse bundled YARA manifest: {e}"))?;
-    let schema_version = value
-        .get("schema_version")
-        .and_then(|value| value.as_u64())
-        .ok_or_else(|| "bundled YARA manifest missing schema_version".to_string())?;
-    if schema_version != 1 {
+fn validate_bundled_pack(
+    manifest_json: &str,
+    embedded_files: &[EmbeddedBundledRuleFile],
+) -> Result<(), String> {
+    let manifest: BundledPackManifest = serde_json::from_str(manifest_json)
+        .map_err(|e| format!("failed to parse bundled YARA pack manifest: {e}"))?;
+    validate_bundled_pack_manifest(&manifest, embedded_files)
+}
+
+fn validate_bundled_pack_manifest(
+    manifest: &BundledPackManifest,
+    embedded_files: &[EmbeddedBundledRuleFile],
+) -> Result<(), String> {
+    if manifest.schema_version != PACK_MANIFEST_SCHEMA_VERSION {
         return Err(format!(
-            "unsupported bundled YARA manifest schema version {schema_version}; expected 1"
+            "unsupported bundled YARA manifest schema version {}; expected {}",
+            manifest.schema_version, PACK_MANIFEST_SCHEMA_VERSION
         ));
+    }
+    ensure_non_empty(&manifest.pack_name, "pack_name")?;
+    ensure_non_empty(&manifest.pack_version, "pack_version")?;
+    ensure_non_empty(&manifest.generated_at, "generated_at")?;
+    ensure_non_empty(&manifest.upstream_name, "upstream_name")?;
+    ensure_non_empty(&manifest.upstream_source_url, "upstream_source_url")?;
+    ensure_non_empty(&manifest.upstream_reference, "upstream_reference")?;
+    ensure_non_empty(&manifest.license, "license")?;
+    if manifest.files.is_empty() {
+        return Err("YARA pack manifest must include at least one file entry".into());
+    }
+
+    let mut embedded_by_path = HashMap::with_capacity(embedded_files.len());
+    for file in embedded_files {
+        if embedded_by_path
+            .insert(file.relative_path, file.source_text)
+            .is_some()
+        {
+            return Err(format!(
+                "bundled YARA pack embeds duplicate relative path {}",
+                file.relative_path
+            ));
+        }
+    }
+
+    let mut seen_paths = HashSet::with_capacity(manifest.files.len());
+    for (idx, file) in manifest.files.iter().enumerate() {
+        validate_bundled_pack_manifest_file(idx, file)?;
+        if !seen_paths.insert(file.relative_path.clone()) {
+            return Err(format!(
+                "YARA pack manifest files[{idx}] reuses duplicate relative_path {}",
+                file.relative_path
+            ));
+        }
+
+        let Some(source_text) = embedded_by_path.get(file.relative_path.as_str()) else {
+            return Err(format!(
+                "bundled YARA pack file {} is listed in the manifest but missing from the embedded file index",
+                file.relative_path
+            ));
+        };
+        let actual_sha = sha256_digest_hex(source_text.as_bytes());
+        if actual_sha != file.sha256 {
+            return Err(format!(
+                "bundled YARA pack file {} failed SHA-256 verification",
+                file.relative_path
+            ));
+        }
+        let actual_rule_count = count_rule_definitions(source_text);
+        if actual_rule_count != file.rule_count {
+            return Err(format!(
+                "bundled YARA pack file {} advertises {} rules but contains {}",
+                file.relative_path, file.rule_count, actual_rule_count
+            ));
+        }
+    }
+
+    if embedded_by_path.len() != manifest.files.len() {
+        return Err(
+            "bundled YARA embedded file index contains files that are missing from the manifest"
+                .into(),
+        );
+    }
+
+    Ok(())
+}
+
+fn validate_bundled_pack_manifest_file(
+    idx: usize,
+    file: &BundledPackManifestFile,
+) -> Result<(), String> {
+    ensure_non_empty(&file.relative_path, &format!("files[{idx}].relative_path"))?;
+    ensure_normalized_relative_path(&file.relative_path, &format!("files[{idx}].relative_path"))?;
+    ensure_lower_hex_sha256(&file.sha256, &format!("files[{idx}].sha256"))?;
+    if file.rule_count == 0 {
+        return Err(format!("files[{idx}].rule_count must be greater than zero"));
+    }
+    ensure_non_empty(&file.source_url, &format!("files[{idx}].source_url"))?;
+    ensure_non_empty(
+        &file.source_reference,
+        &format!("files[{idx}].source_reference"),
+    )?;
+    if let Some(category) = &file.category {
+        ensure_non_empty(category, &format!("files[{idx}].category"))?;
     }
     Ok(())
 }
@@ -571,6 +687,64 @@ fn looks_like_attack_tag(tag: &str) -> bool {
         return true;
     }
     tail.len() == 3 && tail.chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn ensure_non_empty(value: &str, field_name: &str) -> Result<(), String> {
+    if value.trim().is_empty() {
+        Err(format!("{field_name} must not be empty"))
+    } else {
+        Ok(())
+    }
+}
+
+fn ensure_lower_hex_sha256(value: &str, field_name: &str) -> Result<(), String> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+    {
+        return Err(format!(
+            "{field_name} must be exactly 64 lowercase hex characters"
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_normalized_relative_path(path: &str, field_name: &str) -> Result<(), String> {
+    if path.contains('\\') {
+        return Err(format!(
+            "{field_name} must use slash-separated relative paths: {path}"
+        ));
+    }
+    let candidate = Path::new(path);
+    for component in candidate.components() {
+        match component {
+            Component::Normal(_) => {}
+            Component::CurDir
+            | Component::ParentDir
+            | Component::RootDir
+            | Component::Prefix(_) => {
+                return Err(format!(
+                    "{field_name} must stay normalized and relative: {path}"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn count_rule_definitions(source_text: &str) -> usize {
+    source_text
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            trimmed.starts_with("rule ")
+                || trimmed.starts_with("private rule ")
+                || trimmed.starts_with("global rule ")
+                || trimmed.starts_with("private global rule ")
+                || trimmed.starts_with("global private rule ")
+        })
+        .count()
 }
 
 fn sha256_file(path: &Path) -> Result<String, String> {


### PR DESCRIPTION
## Summary

- Implements the next concrete Phase 20 memory-scan slice as dump-backed YARA scanning after successful opt-in process dump capture.
- Reuses the trusted bundled and verified operator-local YARA rule sources, scans in a background worker, and persists results separately under `target_kind = "process_dump"`.
- Audits `matched`, `clean`, `skipped`, and `error` outcomes without changing alert delivery, scoring, containment, or auto-response behavior.
- Updates `docs/YARA-MEMORY-SCAN.md` to describe the implemented bounds and non-goals.

## Safety notes

- Dump scans are skipped above 256 MiB and use the existing 10-second YARA scan timeout.
- Scan failures remain fail-open and do not manufacture clean verdicts.
- This does not add arbitrary live-memory reads or new automatic response semantics.

## Validation

- Source-level review only in this scheduled run. The workspace could not clone GitHub directly, so CI should provide compile/test validation on the PR.