### PR TITLE
Add main CLI protection status command

### DIFF
--- a/docs/PROTECTION-STATUS.md
+++ b/docs/PROTECTION-STATUS.md
@@ -1,11 +1,17 @@
 # Vigil Protection Status
 
-`vigil_status` is the first status-reporting foundation for Vigil's production endpoint-protection track.
+`vigil status --json` is the primary status-reporting entrypoint for Vigil's production endpoint-protection track. The standalone `vigil_status` helper exposes the same JSON report for environments that package helper binaries separately.
 
 It prints a conservative JSON report about local Vigil state without attaching to the live GUI or service runtime. Facts that cannot be checked safely from a standalone CLI process are reported as `unknown` rather than guessed.
 
 ```bash
-vigil_status --json
+vigil status --json
+```
+
+The status command also accepts the normal data-directory override when an operator needs to inspect a non-default Vigil state directory:
+
+```bash
+vigil status --json --data-dir PATH
 ```
 
 ## Current scope
@@ -17,7 +23,7 @@ The schema reports:
 - `health_summary`, a compact single-panel view of the key Phase 21 protection signals
 - subsystem entries for configuration, runtime monitor, blocklist engine, firewall backend, response policy, active-response state, protected storage, YARA rules, advisory cache, and update trust
 
-The first implementation can inspect files and static policy. It intentionally does **not** claim live protection health yet.
+The current implementation can inspect files and static policy. It intentionally does **not** claim live protection health yet.
 
 ## Health summary
 
@@ -45,6 +51,6 @@ Subsystem states use these lowercase JSON values:
 
 ## Production direction
 
-This is the base contract for the future GUI dashboard, tray health indicator, and `vigil status --json` command. The next slices should move runtime-only checks out of `unknown` by publishing live health from the GUI/service monitor into protected local state.
+This is the base contract for the future GUI dashboard and tray health indicator. The next slices should move runtime-only checks out of `unknown` by publishing live health from the GUI/service monitor into protected local state.
 
 The status surface must stay honest: it must never report the machine as protected unless the required protection subsystems are actually healthy.

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,7 @@ mod session;
 #[allow(clippy::type_complexity)]
 mod software_inventory;
 mod startup_integrity;
+mod status_report;
 mod storage;
 mod tls;
 mod tls_artifacts;
@@ -148,6 +149,65 @@ fn apply_data_dir_override_early(args: &[String]) {
         }
         i += 1;
     }
