### PR TITLE
Fix blocklist status preflight parity

### DIFF
--- a/src/status_report.rs
+++ b/src/status_report.rs
@@ -7,11 +7,13 @@
 #[path = "security/policy.rs"]
 mod policy;
 
+use ipnetwork::IpNetwork;
 use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::env;
 use std::fs;
+use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -246,7 +248,7 @@ fn firewall_status() -> SubsystemStatus {
     }
 }
 
-fn blocklist_status(config: Option<&Value>, data_dir: &Path) -> SubsystemStatus {
+fn blocklist_status(config: Option<&Value>, _data_dir: &Path) -> SubsystemStatus {
     let Some(config) = config else {
         return SubsystemStatus {
             name: "blocklist_engine",
@@ -271,7 +273,7 @@ fn blocklist_status(config: Option<&Value>, data_dir: &Path) -> SubsystemStatus 
     let mut total_entries = 0usize;
 
     for configured in &paths {
-        let path = expand_data_relative(data_dir, configured);
+        let path = configured_blocklist_path(configured);
         details.push(format!("path={}", path.display()));
         match verify_blocklist_file(&path) {
             Ok(entries) => {
@@ -635,6 +637,10 @@ fn expand_data_relative(data_dir: &Path, configured: &str) -> PathBuf {
     }
 }
 
+fn configured_blocklist_path(configured: &str) -> PathBuf {
+    PathBuf::from(configured.trim())
+}
+
 fn verify_blocklist_file(path: &Path) -> Result<usize, String> {
     let contents = fs::read(path).map_err(|err| format!("failed_to_read_blocklist={err}"))?;
     let sidecar_path = sha256_sidecar_path(path);
@@ -661,15 +667,44 @@ fn verify_blocklist_file(path: &Path) -> Result<usize, String> {
 fn count_blocklist_entries(contents: &str) -> usize {
     contents
         .lines()
-        .filter(|raw_line| {
-            let line = raw_line
-                .split_once('#')
-                .map(|(before_comment, _)| before_comment)
-                .unwrap_or(raw_line)
-                .trim();
-            !line.is_empty()
-        })
+        .filter_map(normalized_blocklist_line)
+        .filter(|line| is_active_blocklist_entry(line))
         .count()
+}
+
+fn normalized_blocklist_line(raw_line: &str) -> Option<&str> {
+    let line = raw_line
+        .split_once('#')
+        .map(|(before_comment, _)| before_comment)
+        .unwrap_or(raw_line)
+        .trim();
+    if line.is_empty() {
+        None
+    } else {
+        Some(line)
+    }
+}
+
+fn is_active_blocklist_entry(line: &str) -> bool {
+    if line.contains('/') {
+        line.parse::<IpNetwork>().is_ok()
+    } else {
+        line.parse::<IpAddr>().is_ok() || is_hash(line) || is_domain(line)
+    }
+}
+
+fn is_hash(s: &str) -> bool {
+    let lower = s.as_bytes();
+    (lower.len() == 64 || lower.len() == 40 || lower.len() == 32)
+        && lower.iter().all(|&b| b.is_ascii_hexdigit())
+}
+
+fn is_domain(s: &str) -> bool {
+    s.contains('.')
+        && !s.contains(':')
+        && !s.contains('/')
+        && s.chars()
+            .all(|c| c.is_ascii() && (c.is_ascii_alphanumeric() || c == '.' || c == '-'))
 }
 
 fn sha256_sidecar_path(path: &Path) -> PathBuf {
@@ -791,6 +826,14 @@ mod tests {
     }
 
     #[test]
+    fn relative_blocklist_path_matches_runtime_loader() {
+        assert_eq!(
+            configured_blocklist_path("blocklists/threats.txt"),
+            PathBuf::from("blocklists/threats.txt")
+        );
+    }
+
+    #[test]
     fn health_summary_reuses_subsystem_states() {
         let subsystems = vec![
             SubsystemStatus {
@@ -822,6 +865,13 @@ mod tests {
     }
 
     #[test]
+    fn blocklist_entry_count_ignores_unrecognized_indicators() {
+        let contents = "\n# comment\nnot an indicator\nbad/cidr\nlocalhost\nexample\n";
+
+        assert_eq!(count_blocklist_entries(contents), 0);
+    }
+
+    #[test]
     fn verified_blocklist_reports_active_entries() {
         let dir = unique_temp_dir();
         fs::create_dir_all(&dir).unwrap();
@@ -841,6 +891,28 @@ mod tests {
 
         assert_eq!(status.state, HealthState::Healthy);
         assert!(status.summary.contains("2 active entries"));
+    }
+
+    #[test]
+    fn signed_blocklist_with_only_invalid_entries_is_not_healthy() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("invalid-only.txt");
+        let contents = b"not an indicator\nbad/cidr\nlocalhost\nexample\nhttp://bad.example\n";
+        fs::write(&path, contents).unwrap();
+        fs::write(
+            sha256_sidecar_path(&path),
+            format!("{:x}  invalid-only.txt\n", Sha256::digest(contents)),
+        )
+        .unwrap();
+        let config = serde_json::json!({
+            "blocklist_paths": [path.to_string_lossy()]
+        });
+
+        let status = blocklist_status(Some(&config), &dir);
+
+        assert_eq!(status.state, HealthState::DisabledByPolicy);
+        assert!(status.summary.contains("no active entries"));
     }
 
     #[test]

--- a/src/status_report.rs
+++ b/src/status_report.rs
@@ -654,7 +654,7 @@ fn verify_blocklist_file(path: &Path) -> Result<usize, String> {
         .split_whitespace()
         .next()
         .ok_or_else(|| format!("empty_sidecar={}", sidecar_path.display()))?;
-    let actual = format!("{:x}", Sha256::digest(&contents));
+    let actual = sha256_hex(&contents);
     if !expected.eq_ignore_ascii_case(&actual) {
         return Err(format!(
             "sha256_mismatch_sidecar={}",
@@ -662,6 +662,21 @@ fn verify_blocklist_file(path: &Path) -> Result<usize, String> {
         ));
     }
     Ok(count_blocklist_entries(&String::from_utf8_lossy(&contents)))
+}
+
+fn sha256_hex(contents: &[u8]) -> String {
+    let digest = Sha256::digest(contents);
+    encode_hex(digest.as_ref())
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
 }
 
 fn count_blocklist_entries(contents: &str) -> usize {
@@ -795,7 +810,7 @@ mod tests {
         let dir = unique_temp_dir();
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("vigil.json");
-        fs::write(&path, br#"{"auto_response_enabled":true}"#).unwrap();
+        fs::write(&path, br#"{\"auto_response_enabled\":true}"#).unwrap();
 
         let probe = probe_config(&path);
         let status = config_status(&path, &probe);
@@ -809,7 +824,7 @@ mod tests {
         let dir = unique_temp_dir();
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("vigil.json");
-        policy::save_json_with_integrity(&path, br#"{"auto_response_enabled":true}"#).unwrap();
+        policy::save_json_with_integrity(&path, br#"{\"auto_response_enabled\":true}"#).unwrap();
 
         let probe = probe_config(&path);
         let status = config_status(&path, &probe);
@@ -880,7 +895,7 @@ mod tests {
         fs::write(&path, contents).unwrap();
         fs::write(
             sha256_sidecar_path(&path),
-            format!("{:x}  threats.txt\n", Sha256::digest(contents)),
+            format!("{}  threats.txt\n", sha256_hex(contents)),
         )
         .unwrap();
         let config = serde_json::json!({
@@ -902,7 +917,7 @@ mod tests {
         fs::write(&path, contents).unwrap();
         fs::write(
             sha256_sidecar_path(&path),
-            format!("{:x}  invalid-only.txt\n", Sha256::digest(contents)),
+            format!("{}  invalid-only.txt\n", sha256_hex(contents)),
         )
         .unwrap();
         let config = serde_json::json!({

--- a/src/status_report.rs
+++ b/src/status_report.rs
@@ -810,7 +810,7 @@ mod tests {
         let dir = unique_temp_dir();
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("vigil.json");
-        fs::write(&path, br#"{\"auto_response_enabled\":true}"#).unwrap();
+        fs::write(&path, br#"{"auto_response_enabled":true}"#).unwrap();
 
         let probe = probe_config(&path);
         let status = config_status(&path, &probe);
@@ -824,7 +824,7 @@ mod tests {
         let dir = unique_temp_dir();
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("vigil.json");
-        policy::save_json_with_integrity(&path, br#"{\"auto_response_enabled\":true}"#).unwrap();
+        policy::save_json_with_integrity(&path, br#"{"auto_response_enabled":true}"#).unwrap();
 
         let probe = probe_config(&path);
         let status = config_status(&path, &probe);


### PR DESCRIPTION
## Summary

- make `vigil_status` resolve configured blocklist paths the same way the runtime blocklist loader does, by using the configured path directly instead of remapping relative paths under `VIGIL_DATA_DIR`
- count only parser-accepted blocklist entries (IP, CIDR, hash, or domain) when reporting active entries
- add focused status-report tests for relative-path parity and signed invalid-only blocklists

## Roadmap / issue

Selected Phase 21 security posture dashboard follow-up from #372 because there were no open PRs needing scheduled-run follow-through, and this is a concrete correctness gap in the CLI status foundations.

## Validation

- Code inspected against `src/blocklist.rs::Blocklist::load` and `src/startup_integrity.rs::scan_operator_inputs`
- Added focused unit tests in `src/status_report.rs`
- Full local `cargo test` could not be run in this environment because direct repository checkout is blocked; CI should provide the build/test signal for this draft PR.

Fixes #372