### PR TITLE
docs: clarify safe YARA UI implementation slices

### DIFF
--- a/docs/YARA-RULE-MANAGEMENT-UI.md
+++ b/docs/YARA-RULE-MANAGEMENT-UI.md
@@ -6,6 +6,22 @@ already verifies and mirrors into protected local state, but it must not add new
 rule-download, rule-editing, or auto-enable behavior until those flows have their
 own integrity and rollback design.
 
+## Roadmap decomposition
+
+The Phase 20 roadmap item is intentionally broader than the first safe code
+change. Treat the work as these ordered slices:
+
+1. Read-only Inspector display of existing `YARA rule: <name>` score reasons.
+2. Read-only trusted catalog display from the protected YARA rule catalog.
+3. Category toggle policy, protected persistence, audited operator actions, and
+   last-known-good scanner reload behavior.
+
+Only the first slice is concrete enough to implement without new product or
+security-policy decisions. The second slice depends on catalog read paths that
+keep provenance and source identity explicit. The third slice must remain out of
+scope until toggle storage, scanner reload, rollback, and audit behavior are
+specified and tested.
+
 ## Current data boundary
 
 Vigil already records two trusted YARA rule sources:


### PR DESCRIPTION
## Summary

- Split the Phase 20 YARA rule management UI contract into ordered implementation slices.
- Mark the read-only Inspector display as the only currently concrete code slice.
- Keep category toggles explicitly blocked on protected policy storage, scanner reload, rollback, and audit behavior.

## Why this task

The next unfinished roadmap item is Phase 20's YARA rule management UI. The item bundles read-only display, metadata catalog work, and category toggles. The existing contract already warns that toggles are not safe yet, so this PR narrows the next implementable work into explicit ordered slices before exposing UI controls.

## Validation

- Documentation-only change; no runtime code changed.
- Reviewed against `ROADMAP.md` and the existing YARA UI contract boundaries.

## Follow-up

- Implement the first code slice: read-only Inspector display of existing `YARA rule: <name>` score reasons, without inferred metadata or category toggles.