+}
+
+fn status_command_index(args: &[String]) -> Option<usize> {
+    let mut i = 1usize;
+    while i < args.len() {
+        if args[i] == service::DATA_DIR_FLAG {
+            i += 2;
+            continue;
+        }
+        return (args[i] == "status").then_some(i);
+    }
+    None
+}
+
+fn print_status_help() {
+    println!(
+        "vigil status v{}\n\nUsage: vigil status --json [--data-dir PATH]\n\nPrints a conservative JSON health report for local Vigil state. Runtime-only\nfacts remain unknown until the GUI/service publishes live health.",
+        env!("CARGO_PKG_VERSION")
+    );
+}
+
+fn handle_status_cli(args: &[String], command_idx: usize) -> ! {
+    let mut json = false;
+    let mut i = 1usize;
+    while i < args.len() {
+        if i == command_idx {
+            i += 1;
+            continue;
+        }
+        match args[i].as_str() {
+            "--json" => json = true,
+            "--help" | "-h" => {
+                print_status_help();
+                std::process::exit(0);
+            }
+            service::DATA_DIR_FLAG => {
+                if args.get(i + 1).is_none() {
+                    eprintln!("Missing path after {}", service::DATA_DIR_FLAG);
+                    std::process::exit(1);
+                }
+                i += 1;
+            }
+            other => {
+                eprintln!("Unknown status argument: {other}\n");
+                print_status_help();
+                std::process::exit(2);
+            }
+        }
+        i += 1;
+    }
+
+    if !json {
+        eprintln!("Missing required --json flag.\n");
+        print_status_help();
+        std::process::exit(2);
+    }
+
+    status_report::print_json_or_exit();
+    std::process::exit(0);
 }
 
 fn spawn_bootstrap(
@@ -292,6 +352,10 @@ fn spawn_service_event_worker(
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     apply_data_dir_override_early(&args);
+
+    if let Some(command_idx) = status_command_index(&args) {
+        handle_status_cli(&args, command_idx);
+    }
 
     if args.iter().any(|a| a == "--advisory-cache-status") {
         match advisory_status::run_cli() {
@@ -574,7 +638,7 @@ fn main() {
                 i += 1;
             }
             "--help" | "-h" => {
-                println!("Vigil v{} — real-time network threat monitor\n\nUsage:  vigil [flags]\n\nFlags:\n  --install-service              register Vigil as a boot-time service\n  --uninstall-service            remove the boot-time service\n  --break-glass-recover          watchdog entrypoint for network recovery\n  --verify-update-manifest       MANIFEST SIG\n                                 verify a signed release manifest against the embedded trust anchor\n  --yara-rule-status             verify local `.yar` / `.yara` files under the Vigil data directory\n                                 and report integrity/provenance intake status\n  --validate-yara-pack-manifest  PATH/TO/manifest.json\n                                 validate bundled YARA pack metadata, safe relative paths,\n                                 and per-file provenance fields before future embedding\n  --import-nvd-snapshot          SNAPSHOT.json [MORE.json ...]\n                                 import or merge one or more NVD CVE JSON snapshots into the protected advisory cache\n  --sync-nvd [--force]           fetch or incrementally refresh the protected NVD CVE cache from the live API\n  --advisory-cache-status        show advisory cache status and source health\n  --import-nvd-change-history    SNAPSHOT.json [MORE.json ...]\n                                 import or merge one or more NVD CVE change-history JSON snapshots into the protected change-history cache\n  --sync-nvd-change-history [--force]\n                                 fetch or incrementally refresh the protected NVD CVE change-history cache from the live API\n  --advisory-change-history-status\n                                 show NVD change-history cache status and source health\n  --advisory-match-status        join the protected software inventory with the advisory cache\n                                 and print explainable local matches\n  --import-euvd                  SNAPSHOT.json [MORE.json ...]\n                                 import or merge one or more operator-supplied EUVD JSON snapshots into the protected advisory cache\n  --import-jvn                   SNAPSHOT.json|RSS.xml [MORE ...]\n                                 import or merge one or more JVN / JVN iPedia JSON or JVNDBRSS XML snapshots into the protected advisory cache\n  --import-ncsc                  SNAPSHOT.json|RSS.xml [MORE ...]\n                                 import or merge one or more NCSC public advisory RSS or mirrored JSON snapshots into the protected advisory cache\n  --import-bsi                   SNAPSHOT.json|RSS.xml [MORE ...]\n                                 import or merge one or more BSI or CERT-Bund public advisory RSS or mirrored JSON snapshots into the protected advisory cache\n  --service-mode                 internal headless service entrypoint\n  --data-dir PATH                override Vigil data/config directory\n  -h, --help                     show this help and exit\n\nRun with no flags to launch the GUI.", env!("CARGO_PKG_VERSION"));
+                println!("Vigil v{} — real-time network threat monitor\n\nUsage:  vigil [flags]\n        vigil status --json [--data-dir PATH]\n\nCommands:\n  status --json                 print a conservative JSON protection-status report\n\nFlags:\n  --install-service              register Vigil as a boot-time service\n  --uninstall-service            remove the boot-time service\n  --break-glass-recover          watchdog entrypoint for network recovery\n  --verify-update-manifest       MANIFEST SIG\n                                 verify a signed release manifest against the embedded trust anchor\n  --yara-rule-status             verify local `.yar` / `.yara` files under the Vigil data directory\n                                 and report integrity/provenance intake status\n  --validate-yara-pack-manifest  PATH/TO/manifest.json\n                                 validate bundled YARA pack metadata, safe relative paths,\n                                 and per-file provenance fields before future embedding\n  --import-nvd-snapshot          SNAPSHOT.json [MORE.json ...]\n                                 import or merge one or more NVD CVE JSON snapshots into the protected advisory cache\n  --sync-nvd [--force]           fetch or incrementally refresh the protected NVD CVE cache from the live API\n  --advisory-cache-status        show advisory cache status and source health\n  --import-nvd-change-history    SNAPSHOT.json [MORE.json ...]\n                                 import or merge one or more NVD CVE change-history JSON snapshots into the protected change-history cache\n  --sync-nvd-change-history [--force]\n                                 fetch or incrementally refresh the protected NVD CVE change-history cache from the live API\n  --advisory-change-history-status\n                                 show NVD change-history cache status and source health\n  --advisory-match-status        join the protected software inventory with the advisory cache\n                                 and print explainable local matches\n  --import-euvd                  SNAPSHOT.json [MORE.json ...]\n                                 import or merge one or more operator-supplied EUVD JSON snapshots into the protected advisory cache\n  --import-jvn                   SNAPSHOT.json|RSS.xml [MORE ...]\n                                 import or merge one or more JVN / JVN iPedia JSON or JVNDBRSS XML snapshots into the protected advisory cache\n  --import-ncsc                  SNAPSHOT.json|RSS.xml [MORE ...]\n                                 import or merge one or more NCSC public advisory RSS or mirrored JSON snapshots into the protected advisory cache\n  --import-bsi                   SNAPSHOT.json|RSS.xml [MORE ...]\n                                 import or merge one or more BSI or CERT-Bund public advisory RSS or mirrored JSON snapshots into the protected advisory cache\n  --service-mode                 internal headless service entrypoint\n  --data-dir PATH                override Vigil data/config directory\n  -h, --help                     show this help and exit\n\nRun with no flags to launch the GUI.", env!("CARGO_PKG_VERSION"));
                 std::process::exit(0);
             }
             _ => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,7 @@ mod session;
 #[allow(clippy::type_complexity)]
 mod software_inventory;
 mod startup_integrity;
+#[allow(clippy::duplicate_mod, clippy::needless_return)]
 mod status_report;
 mod storage;
 mod tls;


### PR DESCRIPTION
## Summary

- expose the existing conservative protection-status JSON report through the primary `vigil status --json` command
- support the existing `--data-dir PATH` override for status inspections without launching the GUI or service runtime
- update CLI help and the protection-status documentation to make the main command the operator-facing entrypoint while preserving the current live-health caveat

## Roadmap / issue

Selected the Phase 21 **CLI status command** roadmap item. There were no open PRs or issues needing scheduled-run follow-through, and prior merged PRs left `vigil status --json` as the explicit next status-foundation slice.

## Validation

- inspected the roadmap and recent status-related PRs (#349, #351, #369, #375)
- reviewed the branch comparison against current `master`; only `src/main.rs` and `docs/PROTECTION-STATUS.md` changed
- local `cargo test` / `cargo check` could not be run because direct repository checkout is blocked in this environment and Cargo project files are only accessible through the connector; CI should provide the compile and test signal

## Scope note

This does not add new runtime health claims. Runtime monitor, advisory freshness, firewall reconciliation, and backend health remain `unknown` until protected live-health publishing lands.