### PR TITLE
[codex] Document YARA rule-management UI boundary

### DIFF
--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -219,3 +219,44 @@ vigil --yara-rule-status
 Warnings on first load or after an intentional rule edit are expected because Vigil records provenance instead of silently treating every local change as corruption.
 
 The next YARA roadmap slice is still narrower than broad live-memory scanning. The safest follow-up remains selected-memory targets such as operator-visible or already-captured process dumps on supported platforms, while preserving the same fail-open behavior as the shipped executable scan path.
+
+## Advisory snapshot imports
+
+Vigil can also extend its protected local advisory cache with operator-supplied public-source snapshots. This is useful when you want advisory context to stay available offline from the last trusted local cache.
+
+Use the CLI importer that matches the source material you have:
+
+```bash
+vigil --import-nvd-snapshot nvdcve-page-1.json nvdcve-page-2.json
+vigil --import-nvd-change-history nvdcvehistory-page-1.json
+vigil --import-euvd euvd-export.json
+vigil --import-jvn jvn-export.json jvndbrss.xml
+vigil --import-ncsc ncsc-feed.xml ncsc-mirror.json
+vigil --import-bsi certbund-feed.xml bsi-advisories.json
+```
+
+The NCSC and BSI/CERT-Bund importers accept either RSS snapshots or mirrored JSON, then preserve source links, identifiers, timestamps, and other provenance fields in the same protected advisory cache as the other Phase 16 sources.
+
+Once Vigil has both the protected advisory cache and a local software inventory snapshot, you can also use those matches as conservative inputs for operator-managed response rules. The dedicated [Response rules](RESPONSE-RULES.md) guide and `response-rules.example.yaml` show how to keep that automation explainable and fail-open.
+
+## Local software inventory
+
+The standalone `vigil_inventory` helper prints local Windows/Linux software inventory metadata as JSON without touching Vigil's startup path.
+
+```bash
+vigil_inventory
+```
+
+Each row includes conservative normalized identity hints so later matching can stay explainable:
+
+- `product_key` for the primary normalized product identity
+- `product_aliases` for alternate normalized product forms derived from names and executable stems
+- `vendor_key` for the primary normalized publisher or vendor identity
+- `vendor_aliases` for alternate normalized vendor forms, including suffix-stripped aliases
+
+Current inventory sources:
+
+- Windows uninstall registry
+- Linux dpkg status database
+- Linux RPM database
+- Linux Alpine apk installed database

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -200,6 +200,8 @@ Vigil now uses the reviewed bundled rules plus any verified operator-local rules
 
 `vigil --yara-rule-status` remains the operator-facing intake command. The command itself does not run scans. It verifies which local rules under `yara-rules/` are trusted enough to join the runtime ruleset and records their provenance.
 
+The first YARA rule-management UI slice is intentionally read-only: it may display trusted rule metadata and matched rule names, but it must not expose category toggles, rule editing, rule deletion, remote downloads, or auto-enable behavior until those flows have protected policy storage, reload semantics, recovery behavior, and audit coverage. See [YARA rule management UI contract](YARA-RULE-MANAGEMENT-UI.md) for the current UI boundary.
+
 1. Run `vigil --yara-rule-status` if you want Vigil to print the exact `yara-rules/` directory path it expects on your machine.
 2. Place each `.yar` or `.yara` file under that directory with a matching `.sha256` sidecar beside it. For example, `sample.yar` should have `sample.yar.sha256`.
 3. Re-run the status command:
@@ -217,44 +219,3 @@ vigil --yara-rule-status
 Warnings on first load or after an intentional rule edit are expected because Vigil records provenance instead of silently treating every local change as corruption.
 
 The next YARA roadmap slice is still narrower than broad live-memory scanning. The safest follow-up remains selected-memory targets such as operator-visible or already-captured process dumps on supported platforms, while preserving the same fail-open behavior as the shipped executable scan path.
-
-## Advisory snapshot imports
-
-Vigil can also extend its protected local advisory cache with operator-supplied public-source snapshots. This is useful when you want advisory context to stay available offline from the last trusted local cache.
-
-Use the CLI importer that matches the source material you have:
-
-```bash
-vigil --import-nvd-snapshot nvdcve-page-1.json nvdcve-page-2.json
-vigil --import-nvd-change-history nvdcvehistory-page-1.json
-vigil --import-euvd euvd-export.json
-vigil --import-jvn jvn-export.json jvndbrss.xml
-vigil --import-ncsc ncsc-feed.xml ncsc-mirror.json
-vigil --import-bsi certbund-feed.xml bsi-advisories.json
-```
-
-The NCSC and BSI/CERT-Bund importers accept either RSS snapshots or mirrored JSON, then preserve source links, identifiers, timestamps, and other provenance fields in the same protected advisory cache as the other Phase 16 sources.
-
-Once Vigil has both the protected advisory cache and a local software inventory snapshot, you can also use those matches as conservative inputs for operator-managed response rules. The dedicated [Response rules](RESPONSE-RULES.md) guide and `response-rules.example.yaml` show how to keep that automation explainable and fail-open.
-
-## Local software inventory
-
-The standalone `vigil_inventory` helper prints local Windows/Linux software inventory metadata as JSON without touching Vigil's startup path.
-
-```bash
-vigil_inventory
-```
-
-Each row includes conservative normalized identity hints so later matching can stay explainable:
-
-- `product_key` for the primary normalized product identity
-- `product_aliases` for alternate normalized product forms derived from names and executable stems
-- `vendor_key` for the primary normalized publisher or vendor identity
-- `vendor_aliases` for alternate normalized vendor forms, including suffix-stripped aliases
-
-Current inventory sources:
-
-- Windows uninstall registry
-- Linux dpkg status database
-- Linux RPM database
-- Linux Alpine apk installed database


### PR DESCRIPTION
## Summary

- Adds operator guidance that the first YARA rule-management UI slice is read-only.
- Points users to the existing YARA rule-management UI contract.
- Explicitly avoids implying that category toggles, editing, deletion, downloads, or auto-enable behavior are implemented before protected policy, reload, recovery, and audit semantics exist.

## Why

The roadmap's next unfinished concrete item is Phase 20's YARA rule-management UI. The repository already has a security contract for the first safe UI slice, but the user guide did not surface that boundary from the operator workflow. This PR makes the safe current scope discoverable without expanding product behavior.

## Validation

- Inspected open PRs/issues first; none were active.
- Compared branch to `master`; net change is limited to `docs/USER-GUIDE.md`.
- No runtime tests were run because this is documentation-only and the container could not clone GitHub directly.