### PR TITLE
Harden WFP DLL loading to System32

### DIFF
--- a/src/security/windows_wfp.rs
+++ b/src/security/windows_wfp.rs
@@ -61,12 +61,8 @@ struct WfpApi {
 
 impl WfpApi {
     unsafe fn load() -> Result<Self, String> {
-        let module = LoadLibraryExW(
-            w!("Fwpuclnt.dll"),
-            None,
-            LOAD_LIBRARY_SEARCH_SYSTEM32,
-        )
-        .map_err(|err| format!("load Fwpuclnt.dll: {err}"))?;
+        let module = LoadLibraryExW(w!("Fwpuclnt.dll"), None, LOAD_LIBRARY_SEARCH_SYSTEM32)
+            .map_err(|err| format!("load Fwpuclnt.dll: {err}"))?;
         Ok(Self {
             module,
             engine_open: load_symbol(module, b"FwpmEngineOpen0\0")?,

--- a/src/security/windows_wfp.rs
+++ b/src/security/windows_wfp.rs
@@ -7,7 +7,9 @@ use windows::Win32::Foundation::{HANDLE, HMODULE};
 use windows::Win32::NetworkManagement::WindowsFilteringPlatform::{
     FWPM_DISPLAY_DATA0, FWPM_PROVIDER0, FWPM_SESSION0, FWPM_SUBLAYER0,
 };
-use windows::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryW};
+use windows::Win32::System::LibraryLoader::{
+    GetProcAddress, LoadLibraryExW, LOAD_LIBRARY_SEARCH_SYSTEM32,
+};
 
 const FWP_E_ALREADY_EXISTS_STATUS: u32 = 0x8032_0009;
 const VIGIL_WFP_PROVIDER_KEY: GUID = GUID::from_u128(0x3b6f3d34_6150_4e3c_9169_7df0c5f1cb52);
@@ -59,8 +61,12 @@ struct WfpApi {
 
 impl WfpApi {
     unsafe fn load() -> Result<Self, String> {
-        let module =
-            LoadLibraryW(w!("Fwpuclnt.dll")).map_err(|err| format!("load Fwpuclnt.dll: {err}"))?;
+        let module = LoadLibraryExW(
+            w!("Fwpuclnt.dll"),
+            None,
+            LOAD_LIBRARY_SEARCH_SYSTEM32,
+        )
+        .map_err(|err| format!("load Fwpuclnt.dll: {err}"))?;
         Ok(Self {
             module,
             engine_open: load_symbol(module, b"FwpmEngineOpen0\0")?,


### PR DESCRIPTION
## Summary

- Reapplies the useful security hardening from closed PR #368 on top of current `master`.
- Replaces the bare `LoadLibraryW("Fwpuclnt.dll")` lookup with `LoadLibraryExW(..., LOAD_LIBRARY_SEARCH_SYSTEM32)` so Windows resolves the WFP DLL from System32 only.

## Why

PR #368 was closed without merge, but the branch still contained a small DLL search-order hardening change that is worth preserving. This PR carries only that change onto the current base branch.

## Validation

- Verified the branch is one commit ahead of current `master` and changes only `src/security/windows_wfp.rs`.
- Local Rust/Windows validation was not available in this scheduled environment; CI should provide the compile signal.