### PR TITLE
Fix blocklist status path parity

### DIFF
--- a/src/status_report.rs
+++ b/src/status_report.rs
@@ -638,7 +638,7 @@ fn expand_data_relative(data_dir: &Path, configured: &str) -> PathBuf {
 }
 
 fn configured_blocklist_path(configured: &str) -> PathBuf {
-    PathBuf::from(configured.trim())
+    PathBuf::from(configured)
 }
 
 fn verify_blocklist_file(path: &Path) -> Result<usize, String> {
@@ -845,6 +845,10 @@ mod tests {
         assert_eq!(
             configured_blocklist_path("blocklists/threats.txt"),
             PathBuf::from("blocklists/threats.txt")
+        );
+        assert_eq!(
+            configured_blocklist_path(" blocklists/threats.txt "),
+            PathBuf::from(" blocklists/threats.txt ")
         );
     }
 


### PR DESCRIPTION
## Summary

- preserve configured blocklist paths exactly in the standalone status preflight
- extend the runtime-parity regression test to cover leading and trailing whitespace

Closes #372.

## Validation

- Not run locally: the workspace cannot clone the repository over the available network path, so this was applied through the GitHub connector and left for CI to validate.