### PR TITLE
Add regressions for active-response review fixes

### DIFF
--- a/src/security/active_response.rs
+++ b/src/security/active_response.rs
@@ -17,6 +17,17 @@ pub use imp::{
     SuspendedProcessEntry,
 };
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_facade_exports_remain_available() {
+        let _: fn(u32, &str, &str) -> Result<String, String> = apply_quarantine_profile;
+        let _: fn() -> Result<String, String> = revert_frozen_autoruns;
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct LockdownSchedule {
     pub start_hour: u8,

--- a/src/security/active_response.rs
+++ b/src/security/active_response.rs
@@ -17,17 +17,6 @@ pub use imp::{
     SuspendedProcessEntry,
 };
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn public_facade_exports_remain_available() {
-        let _: fn(u32, &str, &str) -> Result<String, String> = apply_quarantine_profile;
-        let _: fn() -> Result<String, String> = revert_frozen_autoruns;
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct LockdownSchedule {
     pub start_hour: u8,

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -20,3 +20,14 @@ pub mod tamper;
 pub mod update;
 #[cfg(windows)]
 pub mod windows_wfp;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn active_response_facade_exports_remain_available() {
+        let _: fn(u32, &str, &str) -> Result<String, String> =
+            crate::security::active_response::apply_quarantine_profile;
+        let _: fn() -> Result<String, String> =
+            crate::security::active_response::revert_frozen_autoruns;
+    }
+}

--- a/src/ui/process_list.rs
+++ b/src/ui/process_list.rs
@@ -1352,3 +1352,54 @@ fn pill(
         egui::StrokeKind::Outside,
     );
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(pid: u32) -> ConnInfo {
+        ConnInfo {
+            timestamp: String::new(),
+            proc_name: format!("proc-{pid}"),
+            pid,
+            proc_path: String::new(),
+            proc_user: String::new(),
+            parent_user: String::new(),
+            parent_name: String::new(),
+            parent_pid: 0,
+            service_name: String::new(),
+            publisher: String::new(),
+            command_line: String::new(),
+            local_addr: String::new(),
+            remote_addr: String::new(),
+            status: String::new(),
+            protocol: crate::types::TransportProtocol::Tcp,
+            first_seen_unix: 0,
+            closed_unix: None,
+            duration_secs: None,
+            score: 0,
+            reasons: Vec::new(),
+            attack_tags: Vec::new(),
+            ancestor_chain: Vec::new(),
+            pre_login: false,
+            hostname: None,
+            country: None,
+            asn: None,
+            asn_org: None,
+            reputation_hit: None,
+            recently_dropped: false,
+            long_lived: false,
+            dga_like: false,
+            baseline_deviation: false,
+            script_host_suspicious: false,
+            tls_sni: None,
+            tls_ja3: None,
+        }
+    }
+
+    #[test]
+    fn count_distinct_processes_tracks_unique_pids() {
+        let rows = VecDeque::from([row(42), row(7), row(42)]);
+
+        assert_eq!(count_distinct_processes(&rows), 2);
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent regressions from a recent refactor that moved active-response internals and updated UI connection handling by asserting the public API surface and process-list helpers remain compatible with existing callers.

### Description
- Add a crate-root security module unit test `active_response_facade_exports_remain_available` in `src/security/mod.rs` that verifies `apply_quarantine_profile` and `revert_frozen_autoruns` remain exported through `crate::security::active_response`.
- Add a unit test `count_distinct_processes_tracks_unique_pids` in `src/ui/process_list.rs` that exercises `process_list::count_distinct_processes`, which the UI event handlers now use instead of the removed helpers.
- These are test-only additions and do not change runtime behavior; they codify the expected API/behavior to catch future compile/API compatibility breaks.

### Testing
- Earlier local validation before review: `cargo check --all-targets`, `cargo test public_facade_exports_remain_available`, `cargo test count_distinct_processes_tracks_unique_pids`, and `git diff --check -- src/security/active_response.rs src/ui/process_list.rs` passed.
- Follow-up validation after review: inspected the updated PR diff and confirmed the facade assertion now lives outside `active_response`'s child module and references `crate::security::active_response::...`.
- Latest GitHub Actions run is in progress for commit `2de3ca1634a4`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a201ce67b1c8328a523d5cf23f7a2cd)