### PR TITLE
Harden WFP DLL loading to System32

### DIFF
--- a/src/security/windows_wfp.rs
+++ b/src/security/windows_wfp.rs
@@ -13,8 +13,9 @@ use windows::Win32::System::LibraryLoader::{
 
 const FWP_E_ALREADY_EXISTS_STATUS: u32 = 0x8032_0009;
 const VIGIL_WFP_PROVIDER_KEY: GUID = GUID::from_u128(0x3b6f3d34_6150_4e3c_9169_7df0c5f1cb52);
-const VIGIL_WFP_SUBLAYER_KEY: GUID =
-    GUID::from_u128(0xe7fae0d0_3af1_4b9f_88ea_ee11e08c9c4a);
+const VIGIL_WFP_SUBLAYER_KEY: GUID = GUID::from_u128(0xe7fae0d0_3af1_4b9f_88ea_ee11e08c9c4a);
+static VIGIL_WFP_PROVIDER_KEY_REF: GUID = GUID::from_u128(0x3b6f3d34_6150_4e3c_9169_7df0c5f1cb52);
+static VIGIL_WFP_SUBLAYER_KEY_REF: GUID = GUID::from_u128(0xe7fae0d0_3af1_4b9f_88ea_ee11e08c9c4a);
 const VIGIL_WFP_SUBLAYER_WEIGHT: u16 = 0x7000;
 
 type FwpmEngineOpen0Fn = unsafe extern "system" fn(
@@ -65,7 +66,7 @@ impl WfpApi {
             None,
             LOAD_LIBRARY_SEARCH_SYSTEM32,
         )
-            .map_err(|err| format!("load Fwpuclnt.dll: {err}"))?;
+        .map_err(|err| format!("load Fwpuclnt.dll: {err}"))?;
         Ok(Self {
             module,
             engine_open: load_symbol(module, b"FwpmEngineOpen0\0")?,
@@ -82,7 +83,9 @@ impl WfpApi {
             (self.engine_open)(PCWSTR::null(), 0, std::ptr::null(), &session, &mut handle)
         };
         if status != 0 {
-            return Err(format!("open WFP engine session failed with 0x{status:08x}"));
+            return Err(format!(
+                "open WFP engine session failed with 0x{status:08x}"
+            ));
         }
         Ok(WfpSession { api: self, handle })
     }
@@ -126,7 +129,7 @@ impl WfpSession<'_> {
             name: PWSTR(name.as_mut_ptr()),
             description: PWSTR(description.as_mut_ptr()),
         };
-        sublayer.providerKey = std::ptr::addr_of!(VIGIL_WFP_PROVIDER_KEY) as _;
+        sublayer.providerKey = std::ptr::addr_of!(VIGIL_WFP_PROVIDER_KEY_REF) as _;
         sublayer.weight = VIGIL_WFP_SUBLAYER_WEIGHT;
         let status = unsafe { (self.api.sublayer_add)(self.handle, &sublayer, std::ptr::null()) };
         ok_or_already_exists(status, "register WFP sublayer")

--- a/src/security/windows_wfp.rs
+++ b/src/security/windows_wfp.rs
@@ -7,7 +7,9 @@ use windows::Win32::Foundation::{HANDLE, HMODULE};
 use windows::Win32::NetworkManagement::WindowsFilteringPlatform::{
     FWPM_DISPLAY_DATA0, FWPM_PROVIDER0, FWPM_SESSION0, FWPM_SUBLAYER0,
 };
-use windows::Win32::System::LibraryLoader::{FreeLibrary, GetProcAddress, LoadLibraryW};
+use windows::Win32::System::LibraryLoader::{
+    FreeLibrary, GetProcAddress, LoadLibraryExW, LOAD_LIBRARY_SEARCH_SYSTEM32,
+};
 
 const FWP_E_ALREADY_EXISTS_STATUS: u32 = 0x8032_0009;
 const VIGIL_WFP_PROVIDER_KEY: GUID = GUID::from_u128(0x3b6f3d34_6150_4e3c_9169_7df0c5f1cb52);
@@ -58,7 +60,11 @@ struct WfpApi {
 
 impl WfpApi {
     unsafe fn load() -> Result<Self, String> {
-        let module = LoadLibraryW(w!("Fwpuclnt.dll"))
+        let module = LoadLibraryExW(
+            w!("Fwpuclnt.dll"),
+            None,
+            LOAD_LIBRARY_SEARCH_SYSTEM32,
+        )
             .map_err(|err| format!("load Fwpuclnt.dll: {err}"))?;
         Ok(Self {
             module,


### PR DESCRIPTION
### Motivation
- Prevent a DLL search-order hijack on Windows by avoiding a bare `LoadLibraryW("Fwpuclnt.dll")` lookup which could load a malicious DLL from the application directory when running elevated or as a service.

### Description
- Replace the bare-name loader with `LoadLibraryExW(w!("Fwpuclnt.dll"), None, LOAD_LIBRARY_SEARCH_SYSTEM32)` and update imports in `src/security/windows_wfp.rs` so the WFP DLL is resolved from `%SystemRoot%\\System32` only.

### Testing
- Ran `cargo check -q --bin vigil` which completed successfully (only pre-existing warnings were emitted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0d81e3e9048328b202916a9db9d2d4)