### PR TITLE
docs: mark CLI status command roadmap slice complete

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -273,7 +273,7 @@ Modern detections hinge on who, not just what. Adds identity attribution so aler
 
 ---
 
-## Phase 30 — Playbook Builder & SaaS-session Visibility
+## Phase 30 — Playbook Builder & SaaS-session Visibility (PRO backlog)
 
 Two differentiators bundled together because each alone is narrow, but together they round out the modern endpoint story.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -162,7 +162,7 @@ A single-panel view that answers "is Vigil actually protecting me?" without digg
 - [ ] **Health summary** — real-time monitoring status (ETW/eBPF/polling), blocklist engine state (loaded entries / empty / degraded), advisory cache freshness, response rules loaded, firewall isolation status, native firewall engine health.
 - [ ] **Threat dashboard** — current connection score distribution, top blocked targets, recent alerts over time, YARA matches summary, firewall rule hit counts.
 - [ ] **Tray indicator integration** — tray icon colour and tooltip reflects current protection status (green = healthy, yellow = degraded, red = stopped / no real-time).
-- [ ] **CLI status command** — `vigil status --json` reuses the shared health model, adds live-runtime health once protected publishing lands, and becomes the main scripting entrypoint.
+- [x] **CLI status command** — `vigil status --json` reuses the shared health model and is the main scripting entrypoint. Live-runtime health remains a follow-up under health-summary publishing.
 
 ---
 
@@ -227,7 +227,7 @@ Extends Vigil with a hosted console for multi-endpoint fleet management, alert a
 
 ## Phase 26 — MSP Multi-tenant & White-label (PRO backlog)
 
-Multi-tenant architecture for managed service providers managing multiple customer fleets. Depends on Phase 20 (YARA) and Phase 19 (Firewall Engine).
+Multi-tenant architecture for managed service providers. Depends on Phase 20 (YARA) and Phase 19 (Firewall Engine).
 
 - [ ] **Tenant hierarchy** — MSP → customer → site → endpoint, with inherited policy and override rules.
 - [ ] **White-label branding** — per-tenant logo, product name, custom domain, branded alert emails.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -227,7 +227,7 @@ Extends Vigil with a hosted console for multi-endpoint fleet management, alert a
 
 ## Phase 26 — MSP Multi-tenant & White-label (PRO backlog)
 
-Multi-tenant architecture for managed service providers. Depends on Phase 20 (YARA) and Phase 19 (Firewall Engine).
+Multi-tenant architecture for managed service providers managing multiple customer fleets. Depends on Phase 20 (YARA) and Phase 19 (Firewall Engine).
 
 - [ ] **Tenant hierarchy** — MSP → customer → site → endpoint, with inherited policy and override rules.
 - [ ] **White-label branding** — per-tenant logo, product name, custom domain, branded alert emails.
@@ -273,7 +273,7 @@ Modern detections hinge on who, not just what. Adds identity attribution so aler
 
 ---
 
-## Phase 30 — Playbook Builder & SaaS-session Visibility (PRO backlog)
+## Phase 30 — Playbook Builder & SaaS-session Visibility
 
 Two differentiators bundled together because each alone is narrow, but together they round out the modern endpoint story.
 


### PR DESCRIPTION
## Summary

- mark the Phase 21 `vigil status --json` roadmap slice complete now that PR #380 exposed the shared protection-status report through the main CLI
- keep live-runtime health explicitly scoped to the remaining health-summary publishing work

## Why

Scheduled follow-up found no open PRs or issues needing CI/review attention. The roadmap had one concrete conflict with merged work: PR #380 made `vigil status --json` the primary status entrypoint and updated `docs/PROTECTION-STATUS.md`, but the roadmap still listed the CLI status command as unchecked.

## Validation

- inspected open PRs and open issues: none found
- inspected merged PR #380 and current `ROADMAP.md`
- reviewed the branch patch to ensure the net change is limited to the Phase 21 roadmap line

No code tests were run because this is documentation-only.