### PR TITLE
Fix blocklist status path whitespace parity

### DIFF
--- a/src/status_report.rs
+++ b/src/status_report.rs
@@ -638,7 +638,7 @@ fn expand_data_relative(data_dir: &Path, configured: &str) -> PathBuf {
 }
 
 fn configured_blocklist_path(configured: &str) -> PathBuf {
-    PathBuf::from(configured.trim())
+    PathBuf::from(configured)
 }
 
 fn verify_blocklist_file(path: &Path) -> Result<usize, String> {
@@ -845,6 +845,10 @@ mod tests {
         assert_eq!(
             configured_blocklist_path("blocklists/threats.txt"),
             PathBuf::from("blocklists/threats.txt")
+        );
+        assert_eq!(
+            configured_blocklist_path(" blocklists/threats.txt "),
+            PathBuf::from(" blocklists/threats.txt ")
         );
     }
 


### PR DESCRIPTION
## Summary

- Preserve configured `blocklist_paths` exactly in `vigil_status` instead of trimming leading/trailing whitespace.
- Extend the runtime-parity unit test so whitespace-padded configured paths stay aligned with `BlocklistEngine::load`, which passes each string directly to `Path::new(...)`.

## Why

Issue #372 identified one remaining status/runtime parity gap after PR #375: the status preflight could verify a trimmed path that the runtime blocklist engine would not load.

## Validation

- Compared the change against `src/blocklist.rs::BlocklistEngine::load` behavior.
- Added a focused regression assertion in `src/status_report.rs`.
- Could not run local Rust tests because the scheduled container cannot clone GitHub directly; CI should provide the build/test signal.

Fixes #372